### PR TITLE
Fix support for old version of setuptools

### DIFF
--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -47,7 +47,7 @@ def tag_to_version(tag):
     # also required for old versions of setuptools
 
     version = tag.rsplit('-', 1)[-1].lstrip('v')
-    if parse_version is None:
+    if VERSION_CLASS is None:
         return version
     version = parse_version(version)
     trace('version', repr(version))


### PR DESCRIPTION
After 47934061 I'm getting failures when using old versions of setuptools.

When `VERSION_CLASS` is `None` (old setuptools), line 54 fails with
```
  File ".../setuptools_scm/version.py", line 54, in tag_to_version
TypeError: isinstance() arg 2 must be a class, type, or tuple of classes and types
```

This change should fix the issue.