### PR TITLE
Improve development version in semver

### DIFF
--- a/setuptools_scm/version.py
+++ b/setuptools_scm/version.py
@@ -1,13 +1,14 @@
 from __future__ import print_function
+
 import datetime
-import warnings
 import re
-from .utils import trace
+import warnings
+from distutils import log
 
 from pkg_resources import iter_entry_points
-
-from distutils import log
 from pkg_resources import parse_version
+
+from .utils import trace
 
 
 def _get_version_class():
@@ -133,8 +134,15 @@ def _bump_dev(version):
 
 
 def _bump_regex(version):
-    prefix, tail = re.match('(.*?)(\d+)$', version).groups()
-    return '%s%d' % (prefix, int(tail) + 1)
+    groups = re.match(
+        '(?:(?P<sv_prefix>.*?\.)(?P<sv_number>\d+)(?P<sv_suffix>\.\d+)|'
+        '(?P<prefix>.*?)(?P<number>\d+))$',
+        version
+    ).groupdict()
+    prefix = groups["sv_prefix"] or groups["prefix"]
+    number = groups["sv_number"] or groups["number"]
+    suffix = groups["sv_suffix"] or ""
+    return '%s%d%s' % (prefix, int(number) + 1, suffix)
 
 
 def guess_next_dev_version(version):

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -16,6 +16,8 @@ class MockTime(object):
 @pytest.mark.parametrize('tag, expected', [
     ('1.1', '1.2.dev0'),
     ('1.2.dev', '1.2.dev0'),
+    ('1.1.0', '1.2.0.dev0'),
+    ('1.2.0.dev', '1.2.0.dev0'),
     ('1.1a2', '1.1a3.dev0'),
     ('23.24.post2+deadbeef', '23.24.post3.dev0'),
     ])


### PR DESCRIPTION
When dealing with semantic versioned code, the original behaviour was to
increment the latest digit. For instance: v1.2.0 gives v1.2.1.dev1. This
commit implements something that might look more logical in semver which
is to increase the minor rather than the patch: v1.2.0 -> v1.3.0.dev1