### PR TITLE
Ensure we call tag_to_version

### DIFF
--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -31,6 +31,7 @@ def callable_or_entrypoint(group, callable_or_name):
 def tag_to_version(tag):
     trace('tag', tag)
     # lstrip the v because of py2/py3 differences in setuptools
+    # also required for old versions of setuptools
     version = tag.rsplit('-', 1)[-1].lstrip('v')
     if parse_version is None:
         return version

--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -78,7 +78,7 @@ class ScmVersion(object):
 
 
 def meta(tag, distance=None, dirty=False, node=None, **kw):
-    if parse_version is not None and not isinstance(tag, SetuptoolsVersion):
+    if SetuptoolsVersion is None or not isinstance(tag, SetuptoolsVersion):
         tag = tag_to_version(tag)
     trace('version', tag)
 


### PR DESCRIPTION
Closes #61

So I found `tag_to_version` already does the right thing. However this function is not called because `parse_version` is None. `tag_to_version` already seems to be able to cope with `parse_version` being None, so this test seems like it isn't required.

Just removing that test produced an error however because `SetuptoolsVersion` is None. I am guessing this is because I am testing based on an old version of setuptools.

Only done some basic testing so far, however it appears to work:

```
# python ./setup.py --version 
important note:

the setup of setuptools_scm is self-using,
the first execution of `python setup.py egg_info`
will generate partial data
its critical to run `python setup.py egg_info`
once before running sdist or easy_install on a fresh checkouts

pip usage is recommended

your setuptools is too old (<12)
setuptools_scm functionality is degraded
1.10.1.dev2+ng77da109
```
