### PR TITLE
git: Use a method instead of a command for listing files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ arguments = dict(
 
         [setuptools_scm.files_command]
         .hg = setuptools_scm.hg:FILES_COMMAND
-        .git = setuptools_scm.git:FILES_COMMAND
+        .git = setuptools_scm.git:list_files_in_archive
 
         [setuptools_scm.version_scheme]
         guess-next-dev = setuptools_scm.version:guess_next_dev_version

--- a/setuptools_scm/git.py
+++ b/setuptools_scm/git.py
@@ -3,7 +3,6 @@ from .version import meta
 
 from os.path import isfile, join
 import subprocess
-import sys
 import tarfile
 import warnings
 
@@ -14,7 +13,6 @@ except ImportError:
     from .win_py31_compat import samefile
 
 
-FILES_COMMAND = sys.executable + ' -m setuptools_scm.git'
 DEFAULT_DESCRIBE = 'git describe --dirty --tags --long --match *.*'
 
 
@@ -123,16 +121,11 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
         return meta(tag, node=node, dirty=dirty)
 
 
-def _list_files_in_archive():
+def list_files_in_archive(path):
     """List the files that 'git archive' generates.
     """
     cmd = ['git', 'archive', 'HEAD']
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=path)
     tf = tarfile.open(fileobj=proc.stdout, mode='r|*')
-    for member in tf.getmembers():
-        if member.type != tarfile.DIRTYPE:
-            print(member.name)
-
-
-if __name__ == "__main__":
-    _list_files_in_archive()
+    return [member.name for member in tf.getmembers()
+            if member.type != tarfile.DIRTYPE]


### PR DESCRIPTION
We can't use "python -m" because if setuptool_scm is install with
easy_install (e.g.: via setup_requires), the module will not be found.

This change use a method instead of a command.

Fixes #232