### PR TITLE
#Fix 403: Close file descriptor before terminating process

### DIFF
--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -50,6 +50,7 @@ def _git_ls_files_and_dirs(toplevel):
             return _git_interpret_archive(proc.stdout, toplevel)
         finally:
             # ensure we avoid resource warnings by cleaning up the process
+            proc.stdout.close()
             proc.terminate()
     except Exception:
         if proc.wait() != 0:

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -46,6 +46,7 @@ setup(use_scm_version={"root": "../..",
 
 
 @pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/298")
+@pytest.mark.issue(403)
 def test_file_finder_no_history(wd, caplog):
     file_list = git_find_files(str(wd.cwd))
     assert file_list == []


### PR DESCRIPTION
This fix passes the test `test_file_finder_no_history` in `test_git.py` . 