### PR TITLE
Updated PY env var creation for GitHub pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
     - name: set PY
-      run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
+      run: echo "PY=$(python --version --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pre-commit

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
           architecture: x64
       - name: Set up Python ${{ matrix.python_version }} (deadsnakes)
-        uses: deadsnakes/action@v1.0.0
+        uses: deadsnakes/action@v2.0.1
         if: matrix.python_version == '3.9-dev'
         with:
           python-version: ${{ matrix.python_version }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -83,7 +83,7 @@ jobs:
         python-version: ${{ matrix.python_version }}
         architecture: x64
     - name: Set up Python ${{ matrix.python_version }} (deadsnakes)
-      uses: deadsnakes/action@v1.0.0
+      uses: deadsnakes/action@v2.0.1
       if: matrix.python_version == '3.9-dev'
       with:
         python-version: ${{ matrix.python_version }}


### PR DESCRIPTION
**Motivation**

After opening https://github.com/pypa/setuptools_scm/pull/490, I was hit with an error during `pre-commit`:

```
Run echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
Error: Unable to process command '::set-env name=PY::5d9d6b1c54447c4a022e02b86cba41e329f085f2e7cd25be9c83b3c23bd75291' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

I took a look at another open PR (https://github.com/pypa/setuptools_scm/pull/484 from a month ago), and saw this used to be just a warning:

```
Run echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

---

**Contents**

Reading in the [error message's provided article here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files), I found the solution.

The fix was just changing the way the environment variable gets populated.  I implemented the suggestion into `pre-commit.yml` in this PR.