### PR TITLE
fix #374 - initialize configuration for toml integration

### DIFF
--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -5,7 +5,12 @@
 import os
 import warnings
 
-from .config import Configuration
+from .config import (
+    Configuration,
+    DEFAULT_VERSION_SCHEME,
+    DEFAULT_LOCAL_SCHEME,
+    DEFAULT_TAG_REGEX,
+)
 from .utils import function_has_arg, string_types
 from .version import format_version, meta
 from .discover import iter_matching_entrypoints
@@ -116,12 +121,12 @@ def _do_parse(config):
 
 def get_version(
     root=".",
-    version_scheme="guess-next-dev",
-    local_scheme="node-and-date",
+    version_scheme=DEFAULT_VERSION_SCHEME,
+    local_scheme=DEFAULT_LOCAL_SCHEME,
     write_to=None,
     write_to_template=None,
     relative_to=None,
-    tag_regex=None,
+    tag_regex=DEFAULT_TAG_REGEX,
     fallback_version=None,
     fallback_root=".",
     parse=None,
@@ -134,18 +139,7 @@ def get_version(
     root of the repository by supplying ``__file__``.
     """
 
-    config = Configuration()
-    config.root = root
-    config.fallback_root = fallback_root
-    config.version_scheme = version_scheme
-    config.local_scheme = local_scheme
-    config.write_to = write_to
-    config.write_to_template = write_to_template
-    config.relative_to = relative_to
-    config.tag_regex = tag_regex
-    config.fallback_version = fallback_version
-    config.parse = parse
-    config.git_describe_command = git_describe_command
+    config = Configuration(**locals())
     return _get_version(config)
 
 

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -2,7 +2,7 @@ from pkg_resources import iter_entry_points
 
 from .version import _warn_if_setuptools_outdated
 from .utils import do, trace_exception
-from . import get_version
+from . import _get_version, Configuration
 
 
 def version_keyword(dist, keyword, value):
@@ -13,8 +13,8 @@ def version_keyword(dist, keyword, value):
         value = {}
     if getattr(value, "__call__", None):
         value = value()
-
-    dist.metadata.version = get_version(**value)
+    config = Configuration(**value)
+    dist.metadata.version = _get_version(config)
 
 
 def find_files(path=""):
@@ -42,7 +42,7 @@ def _args_from_toml(name="pyproject.toml"):
 def infer_version(dist):
 
     try:
-        args = _args_from_toml()
+        config = Configuration.from_file()
     except Exception:
         return trace_exception()
-    dist.metadata.version = get_version(**args)
+    dist.metadata.version = _get_version(config)

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -1,9 +1,8 @@
 from pkg_resources import iter_entry_points
 
 from .version import _warn_if_setuptools_outdated
-from .config import Configuration
 from .utils import do, trace_exception
-from . import get_version, _get_version
+from . import get_version
 
 
 def version_keyword(dist, keyword, value):
@@ -31,9 +30,19 @@ def find_files(path=""):
     return []
 
 
+def _args_from_toml(name="pyproject.toml"):
+    # todo: more sensible config initialization
+    # move this elper back to config and unify it with the code from get_config
+
+    with open(name) as strm:
+        defn = __import__("toml").load(strm)
+    return defn.get("tool", {})["setuptools_scm"]
+
+
 def infer_version(dist):
+
     try:
-        config = Configuration.from_file()
+        args = _args_from_toml()
     except Exception:
         return trace_exception()
-    dist.metadata.version = _get_version(config)
+    dist.metadata.version = get_version(**args)

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -16,6 +16,7 @@ def wd(wd):
 
 
 def test_pyproject_support(tmpdir, monkeypatch):
+    pytest.importorskip("toml")
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     pkg = tmpdir.ensure("package", dir=42)
     pkg.join("pyproject.toml").write(
@@ -28,7 +29,6 @@ fallback_version = "12.34"
     assert res == "12.34"
 
 
-@pytest.mark.xfail(reason="#174")
 def test_pyproject_support_with_git(tmpdir, monkeypatch, wd):
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     pkg = tmpdir.join("wd")


### PR DESCRIPTION
#374 indicates a need for a followup with unifying configuration initialization at the right place,



- [x]  pass configuration data from yaml correctly
- [x] unify configuration initialization at the configuration class
- [x] use configuration directly in the integrations

followup in #393 
- [ ] harden configuration loading/setup for forward/backward compatibility wrt new arguments
- [ ] sort out if/when to unify configuration argument order (by going kw-only)
- [ ] ensure toml is a hard test dependency