### PR TITLE
Fix misspelled "surogate_escape" bug.

### DIFF
--- a/setuptools_scm/utils.py
+++ b/setuptools_scm/utils.py
@@ -26,7 +26,7 @@ def ensure_stripped_str(str_or_bytes):
     if isinstance(str_or_bytes, str):
         return str_or_bytes.strip()
     else:
-        return str_or_bytes.decode('utf-8', 'surogate_escape').strip()
+        return str_or_bytes.decode('utf-8', 'surrogateescape').strip()
 
 
 def _always_strings(env_dict):


### PR DESCRIPTION
```
In [4]: letter
Out[4]: b'\xdc'

In [5]: letter.decode('utf-8', 'surogate_escape')
---------------------------------------------------------------------------
LookupError                               Traceback (most recent call last)
<ipython-input-5-2dfe1ae387a2> in <module>()
----> 1 letter.decode('utf-8', 'surogate_escape')

LookupError: unknown error handler name 'surogate_escape'

In [6]: letter.decode('utf-8', 'surrogateescape')
Out[6]: '\udcdc'
```

Thought I'd take a quick peek at the code in this module for the first time, and spotted this in my first minute. Seems like the kind of bug that wouldn't have made it past basic testing? Haven't read enough yet to even know whether this is dead code anyway, but submitting this PR without further ado in case it's helpful.