### PR TITLE
importlib.metadata/pkg_resources docs clarifications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ Retrieving package version at runtime
 
 If you have opted not to hardcode the version number inside the package,
 you can retrieve it at runtime from PEP-0566_ metadata using
-``importlib.metadata`` from the standard library
+``importlib.metadata`` from the standard library (added in Python 3.8)
 or the `importlib_metadata`_ backport:
 
 .. code:: python
@@ -195,7 +195,7 @@ or the `importlib_metadata`_ backport:
     from importlib.metadata import version, PackageNotFoundError
 
     try:
-        __version__ = version(__name__)
+        __version__ = version("package-name")
     except PackageNotFoundError:
         # package is not installed
        pass
@@ -208,7 +208,7 @@ Alternatively, you can use ``pkg_resources`` which is included in
    from pkg_resources import get_distribution, DistributionNotFound
 
    try:
-       __version__ = get_distribution(__name__).version
+       __version__ = get_distribution("package-name").version
    except DistributionNotFound:
         # package is not installed
        pass


### PR DESCRIPTION
A few weeks ago, I got temporarily hung up on the `__name__` in the `README.rst`.  I wrote it down to try and ameliorate this for future users of `setuptools_scm`, which is an awesome library.

I was not previously familiar with the `importlib.metadata.version` and/or `pkg_resources.get_distribution` APIs, and didn't realize they just took a `str` input corresponding with the package name.

The code samples provided in the `README.rst` indicate they take a `__name__`.  I thought the samples were referring to the actual Python special `__name__` variable, not just the package name.

This PR makes two changes within the `README.rst`:
- Replaces `__name__` with a self-descriptive `"package-name"` in the code samples
- Specifies when `importlib.metadata` was added to the standard library, so users don't have to search that as well
