### PR TITLE
Require setuptools >=42 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=34.4", "wheel"]
+requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I noticed that ``test_pyproject_support`` and ``test_pyproject_support_with_git`` are broken with setuptools 41.6 on Fedora 32. Tests and feature are working correctly with setuptools 42 and newer. ``tox.ini`` already requires setuptools >= 42.