### PR TITLE
fix typo README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ To enable version inference, add this section to your pyproject.toml:
 .. code:: ini
 
     # pyproject.toml
-    [tools.setuptools_scm]
+    [tool.setuptools_scm]
 
 Including this section is comparable to supplying
 ``use_scm_version=True`` in ``setup.py``. Additionally,
@@ -60,7 +60,7 @@ to be supplied to ``get_version()``. For example:
 .. code:: ini
 
     # pyproject.toml
-    [tools.setuptools_scm]
+    [tool.setuptools_scm]
     write_to = pkg/version.py
 
 


### PR DESCRIPTION
`tools` is incorrect name of section.

- https://www.python.org/dev/peps/pep-0518/#json-schema
- https://github.com/pypa/setuptools_scm/blob/master/src/setuptools_scm/config.py#L123