### PR TITLE
Implement declarative config for compatibility with setuptools declarative config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+v3.4.0
+======
+
+* fix #181 - add support for projects built under setuptools declarative config
+  by way of the setuptools.finalize_distribution_options hook in Setuptools 42.
+
 * fix #305 - ensure the git file finder closes filedescriptors even when errors happen
 
 v3.3.3

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,62 @@ It also handles file finders for the supported SCMs.
 .. image:: https://tidelift.com/badges/github/pypa/setuptools_scm
    :target: https://tidelift.com/subscription/pkg/pypi-setuptools_scm?utm_source=pypi-setuptools_scm&utm_medium=readme
 
+``pyproject.toml`` usage
+------------------------
+
+The preferred way to configure ``setuptools_scm`` is to author
+settings in a ``tool.setuptools_scm`` section of ``pyproject.toml``.
+
+This feature requires Setuptools 42 or later, released in Nov, 2019.
+If your project needs to support build from sdist on older versions
+of Setuptools, you will need to also implement the ``setup.py usage``
+for those legacy environments.
+
+First, ensure that ``setuptools_scm`` is present during the project's
+built step by specifying it as one of the build requirements.
+
+.. code:: ini
+
+    # pyproject.toml
+    [build-system]
+    requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+
+Note that the ``toml`` extra must be supplied.
+
+That will be sufficient to require ``setuptools_scm`` for projects
+that support PEP 518 (`pip <https://pypi.org/project/pip>`_ and
+`pep517 <https://pypi.org/project/pep517/>`_). Many tools,
+especially those that invoke ``setup.py`` for any reason, may
+continue to rely on ``setup_requires``. For maximum compatibility
+with those uses, consider also including a ``setup_requires`` directive
+(described below in ``setup.py usage`` and ``setup.cfg``).
+
+To enable version inference, add this section to your pyproject.toml:
+
+.. code:: ini
+
+    # pyproject.toml
+    [tools.setuptools_scm]
+
+Including this section is comparable to supplying
+``use_scm_version=True`` in ``setup.py``. Additionally,
+include arbitrary keyword arguments in that section
+to be supplied to ``get_version()``. For example::
+
+.. code:: ini
+
+    # pyproject.toml
+    [tools.setuptools_scm]
+    write_to = pkg/version.py
+
+
 ``setup.py`` usage
 ------------------
+
+The following settings are considered legacy behavior and
+superseded by the ``pyproject.toml`` usage, but for maximal
+compatibility, projects may also supply the configuration in
+this older form.
 
 To use ``setuptools_scm`` just modify your project's ``setup.py`` file
 like this:

--- a/setup.py
+++ b/setup.py
@@ -113,8 +113,8 @@ arguments = dict(
         "Topic :: System :: Software Distribution",
         "Topic :: Utilities",
     ],
-    install_requires=["toml"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    extras_require=dict(toml=["toml"]),
 )
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ arguments = dict(
         "Topic :: System :: Software Distribution",
         "Topic :: Utilities",
     ],
+    install_requires=["toml"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
 )
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ arguments = dict(
         [setuptools.file_finders]
         setuptools_scm = setuptools_scm.integration:find_files
 
+        [setuptools.finalize_distribution_options]
+        setuptools_scm = setuptools_scm.integration:infer_version
+
         [setuptools_scm.parse_scm]
         .hg = setuptools_scm.hg:parse
         .git = setuptools_scm.git:parse

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -80,6 +80,9 @@ def dump_version(root, version, write_to, template=None):
 
 
 def _do_parse(config):
+    if not config.enabled:
+        return
+
     pretended = os.environ.get(PRETEND_KEY)
     if pretended:
         # we use meta here since the pretended version
@@ -146,18 +149,24 @@ def get_version(
     config.fallback_version = fallback_version
     config.parse = parse
     config.git_describe_command = git_describe_command
+    config.enabled = True
+    return _get_version(config)
 
+
+def _get_version(config):
     parsed_version = _do_parse(config)
 
     if parsed_version:
         version_string = format_version(
-            parsed_version, version_scheme=version_scheme, local_scheme=local_scheme
+            parsed_version,
+            version_scheme=config.version_scheme,
+            local_scheme=config.local_scheme,
         )
         dump_version(
-            root=root,
+            root=config.root,
             version=version_string,
-            write_to=write_to,
-            template=write_to_template,
+            write_to=config.write_to,
+            template=config.write_to_template,
         )
 
         return version_string

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -80,9 +80,6 @@ def dump_version(root, version, write_to, template=None):
 
 
 def _do_parse(config):
-    if not config.enabled:
-        return
-
     pretended = os.environ.get(PRETEND_KEY)
     if pretended:
         # we use meta here since the pretended version
@@ -149,7 +146,6 @@ def get_version(
     config.fallback_version = fallback_version
     config.parse = parse
     config.git_describe_command = git_describe_command
-    config.enabled = True
     return _get_version(config)
 
 

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -114,5 +114,5 @@ class Configuration(object):
         with open(name) as strm:
             defn = __import__('toml').load(strm)
         config = cls()
-        vars(config).update(defn.get('setuptools_scm', {}))
+        vars(config).update(defn.get("tool",{}).get('setuptools_scm', {}))
         return config

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -107,12 +107,12 @@ class Configuration(object):
         self._tag_regex = _check_tag_regex(value)
 
     @classmethod
-    def from_file(cls, name='pyproject.toml'):
+    def from_file(cls, name="pyproject.toml"):
         """
         Read Configuration from pyproject.toml (or similar)
         """
         with open(name) as strm:
-            defn = __import__('toml').load(strm)
+            defn = __import__("toml").load(strm)
         config = cls()
-        vars(config).update(defn.get("tool",{}).get('setuptools_scm', {}))
+        vars(config).update(defn.get("tool", {}).get("setuptools_scm", {}))
         return config

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -49,7 +49,6 @@ class Configuration(object):
     parse = None
     _tag_regex = None
     _absolute_root = None
-    enabled = False
 
     def __init__(self, relative_to=None, root="."):
         # TODO:
@@ -107,15 +106,18 @@ class Configuration(object):
     def tag_regex(self, value):
         self._tag_regex = _check_tag_regex(value)
 
+    def _load(self, values):
+        vars(self).update(values)
+        return self
+
     @classmethod
     def from_file(cls, name="pyproject.toml"):
         """
-        Read Configuration from pyproject.toml (or similar)
+        Read Configuration from pyproject.toml (or similar).
+        Raises exceptions when file is not found or toml is
+        not installed or the file has invalid format or does
+        not contain the [tool.setuptools_scm] section.
         """
-        if not os.path.isfile(name):
-            return cls()
         with open(name) as strm:
             defn = __import__("toml").load(strm)
-        config = cls()
-        vars(config).update(defn.get("tool", {}).get("setuptools_scm", {}))
-        return config
+        return cls()._load(defn.get("tool", {})["setuptools_scm"])

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -105,3 +105,10 @@ class Configuration(object):
     @tag_regex.setter
     def tag_regex(self, value):
         self._tag_regex = _check_tag_regex(value)
+
+    @classmethod
+    def from_file(cls):
+        """
+        Read Configuration from pyproject.toml (or similar)
+        """
+        # stubbed

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -107,8 +107,12 @@ class Configuration(object):
         self._tag_regex = _check_tag_regex(value)
 
     @classmethod
-    def from_file(cls):
+    def from_file(cls, name='pyproject.toml'):
         """
         Read Configuration from pyproject.toml (or similar)
         """
-        # stubbed
+        with open(name) as strm:
+            defn = __import__('toml').load(strm)
+        config = cls()
+        vars(config).update(defn.get('setuptools_scm', {}))
+        return config

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -112,6 +112,8 @@ class Configuration(object):
         """
         Read Configuration from pyproject.toml (or similar)
         """
+        if not os.path.isfile(name):
+            return cls()
         with open(name) as strm:
             defn = __import__("toml").load(strm)
         config = cls()

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -49,6 +49,7 @@ class Configuration(object):
     parse = None
     _tag_regex = None
     _absolute_root = None
+    enabled = False
 
     def __init__(self, relative_to=None, root="."):
         # TODO:

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -2,7 +2,7 @@ from pkg_resources import iter_entry_points
 
 from .version import _warn_if_setuptools_outdated
 from .config import Configuration
-from .utils import do
+from .utils import do, trace_exception
 from . import get_version, _get_version
 
 
@@ -32,6 +32,8 @@ def find_files(path=""):
 
 
 def infer_version(dist):
-    version = _get_version(Configuration.from_file())
-    if version:
-        dist.metadata.version = version
+    try:
+        config = Configuration.from_file()
+    except Exception:
+        return trace_exception()
+    dist.metadata.version = _get_version(config)

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -1,8 +1,9 @@
 from pkg_resources import iter_entry_points
 
 from .version import _warn_if_setuptools_outdated
+from .config import Configuration
 from .utils import do
-from . import get_version
+from . import get_version, _get_version
 
 
 def version_keyword(dist, keyword, value):
@@ -28,3 +29,9 @@ def find_files(path=""):
         if res:
             return res
     return []
+
+
+def infer_version(dist):
+    version = _get_version(Configuration.from_file())
+    if version:
+        dist.metadata.version = version

--- a/src/setuptools_scm/utils.py
+++ b/src/setuptools_scm/utils.py
@@ -10,6 +10,7 @@ import subprocess
 import os
 import io
 import platform
+import traceback
 
 
 DEBUG = bool(os.environ.get("SETUPTOOLS_SCM_DEBUG"))
@@ -23,6 +24,10 @@ def trace(*k):
     if DEBUG:
         print(*k)
         sys.stdout.flush()
+
+
+def trace_exception():
+    DEBUG and traceback.print_exc()
 
 
 def ensure_stripped_str(str_or_bytes):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -24,6 +24,5 @@ def test_tag_regex(tag, expected_version):
 
 def test_config_from_pyproject(tmpdir):
     fn = tmpdir / "pyproject.toml"
-    fn.write_text("[tool.setuptools_scm]\nenabled = true\n", encoding="utf-8")
-    config = Configuration.from_file(str(fn))
-    assert config.enabled
+    fn.write_text("[tool.setuptools_scm]\n", encoding="utf-8")
+    assert Configuration.from_file(str(fn))

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -21,7 +21,7 @@ def test_tag_regex(tag, expected_version):
 
 
 def test_config_from_pyproject(tmpdir):
-    fn = tmpdir / 'pyproject.toml'
-    fn.write_text('[tool.setuptools_scm]\nenabled = true\n', encoding='utf-8')
+    fn = tmpdir / "pyproject.toml"
+    fn.write_text("[tool.setuptools_scm]\nenabled = true\n", encoding="utf-8")
     config = Configuration.from_file(str(fn))
     assert config.enabled

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -18,3 +18,10 @@ def test_tag_regex(tag, expected_version):
     match = config.tag_regex.match(tag)
     version = match.group("version")
     assert version == expected_version
+
+
+def test_config_from_pyproject(tmpdir):
+    fn = tmpdir / 'pyproject.toml'
+    fn.write_text('[setuptools_scm]\nenabled = true\n', encoding='utf-8')
+    config = Configuration.from_file(str(fn))
+    assert config.enabled

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from setuptools_scm.config import Configuration
 
 import pytest

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -22,6 +22,6 @@ def test_tag_regex(tag, expected_version):
 
 def test_config_from_pyproject(tmpdir):
     fn = tmpdir / 'pyproject.toml'
-    fn.write_text('[setuptools_scm]\nenabled = true\n', encoding='utf-8')
+    fn.write_text('[tool.setuptools_scm]\nenabled = true\n', encoding='utf-8')
     config = Configuration.from_file(str(fn))
     assert config.enabled

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -8,7 +8,6 @@ def test_pyproject_support(tmpdir, monkeypatch):
     pkg = tmpdir.ensure("package", dir=42)
     pkg.join("pyproject.toml").write(
         """[tool.setuptools_scm]
-enabled = true
 fallback_version = "12.34"
 """
     )

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -1,0 +1,17 @@
+import sys
+
+from setuptools_scm.utils import do
+
+
+def test_pyproject_support(tmpdir, monkeypatch):
+    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
+    pkg = tmpdir.ensure("package", dir=42)
+    pkg.join("pyproject.toml").write(
+        """[tool.setuptools_scm]
+enabled = true
+fallback_version = "12.34"
+"""
+    )
+    pkg.join("setup.py").write("__import__('setuptools').setup()")
+    res = do((sys.executable, "setup.py", "--version"), pkg)
+    assert res == "12.34"

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ deps=
 commands=
     test: py.test []
     selfcheck: python setup.py --version
+extras =
+    toml
 
 [testenv:flake8]
 skip_install=True

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ skip_install=
     test: False
 deps=
     pytest
+    setuptools >= 42
 commands=
     test: py.test []
     selfcheck: python setup.py --version


### PR DESCRIPTION
Fixes #181 

In irc.freenode.net#pylib, Ronny asked about supporting setuptools_scm on setuptools in a declarative config world. This change illustrates how I'd propose for that to happen. Setuptools would expose a new hook, something like

https://gist.github.com/b45998781be03918a21f17da996ee687

And then setuptools_scm would provide a hook into that such as the one (building on all of the existing work already done).