### PR TITLE
use sys.executable instead of 'python' for running regression tests

### DIFF
--- a/testing/test_regressions.py
+++ b/testing/test_regressions.py
@@ -18,16 +18,16 @@ def test_pkginfo_noscmroot(tmpdir, monkeypatch):
         'from setuptools import setup;'
         'setup(use_scm_version={"root": ".."})')
 
-    _, stderr, ret = do_ex('python setup.py --version', p)
+    _, stderr, ret = do_ex(sys.executable + ' setup.py --version', p)
     assert 'setuptools-scm was unable to detect version for' in stderr
     assert ret == 1
 
     p.join("PKG-INFO").write('Version: 1.0')
-    res = do('python setup.py --version', p)
+    res = do(sys.executable + ' setup.py --version', p)
     assert res == '1.0'
 
     do('git init', p.dirpath())
-    res = do('python setup.py --version', p)
+    res = do(sys.executable + ' setup.py --version', p)
     assert res == '1.0'
 
 
@@ -64,7 +64,7 @@ setup(use_scm_version=vcfg)
 ''')
     p.join("PKG-INFO").write('Version: 1.0')
 
-    res = do('python setup.py --version', p)
+    res = do(sys.executable + ' setup.py --version', p)
     assert res == '1.0'
 
 


### PR DESCRIPTION
`test_regressions.py` is running a python subprocess, but it is using the "python" it finds on `PATH`, instead of the same executable that is running the test.

This could mean that it is testing the wrong thing (if the generic executable is using a different home path) or wrong version of Python (which also means that it creates stray `pyc`s for the other version).