### PR TITLE
Do not parse tag when pretending version

### DIFF
--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -60,7 +60,7 @@ def _do_parse(root, parse):
     if pretended:
         # we use meta here since the pretended version
         # must adhere to the pep to begin with
-        return meta(pretended)
+        return meta(tag=pretended, preformatted=True)
 
     if parse:
         parse_result = parse(root)

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -51,10 +51,12 @@ def test_root_parameter_pass_by(monkeypatch, tmpdir):
     setuptools_scm.get_version(root=tmpdir.strpath)
 
 
-def test_pretended(monkeypatch):
-    pretense = "2345"
-    monkeypatch.setenv(setuptools_scm.PRETEND_KEY, pretense)
-    assert setuptools_scm.get_version() == pretense
+@pytest.mark.parametrize(
+    "version", ["1.0", "1.2.3.dev1+ge871260", "1.2.3.dev15+ge871260.d20180625", "2345"]
+)
+def test_pretended(version, monkeypatch):
+    monkeypatch.setenv(setuptools_scm.PRETEND_KEY, version)
+    assert setuptools_scm.get_version() == version
 
 
 def test_root_relative_to(monkeypatch, tmpdir):

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -72,10 +72,13 @@ def test_dump_version_doesnt_bail_on_value_error(tmpdir):
     assert str(exc_info.value).startswith("bad file format:")
 
 
-def test_dump_version_works_with_pretend(tmpdir, monkeypatch):
-    monkeypatch.setenv(PRETEND_KEY, "1.0")
+@pytest.mark.parametrize(
+    "version", ["1.0", "1.2.3.dev1+ge871260", "1.2.3.dev15+ge871260.d20180625"]
+)
+def test_dump_version_works_with_pretend(version, tmpdir, monkeypatch):
+    monkeypatch.setenv(PRETEND_KEY, version)
     get_version(write_to=str(tmpdir.join("VERSION.txt")))
-    assert tmpdir.join("VERSION.txt").read() == "1.0"
+    assert tmpdir.join("VERSION.txt").read() == version
 
 
 def test_has_command(recwarn):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,34,35,36,37}-test,flake8,check_readme,py{27,36}-selftest
+envlist=py{27,34,35,36,37}-test,flake8,check_readme,py{27,36}-selfcheck
 
 [flake8]
 max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps=
     readme
     check-manifest
 commands=
-    python setup.py check -r -s
+    python setup.py check -r
     rst2html.py README.rst {envlogdir}/README.html --strict []
     check-manifest
 


### PR DESCRIPTION
Fixes #271.

From what I understand of the pretend behavior I am not sure it should go through the parsing process.  