### PR TITLE
Fix install failure when using non-version tag

### DIFF
--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -6,7 +6,7 @@ from os.path import abspath, realpath
 FILES_COMMAND = 'git ls-files'
 
 
-def parse(root):
+def parse(root, exact=False):
     real_root, _, ret = do_ex('git rev-parse --show-toplevel', root)
     trace('real root', real_root)
     if abspath(realpath(real_root)) != abspath(realpath(root)):
@@ -15,7 +15,10 @@ def parse(root):
     if ret:
         return meta('0.0')
     rev_node = rev_node[:7]
-    out, err, ret = do_ex('git describe --dirty --tags --long', root)
+    if exact:
+        out, err, ret = do_ex('git describe --dirty --tags --long --match "v*.*.*"', root)
+    else:
+        out, err, ret = do_ex('git describe --dirty --tags --long --match "*.*"', root)
     if '-' not in out and '.' not in out:
         revs = do('git rev-list HEAD', root)
         count = revs.count('\n')


### PR DESCRIPTION
When installing a package with a non-version formatted git tag
(for example 'example_tag') as the as the most recent tag then
setuptools_scm will assert that it can't parse the tag.  This patch
fixes this assert by filtering out non-version formatted tags.  By
default any tag with a '.' in the name will be interpreted as a version
tag.  Optionally, if 'exact' is set to true when calling parse then
only tags in the form of 'v_._.*' will be found.
