### PR TITLE
Added `get_local_node_and_timestamp()` for timestamp versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ arguments = dict(
 
         [setuptools_scm.local_scheme]
         node-and-date = setuptools_scm.version:get_local_node_and_date
-        node-and-timestamp = setuptools_scm.version:get_local_node_and_timestamp
+        node-and-timestamp = \
+        setuptools_scm.version:get_local_node_and_timestamp
         dirty-tag = setuptools_scm.version:get_local_dirty_tag
     """,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ arguments = dict(
 
         [setuptools_scm.local_scheme]
         node-and-date = setuptools_scm.version:get_local_node_and_date
+        node-and-timestamp = setuptools_scm.version:get_local_node_and_timestamp
         dirty-tag = setuptools_scm.version:get_local_dirty_tag
     """,
     classifiers=[

--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -144,6 +144,20 @@ def get_local_node_and_date(version):
         return version.format_choice("+{node}", "+{node}.d{time:%Y%m%d}")
 
 
+def get_local_node_and_timestamp(version, fmt='%Y%m%d%H%M%S'):
+    if version.exact or version.node is None:
+        return version.format_choice("",
+                                     "+d{time:"
+                                     + "{fmt}".format(fmt=fmt)
+                                     + "}")
+    else:
+        return version.format_choice("+{node}",
+                                     "+{node}"
+                                     + ".d{time:"
+                                     + "{fmt}".format(fmt=fmt)
+                                     + "}")
+
+
 def get_local_dirty_tag(version):
     return version.format_choice('', '+dirty')
 


### PR DESCRIPTION
## Affected Issues
- Fixes #200 

## Proposed Changes
- Added function `get_local_node_and_timestamp(version, fmt='%Y%m%d%H%M%S')`
- This function is callable as is (e.g., `get_version(local_scheme=get_local_node_and_timestamp)`) or as an entry point (e.g., `get_version(local_scheme='node-and-timestamp')`)
- Wrappers can be built around this function to provide custom timestamps, see examples below:

## Example Usage
### Using Entry Point
```python
v = setuptools_scm.get_version(root='..', relative_to=__file__,
                               local_scheme='node-and-timestamp')
print(v)
```

### Using Callable
```python
v = setuptools_scm.get_version(root='..', relative_to=__file__,
                               local_scheme=get_local_node_and_timestamp)
print(v)
```

### Using a Format Wrapper
```python
def min_timestamp(version):
    return get_local_node_and_timestamp(version, fmt='%Y%m%d%H%M')


v = setuptools_scm.get_version(root='..', relative_to=__file__,
                               local_scheme=min_timestamp)
print(v)
```

```python
def micro_timestamp(version):
    return get_local_node_and_timestamp(version, fmt='%Y%m%d%H%M%S%f')


v = setuptools_scm.get_version(root='..', relative_to=__file__,
                               local_scheme=micro_timestamp)
print(v)
```



