### PR TITLE
WIP: Optionally omit the "g" for "git describe"

### DIFF
--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -108,6 +108,11 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
       dirty = False
 
     tag, number, node = out.rsplit('-', 2)
+
+    # Omit the leading 'g' which is not part of the revision to be consistent with
+    # other code paths.
+    node = [1:]
+
     number = int(number)
     if number:
         return meta(tag, distance=number, node=node, dirty=dirty)

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -4,7 +4,7 @@ from os.path import abspath, normcase, realpath, isfile, join
 import warnings
 
 FILES_COMMAND = 'git ls-files'
-DEFAULT_DESCRIBE = 'git describe --tags --long --match *.*'
+DEFAULT_DESCRIBE = 'git describe --tags --long --dirty --match *.*'
 
 
 def _normalized(path):
@@ -83,20 +83,29 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
         return
     if pre_parse:
         pre_parse(wd)
-    rev_node = wd.node()
-    dirty = wd.is_dirty()
-
-    if rev_node is None:
-        return meta('0.0', distance=0, dirty=dirty)
 
     out, err, ret = do_ex(describe_command, root)
     if ret:
+        # If 'git describe' failed, try to get the information otherwise.
+        rev_node = wd.node()
+        dirty = wd.is_dirty()
+
+        if rev_node is None:
+            return meta('0.0', distance=0, dirty=dirty)
+
         return meta(
             '0.0',
             distance=wd.count_all_nodes(),
             node=rev_node,
             dirty=dirty,
         )
+
+    # 'out' looks e.g. like 'v1.5.0-0-g4060507' or 'v1.15.1rc1-37-g9bd1298-dirty'.
+    if out.endswith('-dirty')
+      dirty = True
+      out = out[:-6]
+    else
+      dirty = False
 
     tag, number, node = out.rsplit('-', 2)
     number = int(number)


### PR DESCRIPTION
Following the discussion started [here](https://github.com/pypa/setuptools_scm/issues/152#issuecomment-282271402) I came up with some basic changes that could lead into the direction of optionally omittin the "g" for "git describe".

The first commit is just a more or less unrelated optimization to do fewer Git calls.

The second commit removes the "g" prefix in the lower level functions by default. This will currently break things, so my idea is to optionally add the "g" back in one of the higher level functions. I'd rather do it that way than the other way around, because in the long run the "g" prefix should be dropped altogether.

Even if this is WIP and not ready yet, I'm posting this here to get some early feedback.