### PR TITLE
Error in 'dump_version' now correctly raised.

### DIFF
--- a/setuptools_scm/__init__.py
+++ b/setuptools_scm/__init__.py
@@ -30,13 +30,16 @@ def version_from_scm(root):
 def dump_version(root, version, write_to):
     if not write_to:
         return
-    target = os.path.join(root, write_to)
+    target = os.path.normpath(os.path.join(root, write_to))
     if target.endswith('.txt'):
         dump = version
     elif target.endswith('.py'):
         dump = PYTHON_TEMPLATE.format(version=version)
     else:
-        raise ValueError('bad file format: ' + os.path.splitext(target))
+        raise ValueError("bad file format: '%s' (of %s) " % (
+            os.path.splitext(target)[1],
+            target
+        ))
     with open(target, 'w') as fp:
         fp.write(dump)
 

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -1,5 +1,8 @@
+import os.path
 import pytest
 import pkg_resources
+import tempfile
+from setuptools_scm import dump_version
 from setuptools_scm.version import guess_next_version, meta, format_version
 
 
@@ -47,3 +50,18 @@ def test_format_version(version, monkeypatch, scheme, expected):
         version,
         version_scheme=vs,
         local_scheme=ls) == expected
+        
+        
+@pytest.fixture
+def tmpfoo(request):
+    fn = tempfile.NamedTemporaryFile(suffix=".foo", delete=False).name
+    request.addfinalizer(lambda: os.remove(fn))
+    return fn
+    
+
+def test_dump_version_doesnt_bail_on_value_error(tmpfoo):
+    root, write_to = os.path.split(tmpfoo)
+    version = VERSIONS['exact']
+    with pytest.raises(ValueError) as exc_info:
+        dump_version(root, version, write_to)
+    assert str(exc_info.value).startswith("bad file format:")

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -1,7 +1,5 @@
-import os.path
 import pytest
 import pkg_resources
-import tempfile
 from setuptools_scm import dump_version
 from setuptools_scm.version import guess_next_version, meta, format_version
 
@@ -52,16 +50,9 @@ def test_format_version(version, monkeypatch, scheme, expected):
         local_scheme=ls) == expected
 
 
-@pytest.fixture
-def tmpfoo(request):
-    fn = tempfile.NamedTemporaryFile(suffix=".foo", delete=False).name
-    request.addfinalizer(lambda: os.remove(fn))
-    return fn
-
-
-def test_dump_version_doesnt_bail_on_value_error(tmpfoo):
-    root, write_to = os.path.split(tmpfoo)
+def test_dump_version_doesnt_bail_on_value_error(tmpdir):
+    write_to = "VERSION"
     version = VERSIONS['exact']
     with pytest.raises(ValueError) as exc_info:
-        dump_version(root, version, write_to)
+        dump_version(tmpdir.strpath, version, write_to)
     assert str(exc_info.value).startswith("bad file format:")

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -50,14 +50,14 @@ def test_format_version(version, monkeypatch, scheme, expected):
         version,
         version_scheme=vs,
         local_scheme=ls) == expected
-        
-        
+
+
 @pytest.fixture
 def tmpfoo(request):
     fn = tempfile.NamedTemporaryFile(suffix=".foo", delete=False).name
     request.addfinalizer(lambda: os.remove(fn))
     return fn
-    
+
 
 def test_dump_version_doesnt_bail_on_value_error(tmpfoo):
     root, write_to = os.path.split(tmpfoo)


### PR DESCRIPTION
This error occurred because the function wasn't correctly extracting the file extension from a filename while trying to raise an Exception, and so the descriptive error never got printed.

This fix just makes sure that the exception is correctly raised.
