### PR TITLE
fix mercurial for several tags on changeset ...

### DIFF
--- a/setuptools_scm/hg.py
+++ b/setuptools_scm/hg.py
@@ -8,13 +8,18 @@ FILES_COMMAND = 'hg locate -I .'
 def _hg_tagdist_normalize_tagcommit(root, tag, dist, node):
     dirty = node.endswith('+')
     node = node.strip('+')
-    st = do('hg st --no-status --change %s' % str(node), root)
-
-    trace('normalize', locals())
-    if int(dist) == 1 and st == '.hgtags' and not dirty:
-        return meta(tag)
+    revset = ("(branch(.) and tag('{0}')::. and file('re:^(?!\.hgtags).*$')"
+              " - tag('{0}'))").format(str(tag))
+    if tag != '0.0':
+        commits = do(['hg', 'log', '-r', revset, '-T', '{node|short}'],
+                     root)
     else:
+        commits = True
+    trace('normalize', locals())
+    if commits or dirty:
         return meta(tag, distance=dist, node=node, dirty=dirty)
+    else:
+        return meta(tag)
 
 
 def parse(root):
@@ -36,7 +41,9 @@ def parse(root):
     out = do(cmd, root)
     try:
         # in merge state we assume parent 1 is fine
-        tag, dist = out.splitlines()[0].split()
+        tags, dist = out.splitlines()[0].split()
+        # pick latest tag from tag list
+        tag = tags.split(':')[-1]
         if tag == 'null':
             tag = '0.0'
             dist = int(dist) + 1

--- a/setuptools_scm/hg.py
+++ b/setuptools_scm/hg.py
@@ -8,8 +8,8 @@ FILES_COMMAND = 'hg locate -I .'
 def _hg_tagdist_normalize_tagcommit(root, tag, dist, node):
     dirty = node.endswith('+')
     node = node.strip('+')
-    revset = ("(branch(.) and tag('{0}')::. and file('re:^(?!\.hgtags).*$')"
-              " - tag('{0}'))").format(str(tag))
+    revset = ("(branch(.) and tag({tag!r})::. and file('re:^(?!\.hgtags).*$')"
+              " - tag({tag!r}))").format(tag=tag)
     if tag != '0.0':
         commits = do(['hg', 'log', '-r', revset, '--template', '{node|short}'],
                      root)

--- a/setuptools_scm/hg.py
+++ b/setuptools_scm/hg.py
@@ -11,7 +11,7 @@ def _hg_tagdist_normalize_tagcommit(root, tag, dist, node):
     revset = ("(branch(.) and tag('{0}')::. and file('re:^(?!\.hgtags).*$')"
               " - tag('{0}'))").format(str(tag))
     if tag != '0.0':
-        commits = do(['hg', 'log', '-r', revset, '-T', '{node|short}'],
+        commits = do(['hg', 'log', '-r', revset, '--template', '{node|short}'],
                      root)
     else:
         commits = True

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -65,6 +65,12 @@ def test_version_from_hg_id(wd):
     wd.commit_testfile()
     assert wd.version.startswith('0.2.dev1+')
 
+    # several tags
+    wd('hg up')
+    wd('hg tag v0.2 -u test -d "0 0"')
+    wd('hg tag v0.3 -u test -d "0 0" -r v0.2')
+    assert wd.version == '0.3'
+
 
 def test_version_from_archival(wd):
     # entrypoints are unordered,


### PR DESCRIPTION
…and distance only consisting of tag commits

This is an attempt to fix a situation when you have several tags on the changeset. What is more, it attempts to detect and "discard" commits that are only tagging, regardless of distance.
I should probably add more tests...
Thanks for considering/commenting.

E.g.:

changeset:   174:8b9eeff53bde
user:        Petre Mierlutiu pmierlutiu@...
date:        Fri Oct 14 15:57:13 2016 +0300
summary:     Added tag 1.3.0.2 for changeset 9b5b4375432e

changeset:   173:a9df4646d79c
user:        Petre Mierlutiu pmierlutiu@...
date:        Fri Oct 14 14:25:14 2016 +0300
summary:     Added tag 1.3.0.1 for changeset 9b5b4375432e

changeset:   172:4436d287bfaa
user:        Petre Mierlutiu pmierlutiu@...
date:        Fri Oct 14 14:22:40 2016 +0300
summary:     Added tag 1.3.0-1 for changeset 9b5b4375432e

changeset:   171:9b5b4375432e
tag:         1.3.0-1
tag:         1.3.0.1
tag:         1.3.0.2
parent:      68:afd9055fb46f
parent:      170:ab327fdcdc33
user:        Petre Mierlutiu pmierlutiu@cmedtechnology.com
date:        Thu Oct 13 12:53:17 2016 +0000
summary:     Merged in 1.3.0-dev (pull request #24)
