### PR TITLE
properly write version file even if in pretend mode

### DIFF
--- a/setuptools_scm/__init__.py
+++ b/setuptools_scm/__init__.py
@@ -104,15 +104,15 @@ def get_version(root='.',
     version = _do_parse(root, parse)
 
     if version:
+        dump_version(
+            root=root,
+            version=version,
+            write_to=write_to,
+            template=write_to_template)
         if isinstance(version, string_types):
             return version
         version = format_version(
             version,
             version_scheme=version_scheme,
             local_scheme=local_scheme)
-        dump_version(
-            root=root,
-            version=version,
-            write_to=write_to,
-            template=write_to_template)
         return version

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -1,6 +1,6 @@
 import pytest
 import pkg_resources
-from setuptools_scm import dump_version
+from setuptools_scm import dump_version, get_version, PRETEND_KEY
 from setuptools_scm.version import guess_next_version, meta, format_version
 
 
@@ -56,3 +56,9 @@ def test_dump_version_doesnt_bail_on_value_error(tmpdir):
     with pytest.raises(ValueError) as exc_info:
         dump_version(tmpdir.strpath, version, write_to)
     assert str(exc_info.value).startswith("bad file format:")
+
+
+def test_dump_version_works_with_pretend(tmpdir, monkeypatch):
+    monkeypatch.setenv(PRETEND_KEY, '1.0')
+    get_version(write_to=str(tmpdir.join('VERSION.txt')))
+    assert tmpdir.join('VERSION.txt').read() == '1.0'


### PR DESCRIPTION
before this, SETUPTOOLS_SCM_PRETEND_VERSION make setuptools_scm fail
to write the `write_to` file correctly. this was apparently to avoid
issues with archives, which we believe is not a problem anymore.

this _is_, however, a problem for other tools like Debian packaging:
there, we use the pretend mechanism to import the version number from
the Debian packaging system (from `debian/changelog`, usually). this
works at setup time: setuptools_scm has the proper environment and
detects the version. but if the software was written to depend on the
`write_to` file, it will fail to find that version at runtime because
`setup.py` will not have written the `write_to` file properly at build
time.

this patch simply makes sure that the version is written even if the
provided version number is a string, which is usually the case for
pretend version numbers. a fixed test case is also provided.

Closes: #101
