### PR TITLE
Use show prefix instead of show toplevel for finding

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,13 +23,15 @@ jobs:
         include:
         - os: ubuntu-latest
           python_version: '3.9-dev'
+        - os: windows-latest
+          python_version: 'msys2'
 
     name: ${{ matrix.os }} - Python ${{ matrix.python_version }}
     steps:
       - uses: actions/checkout@v1
       - name: Setup python
         uses: actions/setup-python@v2
-        if: matrix.python_version != '3.9-dev'
+        if: matrix.python_version != '3.9-dev' || matrix.python_version != 'msys2'
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64
@@ -39,7 +41,15 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        if: matrix.python_version == 'msys2'
+        with:
+          msystem: MINGW64
+          install: git mingw-w64-x86_64-python mingw-w64-x86_64-python-setuptools
+          update: true
       - run: pip install -U setuptools
+        if: matrix.python_version != 'msys2'
       - run: pip install -e .[toml] pytest
       - run: pytest
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Setup python
         uses: actions/setup-python@v2
-        if: matrix.python_version != '3.9-dev' || matrix.python_version != 'msys2'
+        if: matrix.python_version != '3.9-dev' && matrix.python_version != 'msys2'
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -19,7 +19,7 @@ def _git_toplevel(path):
                 universal_newlines=True,
                 stderr=devnull,
             )
-        out = out.strip()[:-1] #remove the trailing pathsep
+        out = out.strip()[:-1]  # remove the trailing pathsep
         if not out:
             out = cwd
         else:
@@ -27,7 +27,7 @@ def _git_toplevel(path):
             # ``cwd`` is absolute path to current working directory.
             # the below method removes the length of ``out`` from
             # ``cwd``, which gives the git toplevel
-            out = cwd[:len(cwd)-len(out)-1]
+            out = cwd[: len(cwd) - len(out) - 1]
         trace("find files toplevel", out)
         return os.path.normcase(os.path.realpath(out.strip()))
     except subprocess.CalledProcessError:

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -29,7 +29,8 @@ def _git_toplevel(path):
             # ``cwd``, which gives the git toplevel
             assert cwd.replace("\\", "/").endswith(out)
             # In windows cwd contains ``\`` which should be replaced by ``/``
-            # for this assertion to work.
+            # for this assertion to work. Length of string isn't changed by replace
+            # ``\\`` is just and escape for `\`
             out = cwd[: -len(out)]
         trace("find files toplevel", out)
         return os.path.normcase(os.path.realpath(out.strip()))

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -19,25 +19,15 @@ def _git_toplevel(path):
                 universal_newlines=True,
                 stderr=devnull,
             )
-        out = out.strip()
+        out = out.strip()[:-1] #remove the trailing pathsep
         if not out:
             out = cwd
         else:
-            cwd_parents = []
-            out_parents = ["."]
-            while True:
-                if os.path.abspath(os.path.join(cwd, os.pardir)) != cwd:
-                    cwd = os.path.abspath(os.path.join(cwd, os.pardir))
-                    cwd_parents.append(cwd)
-                else:
-                    break
-            while True:
-                if os.path.basename(out) != "":
-                    out = os.path.join(out, os.pardir)
-                    out_parents.append(out)
-                else:
-                    break
-            out = str(cwd_parents[len(out_parents) - 1])
+            # Here, ``out`` is a relative path to root of git.
+            # ``cwd`` is absolute path to current working directory.
+            # the below method removes the length of ``out`` from
+            # ``cwd``, which gives the git toplevel
+            out = cwd[:len(cwd)-len(out)-1]
         trace("find files toplevel", out)
         return os.path.normcase(os.path.realpath(out.strip()))
     except subprocess.CalledProcessError:

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -27,7 +27,7 @@ def _git_toplevel(path):
             # ``cwd`` is absolute path to current working directory.
             # the below method removes the length of ``out`` from
             # ``cwd``, which gives the git toplevel
-            assert cwd[len(cwd) - len(out) :].replace("\\", "/") == out
+            assert cwd.replace("\\", "/").endswith(out)
             # In windows cwd contains ``\`` which should be replaced by ``/``
             # for this assertion to work.
             out = cwd[: len(cwd) - len(out) - 1]

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -37,8 +37,6 @@ def _git_toplevel(path):
                     out_parents.append(out)
                 else:
                     break
-            print(cwd_parents)
-            print(out_parents)
             out = str(cwd_parents[len(out_parents) - 1])
         trace("find files toplevel", out)
         return os.path.normcase(os.path.realpath(out.strip()))

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -30,7 +30,7 @@ def _git_toplevel(path):
             assert cwd.replace("\\", "/").endswith(out)
             # In windows cwd contains ``\`` which should be replaced by ``/``
             # for this assertion to work.
-            out = cwd[: len(cwd) - len(out) - 1]
+            out = cwd[: -len(out)]
         trace("find files toplevel", out)
         return os.path.normcase(os.path.realpath(out.strip()))
     except subprocess.CalledProcessError:

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -27,7 +27,7 @@ def _git_toplevel(path):
             # ``cwd`` is absolute path to current working directory.
             # the below method removes the length of ``out`` from
             # ``cwd``, which gives the git toplevel
-            assert cwd[len(cwd) - len(out):].replace('\\','/') == out
+            assert cwd[len(cwd) - len(out) :].replace("\\", "/") == out
             # In windows cwd contains ``\`` which should be replaced by ``/``
             # for this assertion to work.
             out = cwd[: len(cwd) - len(out) - 1]

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -27,6 +27,9 @@ def _git_toplevel(path):
             # ``cwd`` is absolute path to current working directory.
             # the below method removes the length of ``out`` from
             # ``cwd``, which gives the git toplevel
+            assert cwd[len(cwd) - len(out):].replace('\\','/') == out
+            # In windows cwd contains ``\`` which should be replaced by ``/``
+            # for this assertion to work.
             out = cwd[: len(cwd) - len(out) - 1]
         trace("find files toplevel", out)
         return os.path.normcase(os.path.realpath(out.strip()))

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -37,7 +37,8 @@ class GitWorkdir(object):
         else:
             assert wd.replace("\\", "/").endswith(real_wd)
             # In windows wd contains ``\`` which should be replaced by ``/``
-            # for this assertion to work.
+            # for this assertion to work.  Length of string isn't changed by replace
+            # ``\\`` is just and escape for `\`
             real_wd = wd[: -len(real_wd)]
         trace("real root", real_wd)
         if not samefile(real_wd, wd):

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -29,26 +29,13 @@ class GitWorkdir(object):
     def from_potential_worktree(cls, wd):
         wd = os.path.abspath(wd)
         real_wd, _, ret = do_ex("git rev-parse --show-prefix", wd)
+        real_wd = real_wd[:-1] #remove the trailing pathsep
         if ret:
             return
         if not real_wd:
             real_wd = wd
         else:
-            wd_parents = []
-            real_wd_parents = ["."]
-            while True:
-                if os.path.abspath(os.path.join(wd, os.pardir)) != wd:
-                    wd = os.path.abspath(os.path.join(wd, os.pardir))
-                    wd_parents.append(wd)
-                else:
-                    break
-            while True:
-                if os.path.basename(real_wd) != "":
-                    real_wd = os.path.join(real_wd, os.pardir)
-                    real_wd_parents.append(real_wd)
-                else:
-                    break
-            real_wd = str(wd_parents[len(real_wd_parents) - 1])
+            real_wd = wd[:len(wd)-len(real_wd)-1]
         trace("real root", real_wd)
         if not samefile(real_wd, wd):
             return

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -35,7 +35,7 @@ class GitWorkdir(object):
         if not real_wd:
             real_wd = wd
         else:
-            assert wd[len(wd) - len(real_wd) :].replace("\\", "/") == real_wd
+            assert wd.replace("\\", "/").endswith(real_wd)
             # In windows wd contains ``\`` which should be replaced by ``/``
             # for this assertion to work.
             real_wd = wd[: len(wd) - len(real_wd) - 1]

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -35,6 +35,9 @@ class GitWorkdir(object):
         if not real_wd:
             real_wd = wd
         else:
+            assert wd[len(wd) - len(real_wd):].replace('\\','/') == real_wd
+            # In windows wd contains ``\`` which should be replaced by ``/``
+            # for this assertion to work.
             real_wd = wd[: len(wd) - len(real_wd) - 1]
         trace("real root", real_wd)
         if not samefile(real_wd, wd):

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -38,7 +38,7 @@ class GitWorkdir(object):
             assert wd.replace("\\", "/").endswith(real_wd)
             # In windows wd contains ``\`` which should be replaced by ``/``
             # for this assertion to work.
-            real_wd = wd[: len(wd) - len(real_wd) - 1]
+            real_wd = wd[: -len(real_wd)]
         trace("real root", real_wd)
         if not samefile(real_wd, wd):
             return

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -35,7 +35,7 @@ class GitWorkdir(object):
         if not real_wd:
             real_wd = wd
         else:
-            assert wd[len(wd) - len(real_wd):].replace('\\','/') == real_wd
+            assert wd[len(wd) - len(real_wd) :].replace("\\", "/") == real_wd
             # In windows wd contains ``\`` which should be replaced by ``/``
             # for this assertion to work.
             real_wd = wd[: len(wd) - len(real_wd) - 1]

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -29,13 +29,13 @@ class GitWorkdir(object):
     def from_potential_worktree(cls, wd):
         wd = os.path.abspath(wd)
         real_wd, _, ret = do_ex("git rev-parse --show-prefix", wd)
-        real_wd = real_wd[:-1] #remove the trailing pathsep
+        real_wd = real_wd[:-1]  # remove the trailing pathsep
         if ret:
             return
         if not real_wd:
             real_wd = wd
         else:
-            real_wd = wd[:len(wd)-len(real_wd)-1]
+            real_wd = wd[: len(wd) - len(real_wd) - 1]
         trace("real root", real_wd)
         if not samefile(real_wd, wd):
             return


### PR DESCRIPTION
This should fix Cygwin type git which will return POSIX path
when `git rev-parse --show-toplevel` is called which isn't parsed
properly. This call `git rev-parse --show-prefix` which return
relative paths which is later parsed.

Fixes https://github.com/pypa/setuptools_scm/issues/415

This idea came from a patch in msys2, https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python-setuptools-scm/0001-git-Use-show-prefix-instead-of-show-toplevel-for-fin.patch, and ported to python2.