### PR TITLE
fix bug when using callable version_scheme

### DIFF
--- a/setuptools_scm/integration.py
+++ b/setuptools_scm/integration.py
@@ -12,10 +12,10 @@ def version_keyword(dist, keyword, value):
         return
     if value is True:
         value = {}
-    if os.path.exists('PKG-INFO'):
-        value.pop('root', None)
     if getattr(value, '__call__', None):
         value = value()
+    if os.path.exists('PKG-INFO'):
+        value.pop('root', None)
     dist.metadata.version = get_version(**value)
 
 

--- a/testing/test_regressions.py
+++ b/testing/test_regressions.py
@@ -23,3 +23,23 @@ def test_pkginfo_noscmroot(tmpdir, monkeypatch):
     do('git init', p.dirpath())
     res = do('python setup.py --version', p)
     assert res == '1.0'
+
+
+def test_use_scm_version_callable(tmpdir, monkeypatch):
+    """use of callable as use_scm_version argument"""
+    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
+
+    p = tmpdir.ensure('sub/package', dir=1)
+    p.join('setup.py').write(
+        '''from setuptools import setup
+def vcfg():
+    from setuptools_scm.version import guess_next_dev_version
+    def vs(v):
+        return guess_next_dev_version(v)
+    return {"version_scheme": vs}
+setup(use_scm_version=vcfg)
+''')
+    p.join("PKG-INFO").write('Version: 1.0')
+
+    res = do('python setup.py --version', p)
+    assert res == '1.0'


### PR DESCRIPTION
This fixes bug introduced with 0f1c98d032b421f65c8ef5b1042386a6b64bf0b6,
looking like this:

```
Complete output from command python setup.py egg_info:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/pip-build-zfpnaarq/xd-docker/setup.py", line 69, in <module>
    setup_requires=['setuptools_scm'],
  File "/usr/local/lib/python3.4/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/usr/local/lib/python3.4/site-packages/setuptools/dist.py", line 272, in __init__
    _Distribution.__init__(self,attrs)
  File "/usr/local/lib/python3.4/distutils/dist.py", line 280, in __init__
    self.finalize_options()
  File "/usr/local/lib/python3.4/site-packages/setuptools/dist.py", line 327, in finalize_options
    ep.load()(self, ep.name, value)
  File "/usr/local/lib/python3.4/site-packages/setuptools_scm-1.10.2.dev8+ng4835e4d-py3.4.egg/setuptools_scm/integration.py", line 16, in version_keyword
AttributeError: 'function' object has no attribute 'pop'
```

Signed-off-by: Esben Haabendal esben@haabendal.dk
