### PR TITLE
Skip mercurial tests when hg is not available

### DIFF
--- a/testing/test_file_finder.py
+++ b/testing/test_file_finder.py
@@ -15,7 +15,10 @@ def inwd(request, wd, monkeypatch):
         wd.add_command = "git add ."
         wd.commit_command = "git commit -m test-{reason}"
     elif request.param == "hg":
-        wd("hg init")
+        try:
+            wd("hg init")
+        except FileNotFoundError:
+            pytest.skip("hg executable not found")
         wd.add_command = "hg add ."
         wd.commit_command = 'hg commit -m test-{reason} -u test -d "0 0"'
     (wd.cwd / "file1").touch()

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -2,7 +2,15 @@ from setuptools_scm import format_version
 from setuptools_scm.hg import archival_to_version, parse
 from setuptools_scm import integration
 from setuptools_scm.config import Configuration
+from setuptools_scm.utils import has_command
 import pytest
+import warnings
+
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore")
+    if not has_command("hg"):
+        pytestmark = pytest.mark.skip(reason="hg executable not found")
 
 
 @pytest.fixture


### PR DESCRIPTION
Mercurial is broken (read: crashing with bus error) on SPARC.
Nevertheless, many packages need setuptools_scm even if we never ever
use Mercurial checkouts.  This patch makes it possible to run the test
suite successfully when Mercurial is not available on the system.