### PR TITLE
git: DEFAULT_DESCRIBE: add --first-parent

### DIFF
--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -12,7 +12,7 @@ except ImportError:
     from .win_py31_compat import samefile
 
 
-DEFAULT_DESCRIBE = "git describe --dirty --tags --long --match *.*"
+DEFAULT_DESCRIBE = "git describe --dirty --tags --long --match *.* --first-parent"
 
 
 class GitWorkdir(object):


### PR DESCRIPTION
This will ignore tags from merged release branches.

Available since Git 1.8.4: https://github.com/git/git/commit/e00dd1e9485c50f202cc97dfae19d510e108b565