### PR TITLE
Feature: issue #87 clean_tag

### DIFF
--- a/setuptools_scm/__init__.py
+++ b/setuptools_scm/__init__.py
@@ -104,6 +104,7 @@ def get_version(root='.',
                 write_to_template=None,
                 relative_to=None,
                 parse=None,
+                clean_tag=None,
                 ):
     """
     If supplied, relative_to should be a file from which root may
@@ -116,7 +117,16 @@ def get_version(root='.',
     root = os.path.abspath(root)
     trace('root', repr(root))
 
+    if clean_tag:
+        import setuptools_scm.version as version_mod
+        trace('setting clean_tag', repr(clean_tag))
+        version_mod.clean_tag = clean_tag
+
     parsed_version = _do_parse(root, parse)
+
+    if clean_tag:  # Restoring the monkey-patched clean_tag is needed for tests
+        trace('restoring clean_tag', repr(version_mod.clean_tag_default))
+        version_mod.clean_tag = version_mod.clean_tag_default
 
     if parsed_version:
         version_string = format_version(

--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -30,15 +30,25 @@ def callable_or_entrypoint(group, callable_or_name):
         return callable_or_name
 
 
-def tag_to_version(tag):
-    trace('tag', tag)
+def clean_tag(tag):
+    """Clean tag of any extraneous components."""
     if '+' in tag:
         warnings.warn("tag %r will be stripped of the local component" % tag)
         tag = tag.split('+')[0]
     # lstrip the v because of py2/py3 differences in setuptools
     # also required for old versions of setuptools
+    tag = tag.rsplit('-', 1)[-1].lstrip('v')
+    return tag
 
-    version = tag.rsplit('-', 1)[-1].lstrip('v')
+
+# Stash an alias in case it's overridden
+clean_tag_default = clean_tag
+
+
+def tag_to_version(tag):
+    trace('tag', tag)
+
+    version = clean_tag(tag)
     if parse_version is None:
         return version
     version = parse_version(version)

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -131,3 +131,13 @@ def test_get_windows_long_path_name(tmpdir):
     with pytest.raises(OSError) as excinfo:
         get_windows_long_path_name("unexistent_file_name")
     assert 'The system cannot find the file specified' in str(excinfo)
+
+
+@pytest.mark.parametrize('tag,expected', [
+    ('1.0.0', '1.0.0'),
+    ('1.0.dev0', '1.0.dev0'),
+    ('v1.0', '1.0'),
+    ('foo-v1.0', '1.0'),
+])
+def test_meta_parse_tag(tag, expected):
+    assert meta(tag).format_with('{tag}') == expected

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -39,6 +39,13 @@ def test_version_from_git(wd):
     assert wd.version.startswith('0.2')
 
 
+@pytest.mark.issue(87)
+def test_version_from_git_clean_tag(wd):
+    wd.commit_testfile()
+    wd('git tag release/1.0.0')
+    assert wd.get_version(clean_tag=lambda t: t[8:]) == '1.0.0'
+
+
 @pytest.mark.issue(108)
 @pytest.mark.issue(109)
 def test_git_worktree(wd):

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -73,6 +73,13 @@ def test_version_from_hg_id(wd):
     assert wd.version == '0.3'
 
 
+@pytest.mark.issue(87)
+def test_version_from_hg_clean_tag(wd):
+    wd.commit_testfile()
+    wd('hg tag release/1.0.0')
+    assert wd.get_version(clean_tag=lambda t: t[8:]) == '1.0.0'
+
+
 def test_version_from_archival(wd):
     # entrypoints are unordered,
     # cleaning the wd ensure this test wont break randomly


### PR DESCRIPTION
An initial implementation of #87, adding a `clean_tag` parameter to `get_version`, which allows fixing up a non-conforming version-tagging scheme.

This isn't a _good_ implementation, but I am submitting it as a proof-of-concept.

Monkey-patching is a pretty horrible way to do this kind of thing but it demonstrates the difficulty of overriding this functionality.
(It also does not allow for overriding via an entrypoint.)
The most obvious alternative is to add parameters down all the way into  `meta` or `tag_to_version`, but that seems pretty ugly too.

I have some ideas for bigger architectural changes that would make it possible to implement more cleanly, but I'd like to know if anyone sees a better way to do this that I am unaware of and if the maintainers would be open to a bigger change before I spend more time on it.

Finally, I have kept the name "clean" instead of "parse" despite @RonnyPfannschmidt's objection for 2 reasons:
There's already enough ambiguity in `version.py` with `_parse_tag` and `meta` and `tag_to_version` and `parse_version` and `.git.parse` and `_do_parse`, etc.
Furthermore, in terms of encouraging conformity, "to clean" carries more negative connotations than "to parse", so the need to use this feature implies non-standard, less-than-desirable naming. (But as naming conventions get entwined in organizational processes, not having this is a major barrier to adoption for much pre-existing software.)