### PR TITLE
 git: ignore directory of the git archive output, remove tar

### DIFF
--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -4,7 +4,7 @@ from .version import meta
 from os.path import isfile, join
 import subprocess
 import sys
-import tarfile
+import codecs
 import warnings
 
 
@@ -126,11 +126,10 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
 def _list_files_in_archive():
     """List the files that 'git archive' generates.
     """
-    cmd = ['git', 'archive', 'HEAD']
+    cmd = ['git', 'ls-files']
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    tf = tarfile.open(fileobj=proc.stdout, mode='r|*')
-    for name in tf.getnames():
-        print(name)
+    for name in codecs.getreader("utf-8")(proc.stdout, "ignore").readlines():
+        print(name[:-1])
 
 
 if __name__ == "__main__":

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -126,7 +126,7 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
 def _list_files_in_archive():
     """List the files that 'git archive' generates.
     """
-    cmd = ['git', 'ls-files']
+    cmd = ['git', 'ls-files', '--exclude-standard']
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     for name in codecs.getreader("utf-8")(proc.stdout, "ignore").readlines():
         print(name[:-1])

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -124,3 +124,11 @@ def test_git_archive_export_ignore(wd):
     wd('git add test1.txt test2.txt')
     wd.commit()
     assert integration.find_files(str(wd.cwd)) == ['test1.txt']
+
+@pytest.mark.issue(228)
+def test_git_archive_subdirectory(wd):
+    wd('mkdir foobar')
+    wd.write('foobar/test1.txt', 'test')
+    wd('git add foobar')
+    wd.commit()
+    assert integration.find_files(str(wd.cwd)) == ['foobar/test1.txt']


### PR DESCRIPTION
Instead of creating a tarfile use python streams.
I think it is a better solution than:
https://github.com/pypa/setuptools_scm/pull/227

Most probably there are still some optimizations possible.