### PR TITLE
DOC Mention slow import times for pkg_resources 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,8 @@ Alternatively, you can use ``pkg_resources`` which is included in
         # package is not installed
        pass
 
-This does place a runtime dependency on ``setuptools``.
+However, this does place a runtime dependency on ``setuptools`` and can add up to
+a few 100ms overhead for the package import time.
 
 .. _PEP-0566: https://www.python.org/dev/peps/pep-0566/
 .. _importlib_metadata: https://pypi.org/project/importlib-metadata/


### PR DESCRIPTION
For retrieving the package version at runtime, the readme makes it sound as though `importlib_metadata` and `pkg_resources` are equivalent. Setuptools is almost always installed, so it's not that different from being in stdlib.

pkg_resources is however fairly slow to import https://github.com/pypa/setuptools/issues/926 and should not be recommended for this use case. This adds a note about pkg_resources import times.