### PR TITLE
no-local-version scheme and improved documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+v3.5.0
+======
+
+* add ``no-local-version`` local scheme and improve documentation for schemes
+
 v3.4.4
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,11 @@ Arguments to ``get_version()`` (see below) may be passed as a dictionary to
     from setuptools import setup
     setup(
         ...,
-        use_scm_version = {"root": "..", "relative_to": __file__},
+        use_scm_version = {
+            "root": "..",
+            "relative_to": __file__,
+            "local_scheme": "node-and-timestamp"
+        },
         setup_requires=['setuptools_scm'],
         ...,
     )
@@ -463,6 +467,7 @@ Version number construction
 
     :guess-next-dev: automatically guesses the next development version (default)
     :post-release: generates post release versions (adds :code:`postN`)
+    :python-simplified-semver: basic semantic versioning similar to ``guess-next-dev``
 
 ``setuptools_scm.local_scheme``
     Configures how the local part of a version is rendered given a
@@ -476,6 +481,8 @@ Version number construction
     :node-and-timestamp: like ``node-and-date`` but with a timestamp of
                          the form ``{:%Y%m%d%H%M%S}`` instead
     :dirty-tag: adds ``+dirty`` if the current workdir has changes
+    :no-local-version: omits local version, useful e.g. because pypi does
+                       not support it
 
 
 Importing in ``setup.py``

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ arguments = dict(
         node-and-timestamp = \
         setuptools_scm.version:get_local_node_and_timestamp
         dirty-tag = setuptools_scm.version:get_local_dirty_tag
+        no-local-version = setuptools_scm.version:get_no_local_node
     """,
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -284,6 +284,10 @@ def get_local_dirty_tag(version):
     return version.format_choice("", "+dirty")
 
 
+def get_no_local_node(_):
+    return ""
+
+
 def postrelease_version(version):
     if version.exact:
         return version.format_with("{tag}")

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -50,9 +50,12 @@ VERSIONS = {
     [
         ("exact", "guess-next-dev node-and-date", "1.1"),
         ("zerodistance", "guess-next-dev node-and-date", "1.2.dev0"),
+        ("zerodistance", "guess-next-dev no-local-version", "1.2.dev0"),
         ("dirty", "guess-next-dev node-and-date", "1.2.dev0+dtime"),
+        ("dirty", "guess-next-dev no-local-version", "1.2.dev0"),
         ("distance", "guess-next-dev node-and-date", "1.2.dev3"),
         ("distancedirty", "guess-next-dev node-and-date", "1.2.dev3+dtime"),
+        ("distancedirty", "guess-next-dev no-local-version", "1.2.dev3"),
         ("exact", "post-release node-and-date", "1.1"),
         ("zerodistance", "post-release node-and-date", "1.1.post0"),
         ("dirty", "post-release node-and-date", "1.1.post0+dtime"),


### PR DESCRIPTION
 * Adds an example for how to use entry point version schemes in a `setup.py` that was sorely missing
 * Documents the existence of the `python-simplified-semver` local version scheme
 * Adds `no-local-version` scheme, which is especially useful because pypi.org does not support local versions in packages
 * Includes tests for the aforementioned new scheme
 * Adds a changelog entry for these changes 