### PR TITLE
Discard local parts when guessing next version.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+v1.15.1
+=======
+
+* fix issue #126: the local part of any tags is discarded
+  when guessing new versions
+
 v1.15.0
 =======
 

--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -89,14 +89,23 @@ def meta(tag, distance=None, dirty=False, node=None, **kw):
 
 def guess_next_version(tag_version, distance):
     version = str(tag_version)
-    if '.dev' in version:
-        prefix, tail = version.rsplit('.dev', 1)
-        assert tail == '0', 'own dev numbers are unsupported'
-    else:
-        prefix, tail = re.match('(.*?)(\d+)$', version).groups()
-        prefix = '%s%d' % (prefix, int(tail) + 1)
+    bumped = _bump_dev(version) or _bump_regex(version)
     suffix = '.dev%s' % distance
-    return prefix + suffix
+    return bumped + suffix
+
+
+def _bump_dev(version):
+    if '.dev' not in version:
+        return
+
+    prefix, tail = version.rsplit('.dev', 1)
+    assert tail == '0', 'own dev numbers are unsupported'
+    return prefix
+
+
+def _bump_regex(version):
+    prefix, tail = re.match('(.*?)(\d+)$', version).groups()
+    return '%s%d' % (prefix, int(tail) + 1)
 
 
 def guess_next_dev_version(version):

--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -92,10 +92,11 @@ def guess_next_version(tag_version, distance):
     if '.dev' in version:
         prefix, tail = version.rsplit('.dev', 1)
         assert tail == '0', 'own dev numbers are unsupported'
-        return '%s.dev%s' % (prefix, distance)
     else:
         prefix, tail = re.match('(.*?)(\d+)$', version).groups()
-        return '%s%d.dev%s' % (prefix, int(tail) + 1, distance)
+        prefix = '%s%d' % (prefix, int(tail) + 1)
+    suffix = '.dev%s' % distance
+    return prefix + suffix
 
 
 def guess_next_dev_version(version):

--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -88,10 +88,15 @@ def meta(tag, distance=None, dirty=False, node=None, **kw):
 
 
 def guess_next_version(tag_version, distance):
-    version = str(tag_version)
+    version = _strip_local(str(tag_version))
     bumped = _bump_dev(version) or _bump_regex(version)
     suffix = '.dev%s' % distance
     return bumped + suffix
+
+
+def _strip_local(version_string):
+    public, sep, local = version_string.partition('+')
+    return public
 
 
 def _bump_dev(version):

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -14,7 +14,7 @@ class MockTime(object):
     ('1.1', '1.2.dev0'),
     ('1.2.dev', '1.2.dev0'),
     ('1.1a2', '1.1a3.dev0'),
-    ('23.24post2+deadbeef', '23.24post3.dev0'),
+    ('23.24.post2+deadbeef', '23.24.post3.dev0'),
     ])
 def test_next_tag(tag, expected):
     version = pkg_resources.parse_version(tag)

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -14,6 +14,7 @@ class MockTime(object):
     ('1.1', '1.2.dev0'),
     ('1.2.dev', '1.2.dev0'),
     ('1.1a2', '1.1a3.dev0'),
+    ('23.24post2+deadbeef', '23.24post3.dev0'),
     ])
 def test_next_tag(tag, expected):
     version = pkg_resources.parse_version(tag)


### PR DESCRIPTION
This series of commits uses test-driven development to demonstrate the failure and a suitable fix for the described issue.

Side note: in d17972e, I extracted functions for `_bump*` initially thinking that the solution would add a third technique for using a parsed version for detecting the parts, but after further consideration (and other failed tests), I settled on this approach. It would be possible to rebase the subsequent tests on 2743575 and bypass d17972e, but I personally prefer the approach as suggested.
