### PR TITLE
Add release-branch-semver to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ setuptools_scm.version_scheme =
     guess-next-dev = setuptools_scm.version:guess_next_dev_version
     post-release = setuptools_scm.version:postrelease_version
     python-simplified-semver = setuptools_scm.version:simplified_semver_version
+    release-branch-semver = setuptools_scm.version:release_branch_semver_version
 
 setuptools_scm.local_scheme =
     node-and-date = setuptools_scm.version:get_local_node_and_date

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -267,7 +267,7 @@ def simplified_semver_version(version):
             )
 
 
-def release_branch_semver(version):
+def release_branch_semver_version(version):
     if version.exact:
         return version.format_with("{tag}")
     if version.branch is not None:

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -286,6 +286,16 @@ def release_branch_semver_version(version):
     return version.format_next_version(guess_next_simple_semver, retain=SEMVER_MINOR)
 
 
+def release_branch_semver(version):
+    warnings.warn(
+        "release_branch_semver is deprecated and will be removed in future. "
+        + "Use release_branch_semver_version instead",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return release_branch_semver_version(version)
+
+
 def _format_local_with_time(version, time_format):
 
     if version.exact or version.node is None:

--- a/testing/test_version.py
+++ b/testing/test_version.py
@@ -3,7 +3,7 @@ from setuptools_scm.config import Configuration
 from setuptools_scm.version import (
     meta,
     simplified_semver_version,
-    release_branch_semver,
+    release_branch_semver_version,
     tags_to_versions,
 )
 
@@ -80,7 +80,7 @@ def test_next_semver(version, expected_next):
     ],
 )
 def test_next_release_branch_semver(version, expected_next):
-    computed = release_branch_semver(version)
+    computed = release_branch_semver_version(version)
     assert computed == expected_next
 
 


### PR DESCRIPTION
the release-branch-semver scheme doesn't seem to have survived the transition from `setup.py` to `setup.cfg`.
 
This adds it back in.
Also, I renamed the internal function to `release_branch_semver_version`, for consistency with the other functions for versions schemes.