### PR TITLE
Prefer to only use 'git describe' for all required info

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ v1.15.1
 
 * fix issue #126: the local part of any tags is discarded
   when guessing new versions
+* minor performance optimization by doing fewer git calls
+  in the usual cases
+
 
 v1.15.0
 =======

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -4,7 +4,7 @@ from os.path import abspath, normcase, realpath, isfile, join
 import warnings
 
 FILES_COMMAND = 'git ls-files'
-DEFAULT_DESCRIBE = 'git describe --tags --long --match *.*'
+DEFAULT_DESCRIBE = 'git describe --dirty --tags --long --match *.*'
 
 
 def _normalized(path):
@@ -83,20 +83,30 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
         return
     if pre_parse:
         pre_parse(wd)
-    rev_node = wd.node()
-    dirty = wd.is_dirty()
-
-    if rev_node is None:
-        return meta('0.0', distance=0, dirty=dirty)
 
     out, err, ret = do_ex(describe_command, root)
     if ret:
+        # If 'git describe' failed, try to get the information otherwise.
+        rev_node = wd.node()
+        dirty = wd.is_dirty()
+
+        if rev_node is None:
+            return meta('0.0', distance=0, dirty=dirty)
+
         return meta(
             '0.0',
             distance=wd.count_all_nodes(),
             node=rev_node,
             dirty=dirty,
         )
+
+    # 'out' looks e.g. like 'v1.5.0-0-g4060507' or
+    # 'v1.15.1rc1-37-g9bd1298-dirty'.
+    if out.endswith('-dirty'):
+        dirty = True
+        out = out[:-6]
+    else:
+        dirty = False
 
     tag, number, node = out.rsplit('-', 2)
     number = int(number)


### PR DESCRIPTION
Previously, three git commands were used to gather all required info.
Now all info is gathered from a single 'git describe' call and only if
that fails fallbacks are used.

There already was the --dirty option before commit 929a5d7, but no
reason was given why it was removed.