### PR TITLE
fix issue with git workdir containing Windows short path names

### DIFF
--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -1,18 +1,10 @@
-from .utils import do_ex, trace, has_command
+from .utils import do_ex, trace, has_command, _normalized
 from .version import meta
-from os.path import abspath, normcase, realpath, isfile, join
+from os.path import isfile, join
 import warnings
-import platform
 
 FILES_COMMAND = 'git ls-files'
 DEFAULT_DESCRIBE = 'git describe --dirty --tags --long --match *.*'
-
-
-def _normalized(path):
-    if platform.system() == 'Windows':
-        from .utils import get_windows_long_path_name
-        path = get_windows_long_path_name(path)
-    return normcase(abspath(realpath(path)))
 
 
 class GitWorkdir(object):

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -2,12 +2,16 @@ from .utils import do_ex, trace, has_command
 from .version import meta
 from os.path import abspath, normcase, realpath, isfile, join
 import warnings
+import platform
 
 FILES_COMMAND = 'git ls-files'
 DEFAULT_DESCRIBE = 'git describe --dirty --tags --long --match *.*'
 
 
 def _normalized(path):
+    if platform.system() == 'Windows':
+        from .utils import get_windows_long_path_name
+        path = get_windows_long_path_name(path)
     return normcase(abspath(realpath(path)))
 
 

--- a/setuptools_scm/utils.py
+++ b/setuptools_scm/utils.py
@@ -7,6 +7,7 @@ import sys
 import shlex
 import subprocess
 import os
+from os.path import abspath, normcase, realpath
 import io
 import platform
 
@@ -107,6 +108,12 @@ def has_command(name):
     if not res:
         warnings.warn("%r was not found" % name)
     return res
+
+
+def _normalized(path):
+    if IS_WINDOWS:
+        path = get_windows_long_path_name(path)
+    return normcase(abspath(realpath(path)))
 
 
 if IS_WINDOWS:

--- a/setuptools_scm/utils.py
+++ b/setuptools_scm/utils.py
@@ -12,6 +12,8 @@ import platform
 
 
 DEBUG = bool(os.environ.get("SETUPTOOLS_SCM_DEBUG"))
+IS_WINDOWS = platform.system() == 'Windows'
+PY2 = sys.version_info < (3,)
 
 
 def trace(*k):
@@ -32,9 +34,7 @@ def _always_strings(env_dict):
     On Windows and Python 2, environment dictionaries must be strings
     and not unicode.
     """
-    is_windows = platform.system == 'Windows'
-    PY2 = sys.version_info < (3,)
-    if is_windows or PY2:
+    if IS_WINDOWS or PY2:
         env_dict.update(
             (key, str(value))
             for (key, value) in env_dict.items()
@@ -107,3 +107,53 @@ def has_command(name):
     if not res:
         warnings.warn("%r was not found" % name)
     return res
+
+
+if IS_WINDOWS:
+    from ctypes import create_unicode_buffer, windll, WinError
+    from ctypes.wintypes import MAX_PATH, LPCWSTR, LPWSTR, DWORD
+
+    GetLongPathNameW = windll.kernel32.GetLongPathNameW
+    GetLongPathNameW.argtypes = [LPCWSTR, LPWSTR, DWORD]
+    GetLongPathNameW.restype = DWORD
+
+    def get_windows_long_path_name(path):
+        """
+        Converts the specified path from short (MS-DOS style) to long form
+        using the 'GetLongPathNameW' function from Windows API.
+
+        https://msdn.microsoft.com/en-us/library/windows/desktop/aa364980(v=vs.85).aspx
+        """
+        if PY2:
+            # decode path using filesystem encoding on python2; on python3
+            # it is already a unicode string
+            path = unicode(path, sys.getfilesystemencoding())  # noqa
+
+        pathlen = MAX_PATH + 1
+        if DEBUG:
+            # test reallocation logic
+            pathlen = 1
+
+        for _ in range(2):
+            buf = create_unicode_buffer(pathlen)
+            retval = GetLongPathNameW(path, buf, pathlen)
+
+            if retval == 0:
+                # if the function fails for any reason (e.g. file does not
+                # exist), the return value is zero
+                raise WinError()
+
+            if retval <= pathlen:
+                # the function succeeded: the return value is the length of
+                # the string copied to the buffer
+                if PY2:
+                    # re-encode to native 'str' type (i.e. bytes) on python2
+                    return buf.value.encode(sys.getfilesystemencoding())
+                return buf.value
+
+            # if the buffer is too small to contain the result, the return
+            # value is the size of the buffer required to hold the path and
+            # the terminating NULL char; we retry using a large enough buffer
+            pathlen = retval
+
+        raise RuntimeError("Failed to get long path name: {!r}".format(path))

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -124,3 +124,10 @@ def test_get_windows_long_path_name(tmpdir):
     assert long_name_a.endswith("long_name_a.txt")
     assert long_name_b.endswith("long_name_b.txt")
     assert long_name_c.endswith("long_name_c")
+
+    # check ctypes.WinError() with no arg shows the last error message, e.g.
+    # when input path doesn't exist. Note, WinError is not itself a subclass
+    # of BaseException; it's a function returning an instance of OSError
+    with pytest.raises(OSError) as excinfo:
+        get_windows_long_path_name("unexistent_file_name")
+    assert 'The system cannot find the file specified' in str(excinfo)

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -1,8 +1,13 @@
 import pytest
+import py
+import sys
 import pkg_resources
 from setuptools_scm import dump_version, get_version, PRETEND_KEY
 from setuptools_scm.version import guess_next_version, meta, format_version
 from setuptools_scm.utils import has_command
+import subprocess
+
+PY3 = sys.version_info > (2,)
 
 
 class MockTime(object):
@@ -70,3 +75,52 @@ def test_has_command(recwarn):
     assert not has_command('yadayada_setuptools_aint_ne')
     msg = recwarn.pop()
     assert 'yadayada' in str(msg.message)
+
+
+def _get_windows_short_path(path):
+    """ Call a temporary batch file that expands the first argument so that
+    it contains short names only.
+    Return a py._path.local.LocalPath instance.
+
+    For info on Windows batch parameters:
+    https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/percent.mspx?mfr=true
+    """
+    tmpdir = py.path.local.mkdtemp()
+    try:
+        batch_file = tmpdir.join("shortpathname.bat")
+        batch_file.write("@echo %~s1")
+        out = subprocess.check_output([str(batch_file), str(path)])
+        if PY3:
+            out = out.decode(sys.getfilesystemencoding())
+    finally:
+        tmpdir.remove()
+    return py.path.local(out.strip())
+
+
+@pytest.mark.skipif(sys.platform != 'win32',
+                    reason="this test is only valid on windows")
+def test_get_windows_long_path_name(tmpdir):
+    from setuptools_scm.utils import get_windows_long_path_name
+
+    # 8.3 names are limited to max 8 characters, plus optionally a period
+    # and three further characters; so here we use longer names
+    file_a = tmpdir.ensure("long_name_a.txt")
+    file_b = tmpdir.ensure("long_name_b.txt")
+    dir_c = tmpdir.ensure("long_name_c", dir=True)
+    short_file_a = _get_windows_short_path(file_a)
+    short_file_b = _get_windows_short_path(file_b)
+    short_dir_c = _get_windows_short_path(dir_c)
+
+    # shortened names contain the first six characters (case insensitive),
+    # followed by a tilde character and an incremental number that
+    # distinguishes files with the same first six letters and extension
+    assert short_file_a.basename == "LONG_N~1.TXT"
+    assert short_file_b.basename == "LONG_N~2.TXT"
+    assert short_dir_c.basename == "LONG_N~1"
+
+    long_name_a = get_windows_long_path_name(str(short_file_a))
+    long_name_b = get_windows_long_path_name(str(short_file_b))
+    long_name_c = get_windows_long_path_name(str(short_dir_c))
+    assert long_name_a.endswith("long_name_a.txt")
+    assert long_name_b.endswith("long_name_b.txt")
+    assert long_name_c.endswith("long_name_c")


### PR DESCRIPTION
When doing pip install from a local git repository, pip moves the working tree to a temporary folder.

The `%TEMP%` environment variable may contain short path names, e.g. "C:\Users\COSIMO~1.LUP\AppData\Local\Temp".

However, when calling `GitWorkdir.from_potential_worktree`, the command `git rev-parse --show-toplevel` always return a path with long names.

Because of this, the root and 'real' working directory returned by `git rev-parse` compare different from each other, even if they are actually the same, and the method will return None.

This adds a new function `get_windows_long_path_name` in utils.py module to get the long path name using the Windows API (via ctypes).