### PR TITLE
Set example indentation to multiple of four

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ To use setuptools_scm just modify your project's setup.py file like this:
       try:
           __version__ = get_distribution(__name__).version
       except DistributionNotFound:
-         # package is not installed
-         pass
+          # package is not installed
+          pass
 
 
 Programmatic usage


### PR DESCRIPTION
In `README.rst`, there was an example with wrong indentation.