### PR TITLE
fix tag_to_version by limiting prefixes to words again

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ v3.0.0
 * switch to src layout (breaking change)
 * no longer alias tag and parsed_version in order to support understanding a version parse failure
 * require parse results to be ScmVersion or None (breaking change)
+* fix #266 by requirin the prefix word to be a word again
+  (breaking change as the bug allowed arbitrary prefixes while the original feature only allowed words")
 
 v2.1.0
 ======

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -111,19 +111,26 @@ def parse(root, describe_command=DEFAULT_DESCRIBE, pre_parse=warn_on_shallow):
             dirty=dirty,
             branch=wd.get_branch(),
         )
+    else:
+        tag, number, node, dirty = _git_parse_describe(out)
 
-    # 'out' looks e.g. like 'v1.5.0-0-g4060507' or
+        branch = wd.get_branch()
+        if number:
+            return meta(tag, distance=number, node=node, dirty=dirty, branch=branch)
+        else:
+            return meta(tag, node=node, dirty=dirty, branch=branch)
+
+
+def _git_parse_describe(describe_output):
+    # 'describe_output' looks e.g. like 'v1.5.0-0-g4060507' or
     # 'v1.15.1rc1-37-g9bd1298-dirty'.
-    if out.endswith("-dirty"):
+
+    if describe_output.endswith("-dirty"):
         dirty = True
-        out = out[:-6]
+        describe_output = describe_output[:-6]
     else:
         dirty = False
 
-    tag, number, node = out.rsplit("-", 2)
+    tag, number, node = describe_output.rsplit("-", 2)
     number = int(number)
-    branch = wd.get_branch()
-    if number:
-        return meta(tag, distance=number, node=node, dirty=dirty, branch=branch)
-    else:
-        return meta(tag, node=node, dirty=dirty, branch=branch)
+    return tag, number, node, dirty

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -13,6 +13,7 @@ from pkg_resources import parse_version as pkg_parse_version
 SEMVER_MINOR = 2
 SEMVER_PATCH = 3
 SEMVER_LEN = 3
+TAG_PREFIX = re.compile(r"^\w+-(.*)")
 
 
 def _pad(iterable, size, padding=None):
@@ -56,14 +57,21 @@ def callable_or_entrypoint(group, callable_or_name):
 
 
 def tag_to_version(tag):
+    """
+    take a tag that might be prefixed with a keyword and return only the version part
+    """
     trace("tag", tag)
     if "+" in tag:
         warnings.warn("tag %r will be stripped of the local component" % tag)
         tag = tag.split("+")[0]
     # lstrip the v because of py2/py3 differences in setuptools
     # also required for old versions of setuptools
-
-    version = tag.rsplit("-", 1)[-1].lstrip("v")
+    prefix_match = TAG_PREFIX.match(tag)
+    if prefix_match is not None:
+        version = prefix_match.group(1)
+    else:
+        version = tag
+    trace("version pre parse", version)
     if VERSION_CLASS is None:
         return version
     version = pkg_parse_version(version)

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -2,7 +2,12 @@ import pytest
 import sys
 import pkg_resources
 from setuptools_scm import dump_version, get_version, PRETEND_KEY
-from setuptools_scm.version import guess_next_version, meta, format_version
+from setuptools_scm.version import (
+    guess_next_version,
+    meta,
+    format_version,
+    tag_to_version,
+)
 from setuptools_scm.utils import has_command
 
 PY3 = sys.version_info > (2,)
@@ -77,3 +82,16 @@ def test_has_command(recwarn):
     assert not has_command("yadayada_setuptools_aint_ne")
     msg = recwarn.pop()
     assert "yadayada" in str(msg.message)
+
+
+@pytest.mark.parametrize(
+    "tag, expected_version",
+    [
+        ("1.1", "1.1"),
+        ("release-1.1", "1.1"),
+        pytest.param("3.3.1-rc26", "3.3.1rc26", marks=pytest.mark.issue(266)),
+    ],
+)
+def test_tag_to_version(tag, expected_version):
+    version = str(tag_to_version(tag))
+    assert version == expected_version

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -16,6 +16,15 @@ def wd(wd):
     return wd
 
 
+@pytest.mark.parametrize(
+    "given, tag, number, node, dirty",
+    [("3.3.1-rc26-0-g9df187b", "3.3.1-rc26", 0, "g9df187b", False)],
+)
+def test_parse_describe_output(given, tag, number, node, dirty):
+    parsed = git._git_parse_describe(given)
+    assert parsed == (tag, number, node, dirty)
+
+
 def test_version_from_git(wd):
     assert wd.version == "0.1.dev0"
 


### PR DESCRIPTION
fixes #266 