### PR TITLE
Add `no-guess-dev` implementation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+v4.2.0
+======
+
+* Add `no-guess-dev` which does no next version guessing, just adds `.post1.devN` in
+  case there are new commits after the tag
+
 v4.1.2
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -497,6 +497,7 @@ Version number construction
         that matches the most recent tag up to the minor segment. Otherwise if on a
         non-release branch, increments the minor segment and sets the micro segment to
         zero, then appends :code:`.devN`.
+    :no-guess-dev: Does no next version guessing, just adds :code:`.post1.devN`
 
 ``setuptools_scm.local_scheme``
     Configures how the local part of a version is rendered given a

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ setuptools_scm.version_scheme =
     post-release = setuptools_scm.version:postrelease_version
     python-simplified-semver = setuptools_scm.version:simplified_semver_version
     release-branch-semver = setuptools_scm.version:release_branch_semver_version
+    no-guess-dev = setuptools_scm.version:no_guess_dev_version
 
 setuptools_scm.local_scheme =
     node-and-date = setuptools_scm.version:get_local_node_and_date

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -300,6 +300,13 @@ def release_branch_semver(version):
     return release_branch_semver_version(version)
 
 
+def no_guess_dev_version(version):
+    if version.exact:
+        return version.format_with("{tag}")
+    else:
+        return version.format_with("{tag}.post1.dev{distance}")
+
+
 def _format_local_with_time(version, time_format):
 
     if version.exact or version.node is None:

--- a/testing/test_version.py
+++ b/testing/test_version.py
@@ -5,6 +5,7 @@ from setuptools_scm.version import (
     simplified_semver_version,
     release_branch_semver_version,
     tags_to_versions,
+    no_guess_dev_version,
 )
 
 
@@ -81,6 +82,31 @@ def test_next_semver(version, expected_next):
 )
 def test_next_release_branch_semver(version, expected_next):
     computed = release_branch_semver_version(version)
+    assert computed == expected_next
+
+
+@pytest.mark.parametrize(
+    "version, expected_next",
+    [
+        pytest.param(
+            meta("1.0.0", distance=2, branch="default", config=c),
+            "1.0.0.post1.dev2",
+            id="dev_distance",
+        ),
+        pytest.param(
+            meta("1.0", distance=2, branch="default", config=c),
+            "1.0.post1.dev2",
+            id="dev_distance_short_tag",
+        ),
+        pytest.param(
+            meta("1.0.0", distance=None, branch="default", config=c),
+            "1.0.0",
+            id="no_dev_distance",
+        ),
+    ],
+)
+def test_no_guess_version(version, expected_next):
+    computed = no_guess_dev_version(version)
     assert computed == expected_next
 
 


### PR DESCRIPTION
The `no-guess-dev` implementation does no next version guessing, it just
adds `.devN` in case there are new commits after the tag.