### PR TITLE
fix #292 - support for uppercase leading v character 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+v3.0.5
+
+* fix #292 - match leading 'V' character as well
+
+  https://www.python.org/dev/peps/pep-0440/#preceding-v-character
+
+v3.0.4
+=======
+
+* rerelease of 3.0.3 after fixing the release process
+
 v3.0.3  (pulled from pypi due to a packaging issue)
 ======
 

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -6,7 +6,7 @@ import warnings
 
 from .utils import trace
 
-DEFAULT_TAG_REGEX = r"^(?:[\w-]+-)?(?P<version>v?\d+(?:\.\d+){0,2}[^\+]+)(?:\+.*)?$"
+DEFAULT_TAG_REGEX = r"^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]+)(?:\+.*)?$"
 DEFAULT_VERSION_SCHEME = "version_scheme"
 
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -9,6 +9,8 @@ import pytest
         ("apache-arrow-0.9.0", "0.9.0"),
         ("arrow-0.9.0", "0.9.0"),
         ("arrow-0.9.0-rc", "0.9.0-rc"),
+        ("v1.1", "v1.1"),
+        ("V1.1", "V1.1"),
     ],
 )
 def test_tag_regex(tag, expected_version):


### PR DESCRIPTION
in tag version extraction regex