### PR TITLE
honour SOURCE_DATE_EPOCH environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -440,6 +440,12 @@ Environment variables
     a lot of debug information will be printed as part of ``setuptools_scm``
     operating
 
+:SOURCE_DATE_EPOCH:
+    when defined, used as the timestamp from which the
+    ``node-and-date`` and ``node-and-timestamp`` local parts are
+    derived, otherwise the current time is used
+    (https://reproducible-builds.org/docs/source-date-epoch/)
+
 Extending setuptools_scm
 ------------------------
 

--- a/src/setuptools_scm/utils.py
+++ b/src/setuptools_scm/utils.py
@@ -11,7 +11,6 @@ import os
 import io
 import platform
 import traceback
-import datetime
 
 
 DEBUG = bool(os.environ.get("SETUPTOOLS_SCM_DEBUG"))
@@ -119,22 +118,6 @@ def data_from_mime(path):
     data = dict(x.split(": ", 1) for x in content.splitlines() if ": " in x)
     trace("data", data)
     return data
-
-
-class UTC(datetime.tzinfo):
-    _ZERO = datetime.timedelta(0)
-
-    def utcoffset(self, dt):
-        return self._ZERO
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return self._ZERO
-
-
-utc = UTC()
 
 
 def function_has_arg(fn, argname):

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 import datetime
 import warnings
 import re
+import time
+import os
 
 from .config import Configuration
 from .utils import trace, string_types, utc
@@ -136,7 +138,9 @@ class ScmVersion(object):
             distance = 0
         self.distance = distance
         self.node = node
-        self.time = datetime.datetime.now(utc)
+        self.time = datetime.datetime.utcfromtimestamp(
+            int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+        )
         self._extra = kw
         self.dirty = dirty
         self.preformatted = preformatted

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -6,7 +6,7 @@ import time
 import os
 
 from .config import Configuration
-from .utils import trace, string_types, utc
+from .utils import trace, string_types
 
 from pkg_resources import iter_entry_points
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -3,6 +3,8 @@ import itertools
 import pytest
 import six
 
+# 2009-02-13T23:31:30+00:00
+os.environ["SOURCE_DATE_EPOCH"] = "1234567890"
 os.environ["SETUPTOOLS_SCM_DEBUG"] = "1"
 VERSION_PKGS = ["setuptools", "setuptools_scm"]
 

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -15,11 +15,6 @@ from setuptools_scm.utils import has_command
 PY3 = sys.version_info > (2,)
 
 
-class MockTime(object):
-    def __format__(self, *k):
-        return "time"
-
-
 @pytest.mark.parametrize(
     "tag, expected",
     [
@@ -51,21 +46,20 @@ VERSIONS = {
         ("exact", "guess-next-dev node-and-date", "1.1"),
         ("zerodistance", "guess-next-dev node-and-date", "1.2.dev0"),
         ("zerodistance", "guess-next-dev no-local-version", "1.2.dev0"),
-        ("dirty", "guess-next-dev node-and-date", "1.2.dev0+dtime"),
+        ("dirty", "guess-next-dev node-and-date", "1.2.dev0+d20090213"),
         ("dirty", "guess-next-dev no-local-version", "1.2.dev0"),
         ("distance", "guess-next-dev node-and-date", "1.2.dev3"),
-        ("distancedirty", "guess-next-dev node-and-date", "1.2.dev3+dtime"),
+        ("distancedirty", "guess-next-dev node-and-date", "1.2.dev3+d20090213"),
         ("distancedirty", "guess-next-dev no-local-version", "1.2.dev3"),
         ("exact", "post-release node-and-date", "1.1"),
         ("zerodistance", "post-release node-and-date", "1.1.post0"),
-        ("dirty", "post-release node-and-date", "1.1.post0+dtime"),
+        ("dirty", "post-release node-and-date", "1.1.post0+d20090213"),
         ("distance", "post-release node-and-date", "1.1.post3"),
-        ("distancedirty", "post-release node-and-date", "1.1.post3+dtime"),
+        ("distancedirty", "post-release node-and-date", "1.1.post3+d20090213"),
     ],
 )
-def test_format_version(version, monkeypatch, scheme, expected):
+def test_format_version(version, scheme, expected):
     version = VERSIONS[version]
-    monkeypatch.setattr(version, "time", MockTime())
     vs, ls = scheme.split()
     assert format_version(version, version_scheme=vs, local_scheme=ls) == expected
 

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -121,15 +121,21 @@ def test_git_worktree(wd):
 
 
 @pytest.mark.issue(86)
-def test_git_dirty_notag(wd):
+@pytest.mark.parametrize("today", [False, True])
+def test_git_dirty_notag(today, wd, monkeypatch):
+    if today:
+        monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
     wd.commit_testfile()
     wd.write("test.txt", "test2")
     wd("git add test.txt")
     assert wd.version.startswith("0.1.dev1")
-    # the date on the tag is in UTC
-    today = datetime.utcnow().date()
+    if today:
+        # the date on the tag is in UTC
+        tag = datetime.utcnow().date().strftime(".d%Y%m%d")
+    else:
+        tag = ".d20090213"
     # we are dirty, check for the tag
-    assert today.strftime(".d%Y%m%d") in wd.version
+    assert tag in wd.version
 
 
 @pytest.mark.issue(193)


### PR DESCRIPTION
In the interest of producing more reproducible builds, honour SOURCE_DATE_EPOCH if set.
