### PR TITLE
Fix documentation for tag_regex and allow single-digit version numbers.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -363,9 +363,9 @@ The currently supported configuration keys are:
     supplying ``__file__``.
 
 :tag_regex:
-    A Python regex string to extract the version part from any SCM tag.
-    The regex needs to contain three named groups prefix, version and suffix,
-    where ``version`` captures the actual version information.
+   A Python regex string to extract the version part from any SCM tag.
+    The regex needs to contain either a single match group, or a group
+    named ``version``, that captures the actual version information.
 
     Defaults to the value of ``setuptools_scm.config.DEFAULT_TAG_REGEX``
     (see `config.py <src/setuptools_scm/config.py>`_).

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -6,7 +6,7 @@ import warnings
 
 from .utils import trace
 
-DEFAULT_TAG_REGEX = r"^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]+)(?:\+.*)?$"
+DEFAULT_TAG_REGEX = r"^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$"
 DEFAULT_VERSION_SCHEME = "guess-next-dev"
 DEFAULT_LOCAL_SCHEME = "node-and-date"
 

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -12,7 +12,7 @@ except ImportError:
     from .win_py31_compat import samefile
 
 
-DEFAULT_DESCRIBE = "git describe --dirty --tags --long --match *.*"
+DEFAULT_DESCRIBE = "git describe --dirty --tags --long --match *[0-9]*"
 
 
 class GitWorkdir(object):

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -11,6 +11,10 @@ import pytest
         ("apache-arrow-0.9.0", "0.9.0"),
         ("arrow-0.9.0", "0.9.0"),
         ("arrow-0.9.0-rc", "0.9.0-rc"),
+        ("arrow-1", "1"),
+        ("arrow-1+", "1"),
+        ("arrow-1+foo", "1"),
+        ("arrow-1.1+foo", "1.1"),
         ("v1.1", "v1.1"),
         ("V1.1", "V1.1"),
     ],
@@ -18,6 +22,7 @@ import pytest
 def test_tag_regex(tag, expected_version):
     config = Configuration()
     match = config.tag_regex.match(tag)
+    assert match
     version = match.group("version")
     assert version == expected_version
 

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -233,6 +233,14 @@ def test_not_matching_tags(wd):
     ).startswith("0.11.2")
 
 
+@pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/411")
+def test_non_dotted_version(wd):
+    wd.commit_testfile()
+    wd("git tag apache-arrow-1")
+    wd.commit_testfile()
+    assert wd.get_version().startswith("2")
+
+
 @pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/381")
 def test_gitdir(monkeypatch, wd):
     """

--- a/testing/test_version.py
+++ b/testing/test_version.py
@@ -53,7 +53,6 @@ def test_next_semver(version, expected_next):
 )
 def test_tag_regex1(tag, expected):
     config = Configuration()
-    config.tag_regex = r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$"
     if "+" in tag:
         # pytest bug wrt cardinality
         with pytest.warns(UserWarning):


### PR DESCRIPTION
This fixes Issue #411, and reduces confusion by matching documentation to code.