### PR TITLE
Respect git's export-ignore for building the sdist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 ## Directory-based project format:
 .idea/
 
+### Other editors
+.*.swp
+
 
 ### Python template
 # Byte-compiled / optimized

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -120,8 +120,8 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
         return meta(tag, node=node, dirty=dirty)
 
 
-def _main():
-    """List the files that 'git archive' wants.
+def _list_files_in_archive():
+    """List the files that 'git archive' generates.
     """
     # TarFile wants a seekable stream.
     stream = BytesIO(subprocess.check_output(['git', 'archive', 'HEAD']))
@@ -130,4 +130,4 @@ def _main():
 
 
 if __name__ == "__main__":
-    _main()
+    _list_files_in_archive()

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -1,9 +1,17 @@
 from .utils import do_ex, trace, has_command, _normalized
 from .version import meta
+try:
+    from io import BytesIO
+except ImportError:
+    from cStringIO import StringIO as BytesIO
+
 from os.path import isfile, join
+import subprocess
+import sys
+from tarfile import TarFile
 import warnings
 
-FILES_COMMAND = 'git ls-files'
+FILES_COMMAND = sys.executable + ' -msetuptools_scm.git'
 DEFAULT_DESCRIBE = 'git describe --dirty --tags --long --match *.*'
 
 
@@ -110,3 +118,16 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
         return meta(tag, distance=number, node=node, dirty=dirty)
     else:
         return meta(tag, node=node, dirty=dirty)
+
+
+def _main():
+    """List the files that 'git archive' wants.
+    """
+    # TarFile wants a seekable stream.
+    stream = BytesIO(subprocess.check_output(['git', 'archive', 'HEAD']))
+    for name in TarFile(fileobj=stream).getnames():
+        print(name)
+
+
+if __name__ == "__main__":
+    _main()

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -1,9 +1,6 @@
 from .utils import do_ex, trace, has_command, _normalized
 from .version import meta
-try:
-    from io import BytesIO
-except ImportError:
-    from cStringIO import StringIO as BytesIO
+import io
 
 from os.path import isfile, join
 import subprocess
@@ -124,7 +121,7 @@ def _list_files_in_archive():
     """List the files that 'git archive' generates.
     """
     # TarFile wants a seekable stream.
-    stream = BytesIO(subprocess.check_output(['git', 'archive', 'HEAD']))
+    stream = io.BytesIO(subprocess.check_output(['git', 'archive', 'HEAD']))
     for name in TarFile(fileobj=stream).getnames():
         print(name)
 

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -1,11 +1,10 @@
 from .utils import do_ex, trace, has_command, _normalized
 from .version import meta
-import io
 
 from os.path import isfile, join
 import subprocess
 import sys
-from tarfile import TarFile
+import tarfile
 import warnings
 
 FILES_COMMAND = sys.executable + ' -m setuptools_scm.git'
@@ -120,9 +119,10 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
 def _list_files_in_archive():
     """List the files that 'git archive' generates.
     """
-    # TarFile wants a seekable stream.
-    stream = io.BytesIO(subprocess.check_output(['git', 'archive', 'HEAD']))
-    for name in TarFile(fileobj=stream).getnames():
+    cmd = ['git', 'archive', 'HEAD']
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    tf = tarfile.open(fileobj=proc.stdout, mode='r|*')
+    for name in tf.getnames():
         print(name)
 
 

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -11,7 +11,7 @@ import sys
 from tarfile import TarFile
 import warnings
 
-FILES_COMMAND = sys.executable + ' -msetuptools_scm.git'
+FILES_COMMAND = sys.executable + ' -m setuptools_scm.git'
 DEFAULT_DESCRIBE = 'git describe --dirty --tags --long --match *.*'
 
 

--- a/setuptools_scm/utils.py
+++ b/setuptools_scm/utils.py
@@ -61,7 +61,7 @@ def _popen_pipes(cmd, cwd):
 
 def do_ex(cmd, cwd='.'):
     trace('cmd', repr(cmd))
-    if not isinstance(cmd, (list, tuple)):
+    if os.name == "posix" and not isinstance(cmd, (list, tuple)):
         cmd = shlex.split(cmd)
 
     p = _popen_pipes(cmd, cwd)

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -112,3 +112,15 @@ def test_alphanumeric_tags_match(wd):
     wd.commit_testfile()
     wd('git tag newstyle-development-started')
     assert wd.version.startswith('0.1.dev1+g')
+
+
+def test_git_archive_export_ignore(wd):
+    wd.write('test1.txt', 'test')
+    wd.write('test2.txt', 'test')
+    wd.write('.git/info/attributes',
+             # Explicitly include test1.txt so that the test is not affected by
+             # a potentially global gitattributes file on the test machine.
+             '/test1.txt -export-ignore\n/test2.txt export-ignore')
+    wd('git add test1.txt test2.txt')
+    wd.commit()
+    assert integration.find_files(str(wd.cwd)) == ['test1.txt']


### PR DESCRIPTION
Implemented by replacing the call to 'git ls-files' to '$sys.executable
-msetuptools_scm.git' with the module parsing the output of 'git
archive' as a tar file.

Fixes #185.  Actually that was easier to do than expected...

I haven't edited the README because I don't think it even explicitly mentions right now that it'll sdist exactly all files tracked by the VCS (it's only implicit in the doc for `setuptools_scm.files_command`), so I don't have a good place to introduce the new piece of info...