### PR TITLE
file finder: symlink edge cases

### DIFF
--- a/setuptools_scm/file_finder.py
+++ b/setuptools_scm/file_finder.py
@@ -8,6 +8,7 @@ def scm_find_files(path, scm_files, scm_dirs):
     - scm_files: set of scm controlled files and symlinks
       (including symlinks to directories)
     - scm_dirs: set of scm controlled directories
+      (including directories containing no scm controlled files)
 
     scm_files and scm_dirs must be absolute with symlinks resolved (realpath),
     with normalized case (normcase)

--- a/setuptools_scm/file_finder.py
+++ b/setuptools_scm/file_finder.py
@@ -5,7 +5,8 @@ def scm_find_files(path, scm_files, scm_dirs):
     """ setuptools compatible file finder that follows symlinks
 
     - path: the root directory from which to search
-    - scm_files: set of scm controlled files
+    - scm_files: set of scm controlled files and symlinks
+      (including symlinks to directories)
     - scm_dirs: set of scm controlled directories
 
     scm_files and scm_dirs must be absolute with symlinks resolved (realpath),

--- a/setuptools_scm/file_finder.py
+++ b/setuptools_scm/file_finder.py
@@ -6,7 +6,7 @@ def scm_find_files(path, scm_files, scm_dirs):
 
     - path: the root directory from which to search
     - scm_files: set of scm controlled files
-    - scm_files: set of scm controlled directories
+    - scm_dirs: set of scm controlled directories
 
     scm_files and scm_dirs must be absolute with symlinks resolved (realpath),
     with normalized case (normcase)
@@ -20,10 +20,31 @@ def scm_find_files(path, scm_files, scm_dirs):
     for dirpath, dirnames, filenames in os.walk(realpath, followlinks=True):
         # dirpath with symlinks resolved
         realdirpath = os.path.normcase(os.path.realpath(dirpath))
-        if realdirpath not in scm_dirs or realdirpath in seen:
+
+        def _link_not_in_scm(n):
+            fn = os.path.join(realdirpath, os.path.normcase(n))
+            return os.path.islink(fn) and fn not in scm_files
+
+        if realdirpath not in scm_dirs:
+            # directory not in scm, don't walk it's content
             dirnames[:] = []
             continue
+        if os.path.islink(dirpath) and \
+                not os.path.relpath(realdirpath, realpath).startswith(os.pardir):
+            # a symlink to a directory not outside path:
+            # we keep it in the result and don't walk its content
+            res.append(
+                os.path.join(path, os.path.relpath(dirpath, path)))
+            dirnames[:] = []
+            continue
+        if realdirpath in seen:
+            # symlink loop protection
+            dirnames[:] = []
+            continue
+        dirnames[:] = [dn for dn in dirnames if not _link_not_in_scm(dn)]
         for filename in filenames:
+            if _link_not_in_scm(filename):
+                continue
             # dirpath + filename with symlinks preserved
             fullfilename = os.path.join(dirpath, filename)
             if os.path.normcase(os.path.realpath(fullfilename)) in scm_files:


### PR DESCRIPTION
It turns out we had a edge case to handle, as the algorithm
included scm controlled files reachable through symlinks while the
symlink itself was not scm controlled.

Additionally, better handle situations where we include a directory
below 'path' as well as a symlink to it. Before it would randomly
return the original directory, or include it under the symlink.