### PR TITLE
Prefer pep517 for building the project

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include testing/*.py
 include tox.ini
 include *.rst
 include LICENSE
+include *.toml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ init:
 
   - ECHO "Updating Environment"
   - python -m pip install -U pip
-  - python -m pip install -U wheel
+  - python -m pip install -U pep517
   - python -m pip install -U --upgrade-strategy=eager tox
 
 
@@ -35,7 +35,7 @@ test_script:
 
 after_test:
   # If tests are successful, create a whl package for the project.
-  - "%CMD_IN_ENV% python setup.py bdist_wheel"
+  - python -m pep517.build --binary .
   - ps: "ls dist"
 
 artifacts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=34.4", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This change adopts PEP 517 and relies on the [pep517 tool](https://pypi.org/project/pep517) to build the wheel in the Appveyor tests, demonstrating how one could build wheels (and sdists for that matter) without a setup.py file (in this case, setup.py does get called, but only because that's what pyproject.toml implies).