### PR TITLE
Multi version scheme

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ v6.0.0
 * drop dead python support >3.6 required
 * drop dead setuptools support > 45 required (can install wheels)
 * drop egg building (use wheels)
-
+* add git node_date metadata to get the commit time-stamp of HEAD
+* allow version schemes to be priority ordered lists of version schemes
 
 v5.0.2
 ======

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -1,7 +1,7 @@
 from .config import Configuration
 from .utils import do_ex, trace, require_command
 from .version import meta
-
+from datetime import datetime, date
 import os
 from os.path import isfile, join
 import warnings
@@ -53,6 +53,15 @@ class GitWorkdir(object):
             trace("branch err", branch, err, ret)
             return
         return branch
+
+    def get_head_date(self):
+        timestamp, err, ret = self.do_ex("git log -n 1 HEAD --format=%cI")
+        if ret:
+            trace("branch err", timestamp, err, ret)
+            return
+        # TODO, when dropping python3.6 use fromiso
+        date_part = timestamp.split("T")[0]
+        return datetime.strptime(date_part, r"%Y-%m-%d").date()
 
     def is_shallow(self):
         return isfile(join(self.path, ".git/shallow"))
@@ -112,6 +121,8 @@ def parse(
         describe_command = config.git_describe_command
 
     out, unused_err, ret = wd.do_ex(describe_command)
+    node_date = wd.get_head_date() or date.today()
+
     if ret:
         # If 'git git_describe_command' failed, try to get the information otherwise.
         branch, branch_err, branch_ret = wd.do_ex("git symbolic-ref --short HEAD")
@@ -123,7 +134,14 @@ def parse(
         dirty = wd.is_dirty()
 
         if rev_node is None:
-            return meta("0.0", distance=0, dirty=dirty, branch=branch, config=config)
+            return meta(
+                "0.0",
+                distance=0,
+                node_date=node_date,
+                dirty=dirty,
+                branch=branch,
+                config=config,
+            )
 
         return meta(
             "0.0",
@@ -131,6 +149,7 @@ def parse(
             node="g" + rev_node,
             dirty=dirty,
             branch=wd.get_branch(),
+            node_date=node_date,
             config=config,
         )
     else:
@@ -145,9 +164,17 @@ def parse(
                 node=node,
                 dirty=dirty,
                 branch=branch,
+                node_date=node_date,
             )
         else:
-            return meta(tag, config=config, node=node, dirty=dirty, branch=branch)
+            return meta(
+                tag,
+                config=config,
+                node=node,
+                node_date=node_date,
+                dirty=dirty,
+                branch=branch,
+            )
 
 
 def _git_parse_describe(describe_output):

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -344,19 +344,47 @@ def postrelease_version(version):
         return version.format_with("{tag}.post{distance}")
 
 
+def _get_ep(group, name):
+    for ep in iter_entry_points(group, name):
+        trace("ep found:", ep.name)
+        return ep.load()
+
+
+def _iter_version_schemes(entrypoint, scheme_value, _memo=None):
+    if _memo is None:
+        _memo = set()
+    if isinstance(scheme_value, str):
+        scheme_value = _get_ep(entrypoint, scheme_value)
+
+    if isinstance(scheme_value, (list, tuple)):
+        for variant in scheme_value:
+            if variant not in _memo:
+                _memo.add(variant)
+                yield from _iter_version_schemes(entrypoint, variant, _memo=_memo)
+    elif callable(scheme_value):
+        yield scheme_value
+
+
+def _call_version_scheme(version, entypoint, given_value, default):
+    for scheme in _iter_version_schemes(entypoint, given_value):
+        result = scheme(version)
+        if result is not None:
+            return result
+    return default
+
+
 def format_version(version, **config):
     trace("scm version", version)
     trace("config", config)
     if version.preformatted:
         return version.tag
-    version_scheme = callable_or_entrypoint(
-        "setuptools_scm.version_scheme", config["version_scheme"]
+    main_version = _call_version_scheme(
+        version, "setuptools_scm.version_scheme", config["version_scheme"], None
     )
-    local_scheme = callable_or_entrypoint(
-        "setuptools_scm.local_scheme", config["local_scheme"]
-    )
-    main_version = version_scheme(version)
     trace("version", main_version)
-    local_version = local_scheme(version)
+    assert main_version is not None
+    local_version = _call_version_scheme(
+        version, "setuptools_scm.local_scheme", config["local_scheme"], "+unknown"
+    )
     trace("local_version", local_version)
-    return version_scheme(version) + local_scheme(version)
+    return main_version + local_version

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -110,6 +110,7 @@ class ScmVersion(object):
         preformatted=False,
         branch=None,
         config=None,
+        node_date=None,
         **kw
     ):
         if kw:
@@ -119,6 +120,7 @@ class ScmVersion(object):
             distance = 0
         self.distance = distance
         self.node = node
+        self.node_date = node_date
         self.time = datetime.datetime.utcfromtimestamp(
             int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
         )
@@ -154,6 +156,7 @@ class ScmVersion(object):
             node=self.node,
             dirty=self.dirty,
             branch=self.branch,
+            node_date=self.node_date,
             **kw
         )
 

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -1,5 +1,5 @@
 import sys
-
+import os
 from setuptools_scm import integration
 from setuptools_scm.utils import do, has_command
 from setuptools_scm import git
@@ -7,7 +7,7 @@ import pytest
 from datetime import datetime
 from os.path import join as opj
 from setuptools_scm.file_finder_git import git_find_files
-
+from datetime import date
 
 skip_if_win_27 = pytest.mark.skipif(
     sys.platform == "win32" and sys.version_info[0] < 3,
@@ -298,3 +298,20 @@ def test_gitdir(monkeypatch, wd):
     # git hooks set this and break subsequent setuptools_scm unless we clean
     monkeypatch.setenv("GIT_DIR", __file__)
     assert wd.version == normal
+
+
+def test_git_getdate(wd):
+    # TODO: case coverage for git wd parse
+    today = date.today()
+
+    def parse_date():
+        return lambda: git.parse(os.fspath(wd.cwd)).node_date
+
+    git_wd = git.GitWorkdir(os.fspath(wd.cwd))
+    assert git_wd.get_head_date() is None
+    assert parse_date() == today
+
+    wd.commit_testfile()
+    assert git_wd.get_head_date() == today
+    meta = git.parse(os.fspath(wd.cwd))
+    assert meta.node_date == today

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -305,7 +305,7 @@ def test_git_getdate(wd):
     today = date.today()
 
     def parse_date():
-        return lambda: git.parse(os.fspath(wd.cwd)).node_date
+        return git.parse(os.fspath(wd.cwd)).node_date
 
     git_wd = git.GitWorkdir(os.fspath(wd.cwd))
     assert git_wd.get_head_date() is None

--- a/testing/test_version.py
+++ b/testing/test_version.py
@@ -7,6 +7,7 @@ from setuptools_scm.version import (
     tags_to_versions,
     no_guess_dev_version,
     guess_next_version,
+    format_version,
 )
 
 
@@ -170,3 +171,12 @@ def test_version_bump_bad():
     ):
 
         guess_next_version(tag_version="2.0.0-alpha.5-PMC")
+
+
+def test_format_version_schemes():
+    version = meta("1.0", config=c)
+    format_version(
+        version,
+        local_scheme="no-local-version",
+        version_scheme=[lambda v: None, "guess-next-dev"],
+    )


### PR DESCRIPTION
initial internal refactoring to enable version schemes to be composed of multiple version schemes

this allows to more easily compose variants of local/main version schemes that bring together different details