### PR TITLE
Extend error message if "unable to detect version"

### DIFF
--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -115,7 +115,10 @@ def _do_parse(config):
         "metadata and will not work.\n\n"
         "For example, if you're using pip, instead of "
         "https://github.com/user/proj/archive/master.zip "
-        "use git+https://github.com/user/proj.git#egg=proj" % config.absolute_root
+        "use git+https://github.com/user/proj.git#egg=proj\n\n"
+        "As an ugly workaround, you can also specifiy the version number "
+        "with the environment variable SETUPTOOLS_SCM_PRETEND_VERSION."
+        % config.absolute_root
     )
 
 


### PR DESCRIPTION
In some cases it's not possible to include the .git subdirectory and the version number doesn't matter. Then, the error message "unable to detect version, make sure your git repository is intact" doesn't help. Add a note on SETUPTOOLS_SCM_PRETEND_VERSION so users spend less time googling for a workaround.

(I do understand that this is not the recommended use-case, but there are situations in which it cannot be avoided without even uglier workarounds.)