### PR TITLE
Use realpath during relpath to avoid cross-volume issues on Windows.

### DIFF
--- a/src/setuptools_scm/file_finder.py
+++ b/src/setuptools_scm/file_finder.py
@@ -50,6 +50,6 @@ def scm_find_files(path, scm_files, scm_dirs):
             # dirpath + filename with symlinks preserved
             fullfilename = os.path.join(dirpath, filename)
             if os.path.normcase(os.path.realpath(fullfilename)) in scm_files:
-                res.append(os.path.join(path, os.path.relpath(fullfilename, path)))
+                res.append(os.path.join(path, os.path.relpath(fullfilename, realpath)))
         seen.add(realdirpath)
     return res


### PR DESCRIPTION
Fixes #436.

I haven't added any tests, and I'd really rather not.