### PR TITLE
tox.ini: don't pin py version; fixes #171

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ max-complexity = 10
 [testenv]
 usedevelop=True
 deps=
-    py==1.4.26
     pytest
 commands=
     test: py.test []


### PR DESCRIPTION
I managed to run the test suite with `tox` after removing this line that pins the version of `py` package. It looks like the latest pytest requires a more recent version of `py`.

See https://github.com/pytest-dev/pytest/issues/2501

Fixes #171 