### PR TITLE
fix #395: correctly transfer tag regex in the Configuration constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+v3.4.2
+======
+
+* fix #395: correctly transfer tag regex in the Configuration constructor
+
 v3.4.1
 ======
 

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -66,7 +66,7 @@ class Configuration(object):
         self.fallback_version = fallback_version
         self.fallback_root = fallback_root
         self.parse = parse
-        self.tag_regex = DEFAULT_TAG_REGEX
+        self.tag_regex = tag_regex
         self.git_describe_command = git_describe_command
 
     @property

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from setuptools_scm.config import Configuration
-
+import re
 import pytest
 
 
@@ -26,3 +26,9 @@ def test_config_from_pyproject(tmpdir):
     fn = tmpdir / "pyproject.toml"
     fn.write_text("[tool.setuptools_scm]\n", encoding="utf-8")
     assert Configuration.from_file(str(fn))
+
+
+def test_config_regex_init():
+    tag_regex = re.compile(r"v(\d+)")
+    conf = Configuration(tag_regex=tag_regex)
+    assert conf.tag_regex is tag_regex


### PR DESCRIPTION
fixes #395 