### PR TITLE
Fix the node for Git to be prefixed with 'g' also in the fallback

### DIFF
--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -96,7 +96,7 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
         return meta(
             '0.0',
             distance=wd.count_all_nodes(),
-            node=rev_node,
+            node='g' + rev_node,
             dirty=dirty,
         )
 


### PR DESCRIPTION
The 'g' prefix is a 'git describe' specific thing, which is that we try
to use first. In the fallback 'git rev-parse' is used to we need to add
the 'g' manually.