### PR TITLE
basic test for git worktrees

### DIFF
--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -107,7 +107,7 @@ def test_git_worktree_support(wd, tmpdir):
     worktree = tmpdir.join("work_tree")
     wd("git worktree add -b work-tree %s" % worktree)
 
-    res = do([sys.executable, "-m", "setuptools_scm"], cwd=worktree)
+    res = do([sys.executable, "-m", "setuptools_scm", "ls"], cwd=worktree)
     assert str(worktree) in res
 
 

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools_scm import integration
 from setuptools_scm.utils import do
 from setuptools_scm import git
@@ -98,6 +99,16 @@ def test_git_dirty_notag(wd):
     today = date.today()
     # we are dirty, check for the tag
     assert today.strftime(".d%Y%m%d") in wd.version
+
+
+@pytest.mark.issue(193)
+def test_git_worktree_support(wd, tmpdir):
+    wd.commit_testfile()
+    worktree = tmpdir.join("work_tree")
+    wd("git worktree add -b work-tree %s" % worktree)
+
+    res = do([sys.executable, "-m", "setuptools_scm"], cwd=worktree)
+    assert str(worktree) in res
 
 
 @pytest.fixture


### PR DESCRIPTION
closes #258 - it seems we supported it since the switch to show-toplevel