### PR TITLE
stop if find_files fail

### DIFF
--- a/setuptools_scm/integration.py
+++ b/setuptools_scm/integration.py
@@ -36,10 +36,8 @@ def find_files(path='.'):
             else:
                 return command(path)
         except Exception:
-            import traceback
             print("File Finder Failed for %s" % ep)
-            traceback.print_exc()
-            return []
+            raise
 
     else:
         return []


### PR DESCRIPTION
We must reraise any expection during find_files instead
of generating an almost empty sdist/bdist.

Related #232