### PR TITLE
git: ignore directory of the git archive output

### DIFF
--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -129,8 +129,9 @@ def _list_files_in_archive():
     cmd = ['git', 'archive', 'HEAD']
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     tf = tarfile.open(fileobj=proc.stdout, mode='r|*')
-    for name in tf.getnames():
-        print(name)
+    for member in tf.getmembers():
+        if member.type != tarfile.DIRTYPE:
+            print(member.name)
 
 
 if __name__ == "__main__":

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -124,3 +124,12 @@ def test_git_archive_export_ignore(wd):
     wd('git add test1.txt test2.txt')
     wd.commit()
     assert integration.find_files(str(wd.cwd)) == ['test1.txt']
+
+
+@pytest.mark.issue(228)
+def test_git_archive_subdirectory(wd):
+    wd('mkdir foobar')
+    wd.write('foobar/test1.txt', 'test')
+    wd('git add foobar')
+    wd.commit()
+    assert integration.find_files(str(wd.cwd)) == ['foobar/test1.txt']


### PR DESCRIPTION
Since 1.16.0, if the git project have subdirectory, bdist fails.

For example:

running bdist_wheel
running build
running build_py
running egg_info
writing requirements to gnocchi.egg-info/requires.txt
writing gnocchi.egg-info/PKG-INFO
writing top-level names to gnocchi.egg-info/top_level.txt
writing dependency_links to gnocchi.egg-info/dependency_links.txt
writing entry points to gnocchi.egg-info/entry_points.txt
reading manifest template 'MANIFEST.in'
writing manifest file 'gnocchi.egg-info/SOURCES.txt'
error: can't copy 'gnocchi/cli': doesn't exist or not a regular file

gnocchi/cli is a directory here.

This change ignores directory of "git archive" output to fix the issue.