### PR TITLE
Test on Python 3.9-dev to avoid surprises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
-- '3.8-dev'
+- '3.8'
+- '3.9-dev'
 dist: xenial  # needed for 3.7+
 env:
 - TOXENV=py-test
@@ -85,7 +86,10 @@ jobs:
       python: '3.7'
     - <<: *bdist_egg
       name: "python eggs 3.8"
-      python: '3.8-dev'
+      python: '3.8'
+    - <<: *bdist_egg
+      name: "python eggs 3.9"
+      python: '3.9-dev'
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 
 stages:
 - linting

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,34,35,36,37,38}-test,flake8,check_readme,py{27,37}-selfcheck
+envlist=py{27,34,35,36,37,38,39}-test,flake8,check_readme,py{27,37}-selfcheck
 
 [pytest]
 testpaths=testing


### PR DESCRIPTION
And `sudo` is no longer needed on Travis CI: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration