### PR TITLE
Add `node-and-timestamp` to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -272,8 +272,8 @@ Version number construction
 
     :node-and-date: adds the node on dev versions and the date on dirty
                     workdir (default)
-    :node-and-timestamp: like :code: `node-and-date` but with a timestamp of
-                         the form :code: `{:%Y%m%d%H%M%S}` instead
+    :node-and-timestamp: like :code:`node-and-date` but with a timestamp of
+                         the form :code:`{:%Y%m%d%H%M%S}` instead
     :dirty-tag: adds :code:`+dirty` if the current workdir has changes
 
 

--- a/README.rst
+++ b/README.rst
@@ -272,6 +272,8 @@ Version number construction
 
     :node-and-date: adds the node on dev versions and the date on dirty
                     workdir (default)
+    :node-and-timestamp: like :code: `node-and-date` but with a timestamp of
+                         the form :code: `{:%Y%m%d%H%M%S}` instead
     :dirty-tag: adds :code:`+dirty` if the current workdir has changes
 
 


### PR DESCRIPTION
It was not obvious that `node-and-timestamp` was an available implementation for `local_scheme`. This PR adds it to the list of implementations in `README.rst`.