### PR TITLE
Add universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,3 +80,7 @@ setuptools_scm.local_scheme =
     node-and-timestamp = setuptools_scm.version:get_local_node_and_timestamp
     dirty-tag = setuptools_scm.version:get_local_dirty_tag
     no-local-version = setuptools_scm.version:get_no_local_node
+
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
See #442

It would be best to rebuild the 4.0.0 wheel locally with the `--universal` flag and upload that; it will have a different name than the 3-only wheel that is there now, and that way users will not have to explicitly avoid 4.0.0 when building.