### PR TITLE
Add configuration options to customize version and local scheme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -336,9 +336,15 @@ The currently supported configuration keys are:
     Configures how the local version number is constructed; either an
     entrypoint name or a callable.
 
+:custom_version_scheme:
+    Overrides format strings for the local version number; a dictionary.
+
 :local_scheme:
     Configures how the local component of the version is constructed; either an
     entrypoint name or a callable.
+
+:custom_local_scheme:
+    Overrides format strings for the local component of the version; a dictionary.
 
 :write_to:
     A path to a file that gets replaced with a file containing the current
@@ -515,6 +521,19 @@ Version number construction
     :dirty-tag: adds ``+dirty`` if the current workdir has changes
     :no-local-version: omits local version, useful e.g. because pypi does
                        not support it
+
+``setuptools_scm.custom_version_scheme``, ``setuptools_scm.custom_local_scheme``
+    Provides a greater degree of control over how the version number is rendered.
+    A dictionary specifying format strings that override the behavior of
+    ``setuptools_scm.version_scheme`` and ``setuptools_scm.local_scheme``,
+    correspondingly, in various conditions.
+
+    Recognized keys:
+
+    :clean_tag: format for zero distance to a tag and clean workdir
+    :dirty_tag: format for zero distance to a tag and dirty workdir
+    :clean_dev: format for non-zero distance to a tag and clean workdir
+    :dirty_dev: format for non-zero distance to a tag and dirty workdir
 
 
 Importing in ``setup.py``

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -134,7 +134,9 @@ def _do_parse(config):
 def get_version(
     root=".",
     version_scheme=DEFAULT_VERSION_SCHEME,
+    custom_version_scheme=None,
     local_scheme=DEFAULT_LOCAL_SCHEME,
+    custom_local_scheme=None,
     write_to=None,
     write_to_template=None,
     relative_to=None,
@@ -163,7 +165,9 @@ def _get_version(config):
         version_string = format_version(
             parsed_version,
             version_scheme=config.version_scheme,
+            custom_version_scheme=config.custom_version_scheme,
             local_scheme=config.local_scheme,
+            custom_local_scheme=config.custom_local_scheme,
         )
         dump_version(
             root=config.root,

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -45,7 +45,9 @@ class Configuration(object):
         relative_to=None,
         root=".",
         version_scheme=DEFAULT_VERSION_SCHEME,
+        custom_version_scheme=None,
         local_scheme=DEFAULT_LOCAL_SCHEME,
+        custom_local_scheme=None,
         write_to=None,
         write_to_template=None,
         tag_regex=DEFAULT_TAG_REGEX,
@@ -61,7 +63,9 @@ class Configuration(object):
 
         self.root = root
         self.version_scheme = version_scheme
+        self.custom_version_scheme = custom_version_scheme
         self.local_scheme = local_scheme
+        self.custom_local_scheme = custom_local_scheme
         self.write_to = write_to
         self.write_to_template = write_to_template
         self.parentdir_prefix_version = parentdir_prefix_version

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -357,4 +357,4 @@ def format_version(version, **config):
     trace("version", main_version)
     local_version = local_scheme(version)
     trace("local_version", local_version)
-    return version_scheme(version) + local_scheme(version)
+    return main_version + local_version

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -61,7 +61,58 @@ VERSIONS = {
 def test_format_version(version, scheme, expected):
     version = VERSIONS[version]
     vs, ls = scheme.split()
-    assert format_version(version, version_scheme=vs, local_scheme=ls) == expected
+    assert (
+        format_version(
+            version,
+            version_scheme=vs,
+            custom_version_scheme=None,
+            local_scheme=ls,
+            custom_local_scheme=None,
+        )
+        == expected
+    )
+
+
+CUSTOM_SCHEMES = {
+    "full": {
+        "clean_dev": "<clean_dev>",
+        "dirty_dev": "<dirty_dev>",
+        "clean_tag": "<clean_tag>",
+        "dirty_tag": "<dirty_tag>",
+    },
+    "dirty": {"dirty_dev": "<dirty_dev>", "dirty_tag": "<dirty_tag>"},
+    "clean": {"clean_dev": "<clean_dev>", "clean_tag": "<clean_tag>"},
+}
+
+
+@pytest.mark.parametrize(
+    "version,scheme,expected",
+    [
+        ("exact", "full full", "<clean_tag><clean_tag>"),
+        ("zerodistance", "full full", "<clean_tag><clean_tag>"),
+        ("dirty", "full full", "<dirty_tag><dirty_tag>"),
+        ("distance", "full full", "<clean_dev><clean_dev>"),
+        ("distancedirty", "full full", "<dirty_dev><dirty_dev>"),
+        ("exact", "dirty full", "1.1<clean_tag>"),
+        ("zerodistance", "dirty full", "1.2.dev0<clean_tag>"),
+        ("dirty", "dirty clean", "<dirty_tag>+d20090213"),
+        ("distance", "dirty clean", "1.2.dev3<clean_dev>"),
+        ("distancedirty", "full clean", "<dirty_dev>+d20090213"),
+    ],
+)
+def test_custom_format_version(version, scheme, expected):
+    version = VERSIONS[version]
+    vs, ls = scheme.split()
+    assert (
+        format_version(
+            version,
+            version_scheme="guess-next-dev",
+            custom_version_scheme=CUSTOM_SCHEMES[vs],
+            local_scheme="node-and-date",
+            custom_local_scheme=CUSTOM_SCHEMES[ls],
+        )
+        == expected
+    )
 
 
 def test_dump_version_doesnt_bail_on_value_error(tmpdir):

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -40,7 +40,11 @@ def test_archival_to_version(expected, data):
     version = archival_to_version(data, config=config)
     assert (
         format_version(
-            version, version_scheme="guess-next-dev", local_scheme="node-and-date"
+            version,
+            version_scheme="guess-next-dev",
+            custom_version_scheme=None,
+            local_scheme="node-and-date",
+            custom_local_scheme=None,
         )
         == expected
     )


### PR DESCRIPTION
Fixes #419.

## Motivation

Let me start by saying that setuptools_scm is one of my favorite Python packages ever! :) Not only it is robust when used as intended, but it can also be stretched very far with minimal effort and support even very strange configurations--for example several of my projects actually compose the wheel version from several git repositories at once.

Most of this flexibility however requires executable code, and the trend lately is towards declarative configuration. Unfortunately, it turns out that every single one of my projects that uses setuptools_scm tweaks its schemes with Python code, which is at odds with the ecosystem.

Fortunately, I think I managed to pin down a fairly elegant way to solve the entire class of "setuptools_scm's output is almost but not quite right" problem.

## Background

This PR actually has a third iteration of this feature. I started out by adding a new kind of schemes, `custom`, which would then always format the version using the custom scheme dictionary and only that. However, the code was very hacky (the existing entry points do not accept additional configuration), the interface was not very convenient (having an empty format string as a default, having a reimplementation of the default scheme as a default, and blowing up without all four keys are all annoying), and ultimately that entire approach was inferior because is mutually exclusive with guessing the next version.

I briefly considered having two conditions (`exact` and `inexact`) for the version scheme, unlike the local scheme, but that was a bad idea for similar reasons.

Overriding the base scheme in fine grained conditions for both versions and local parts seems like the right choice to me here.

## Results

 * I think it's a good sign that all of the built-in schemes except for version guessing ones are representable as custom schemes.
 * I like [this commit](https://github.com/nmigen/nmigen/commit/0892894da3a6c2791bfb70730596a0183f85f1a9).
 * I think it's useful that `guess-next-dev` can be stopped from increasing the minor version when it runs on a dirty worktree with zero distance to a tag with just `"custom_version_scheme": {"dirty_tag": "{tag}"}`. (Why does it do that? That seems really inconvenient for testing out local changes to a checkout of a released package.)

## Unresolved questions

 * Naming?
 * How does `exact` differ from `zerodistance`? It seems like the difference is intentional but I couldn't figure out in what situation would one ever get `zerodistance` instead of `exact`.