### PR TITLE
add support for SemVer prerelease syntax in a mostly backwards-compat…

### DIFF
--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -7,6 +7,48 @@ from pkg_resources import iter_entry_points
 
 from distutils import log
 
+NUMERIC_NO_LZ = r"(0|[1-9][0-9]*)"
+PRE_COMPONENT = r"([a-zA-Z1-9\-][a-zA-Z0-9\-]*)"
+META_COMPONENT = r"([a-zA-Z0-9\-]+)"
+
+VERSION_RE_SRC = r"""
+    ^
+    v?                         # optional v prefix (as in v1.2.3)
+    (?P<version>               # begin named group matching the actual version
+        {NUMERIC_NO_LZ}        # major
+        \.
+        {NUMERIC_NO_LZ}        # minor
+        (
+            \.
+            {NUMERIC_NO_LZ}    # optional patch
+        )?
+        (                      # begin optional prerelease part
+            \-
+            {PRE_COMPONENT}    # first component (fE "beta")
+            (
+                \.
+                {PRE_COMPONENT}
+            )*                 # and any number more
+        )?                     # end prerelease
+        (                      # begin optional build metadata part
+            \+
+            {META_COMPONENT}   # first component
+            (
+                \.
+                {META_COMPONENT}
+            )*                 # and any number more
+        )?                     # end metadata
+    )                          # end version
+    $
+""".format(
+    NUMERIC_NO_LZ=NUMERIC_NO_LZ,
+    PRE_COMPONENT=PRE_COMPONENT,
+    META_COMPONENT=META_COMPONENT,
+)
+
+VERSION_RE = re.compile(VERSION_RE_SRC, re.VERBOSE)
+
+
 try:
     from pkg_resources import parse_version, SetuptoolsVersion
 except ImportError as e:
@@ -28,11 +70,70 @@ def callable_or_entrypoint(group, callable_or_name):
         return callable_or_name
 
 
+def tag_to_version_string(tag):
+    """
+    Extract the version string from a tag.
+
+    Return the longest valid SemVer at the end of the tag if it is separated
+    from the rest by a hyphen (and optionally a "v" character).
+
+    This rest is assumed to be internal information that can safely be ignored.
+
+    Alternatively, if this is not possible, return everything after the last
+    hyphen, or the entire string if no hyphen exists (old behavior).
+    """
+
+    # This implementation has two goals:
+    #  - preserve, as far as possible, the old behavior of ignoring internal,
+    #     non-version-relevant tag data
+    #  -- assume that such data is separated from the version with a hyphen
+    #  - correctly extract every SemVer version, including those containing
+    #     hyphens
+
+    # SemVer with prerelease or build metadata components can be complicated.
+    # In particular, there is no good way to split the tag into internal data
+    # and actual version, as there can be an arbitrary number of hyphens in
+    # those components.
+    # A pure regex solution would either be excessively complicated or use a
+    # (slow) lazy match for the non-SemVer part of the tag.
+    # Therefore, we just check progressively shorter substrings of the original
+    # tag and see if they are valid SemVers.
+
+    # For example, if our tag were tag-spam-v1.2.3-beta, we would try (in
+    # order):
+    #  - tag-spam-v1.2.3-beta
+    #  - spam-v1.2.3-beta
+    #  - v1.2.3-beta
+    # The last substring would match.
+    search_tag = tag
+    while search_tag:
+        match = VERSION_RE.match(search_tag)
+        if match is not None:
+            groupdict = match.groupdict()
+            # version without prepended "v" if originally present
+            return groupdict["version"]
+
+        # [part_before_hyphen, part_after_hyphen] or
+        # [string_without_hyphen]
+        parts = search_tag.split("-", 1)
+
+        # [part_before_hyphen, part_after_hyphen, None] or
+        # [string_without_hyphen, None]
+        parts.append(None)
+
+        # part_after_hyphen or None
+        search_tag = parts[1]
+
+    # Could not find a valid SemVer, revert to using weapons from a less
+    # civilized age
+    return tag.rsplit('-', 1)[-1].lstrip('v')
+
+
 def tag_to_version(tag):
     trace('tag', tag)
     # lstrip the v because of py2/py3 differences in setuptools
     # also required for old versions of setuptools
-    version = tag.rsplit('-', 1)[-1].lstrip('v')
+    version = tag_to_version_string(tag)
     if parse_version is None:
         return version
     version = parse_version(version)

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -2,12 +2,40 @@ import pytest
 import pkg_resources
 from setuptools_scm import dump_version, get_version, PRETEND_KEY
 from setuptools_scm.version import guess_next_version, meta, format_version
+from setuptools_scm.version import tag_to_version_string
 from setuptools_scm.utils import has_command
 
 
 class MockTime(object):
     def __format__(self, *k):
         return 'time'
+
+
+@pytest.mark.parametrize('tag, expected', [
+    ('1.2.3', '1.2.3'),
+    ('v1.2.3', '1.2.3'),
+    ('spam-1.2.3', '1.2.3'),
+    ('spam-v1.2.3', '1.2.3'),
+    ('spam-and-eggs-v1.2.3', '1.2.3'),
+    ('spam-and-eggs-1.2.3', '1.2.3'),
+    ('1.2.3-beta', '1.2.3-beta'),
+    ('v1.2.3-beta', '1.2.3-beta'),
+    ('spam-1.2.3-beta', '1.2.3-beta'),
+    ('spam-v1.2.3-beta', '1.2.3-beta'),
+    ('spam-1.2.3-beta.17', '1.2.3-beta.17'),
+    ('spam-v1.2.3-beta.17', '1.2.3-beta.17'),
+    ('spam-v1.2.3-volatile', '1.2.3-volatile'),
+    ('spam-and-eggs-v1.2.3-volatile', '1.2.3-volatile'),
+    ('spam-and-eggs-v1.2.3-volatile.42', '1.2.3-volatile.42'),
+    (
+        'spam-and-eggs-v1.2.3-very-edgy-case-but-'
+        + 'still-semver.-42.1337.666.yes-this-seems-to-be-allowed',
+        '1.2.3-very-edgy-case-but-'
+        + 'still-semver.-42.1337.666.yes-this-seems-to-be-allowed'
+    ),
+    ])
+def test_tag_to_version_string(tag, expected):
+    assert tag_to_version_string(tag) == expected
 
 
 @pytest.mark.parametrize('tag, expected', [


### PR DESCRIPTION
…ible way

This pull request contains my proposed solution for #144  It is backwards compatible except in some extreme edge cases - SemVer versions are now extracted using a very specific regex, and if no SemVer is found, the old implementation is used.

The only way this can fail is if the end of the internal part of a tag is the start of a valid SemVer, which sounds like a Very Bad Idea anyway.

