### PR TITLE
.travis.yml: Use Python version '3.6'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
-- '3.6-dev'
+- '3.6'
 env:
 - TOXENV=py-test
 


### PR DESCRIPTION
Python 3.6 has been released, and the old Travis CI '3.6-dev'
environment can be accessed using '3.6'.