### PR TITLE
Fix testing/test_git.py::test_git_archive_export_ignore

### DIFF
--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -10,7 +10,8 @@ from setuptools_scm.file_finder_git import git_find_files
 
 
 @pytest.fixture
-def wd(wd):
+def wd(wd, monkeypatch):
+    monkeypatch.delenv("HOME", raising=False)
     wd("git init")
     wd("git config user.email test@example.com")
     wd('git config user.name "a test"')


### PR DESCRIPTION
Ensure `$HOME` is unset, since otherwise `init.templatedir` might get
picked up from the user's config, which might e.g. not include the
`.git/info` dir then.