### PR TITLE
Use per-SCM node prefix letters instead of the general "n"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,11 +114,11 @@ and uses roughly the following logic to render the version:
 :code:`no distance and clean`:
     :code:`{tag}`
 :code:`distance and clean`:
-    :code:`{next_version}.dev{distance}+n{revision hash}`
+    :code:`{next_version}.dev{distance}+{scm letter}{revision hash}`
 :code:`no distance and not clean`:
     :code:`{tag}+dYYYMMMDD`
 :code:`distance and not clean`:
-    :code:`{next_version}.dev{distance}+n{revision hash}.dYYYMMMDD`
+    :code:`{next_version}.dev{distance}+{scm letter}{revision hash}.dYYYMMMDD`
 
 The next version is calculated by adding ``1`` to the last numeric component
 of the tag.

--- a/setuptools_scm/hg.py
+++ b/setuptools_scm/hg.py
@@ -7,7 +7,7 @@ FILES_COMMAND = 'hg locate -I .'
 
 def _hg_tagdist_normalize_tagcommit(root, tag, dist, node):
     dirty = node.endswith('+')
-    node = node.strip('+')
+    node = 'h' + node.strip('+')
     revset = ("(branch(.) and tag({tag!r})::. and file('re:^(?!\.hgtags).*$')"
               " - tag({tag!r}))").format(tag=tag)
     if tag != '0.0':
@@ -58,14 +58,17 @@ def parse(root):
 
 def archival_to_version(data):
     trace('data', data)
+    node = data.get('node', '')[:12]
+    if node:
+        node = 'h' + node
     if 'tag' in data:
         return meta(data['tag'])
     elif 'latesttag' in data:
         return meta(data['latesttag'],
                     distance=data['latesttagdistance'],
-                    node=data['node'][:12])
+                    node=node)
     else:
-        return meta('0.0', node=data.get('node', '')[:12])
+        return meta('0.0', node=node)
 
 
 def parse_archival(root):

--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -125,7 +125,7 @@ def get_local_node_and_date(version):
     if version.exact or version.node is None:
         return version.format_choice("", "+d{time:%Y%m%d}")
     else:
-        return version.format_choice("+n{node}", "+n{node}.d{time:%Y%m%d}")
+        return version.format_choice("+{node}", "+{node}.d{time:%Y%m%d}")
 
 
 def get_local_dirty_tag(version):

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -19,17 +19,17 @@ def test_version_from_git(wd):
     assert wd.version == '0.1.dev0'
 
     wd.commit_testfile()
-    assert wd.version.startswith('0.1.dev1+')
+    assert wd.version.startswith('0.1.dev1+g')
     assert not wd.version.endswith('1-')
 
     wd('git tag v0.1')
     assert wd.version == '0.1'
 
     wd.write('test.txt', 'test2')
-    assert wd.version.startswith('0.2.dev0+')
+    assert wd.version.startswith('0.2.dev0+g')
 
     wd.commit_testfile()
-    assert wd.version.startswith('0.2.dev1+')
+    assert wd.version.startswith('0.2.dev1+g')
 
     wd('git tag version-0.2')
     assert wd.version.startswith('0.2')
@@ -101,4 +101,4 @@ def test_parse_no_worktree(tmpdir):
 def test_alphanumeric_tags_match(wd):
     wd.commit_testfile()
     wd('git tag newstyle-development-started')
-    assert wd.version.startswith('0.1.dev1+')
+    assert wd.version.startswith('0.1.dev1+g')

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -15,7 +15,7 @@ def wd(wd):
 
 archival_mapping = {
     '1.0': {'tag': '1.0'},
-    '1.1.dev3+n000000000000': {
+    '1.1.dev3+h000000000000': {
         'latesttag': '1.0',
         'latesttagdistance': '3',
         'node': '0'*20,
@@ -91,7 +91,7 @@ def test_version_from_archival(wd):
         'latesttagdistance: 3\n'
     )
 
-    assert wd.version == '0.2.dev3+n000000000000'
+    assert wd.version == '0.2.dev3+h000000000000'
 
 
 @pytest.mark.issue('#72')


### PR DESCRIPTION
"Node" is an uncommon name for what SCMs usually call "revision", so the
"n" prefix is not very telling. Replace it with a prefix specific to the
SCM, so we actually also get to know with SCM is used.