### PR TITLE
Support working on a Git repository with hg-git

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -40,6 +40,8 @@ jobs:
       - run: pip install -U setuptools
         if: matrix.python_version != 'msys2'
       - run: pip install -e .[toml] pytest
+      - run: $(hg debuginstall --template "{pythonexe}") -m pip install hg-git --user
+        if: matrix.os == "ubuntu-latest"
       - run: pytest
 
   check_selfinstall:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.python_version != 'msys2'
       - run: pip install -e .[toml] pytest
       - run: $(hg debuginstall --template "{pythonexe}") -m pip install hg-git --user
-        if: matrix.os == "ubuntu-latest"
+        if: matrix.os == 'ubuntu-latest'
       - run: pytest
 
   check_selfinstall:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -41,7 +41,11 @@ jobs:
       - run: pip install -U setuptools
         if: matrix.python_version != 'msys2'
       - run: pip install -e .[toml] pytest
-      - run: $(hg debuginstall --template "{pythonexe}") -m pip install hg-git --user
+      # pip2 is needed because Mercurial uses python2 on Ubuntu 20.04
+      - run: |
+          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+          sudo python2 get-pip.py
+          $(hg debuginstall --template "{pythonexe}") -m pip install hg-git --user
         if: matrix.os == 'ubuntu-latest'
       - run: pytest
 

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -235,6 +235,8 @@ def parse(root, describe_command=None, pre_parse=warn_on_shallow, config=None):
 
     if ret == 0:
         tag, distance, node, dirty = _git_parse_describe(out)
+        if distance == 0 and not dirty:
+            distance = None
     else:
         # If 'git git_describe_command' failed, try to get the information otherwise.
         tag = "0.0"
@@ -244,8 +246,6 @@ def parse(root, describe_command=None, pre_parse=warn_on_shallow, config=None):
         else:
             distance = wd.count_all_nodes()
             node = "g" + node
-        if distance == 0:
-            distance = None
         dirty = wd.is_dirty()
 
     branch = wd.get_branch()

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -1,28 +1,20 @@
+from datetime import datetime, date
+import os
+from os.path import isfile, join, samefile
+import warnings
+
 from .config import Configuration
 from .utils import do_ex, trace, require_command
 from .version import meta
-from datetime import datetime, date
-import os
-from os.path import isfile, join
-import warnings
-
-
-from os.path import samefile
-
+from .scm_workdir import Workdir
 
 DEFAULT_DESCRIBE = "git describe --dirty --tags --long --match *[0-9]*"
 
 
-class GitWorkdir:
+class GitWorkdir(Workdir):
     """experimental, may change at any time"""
 
     COMMAND = "git"
-
-    def __init__(self, path):
-        self.path = path
-
-    def do_ex(self, cmd):
-        return do_ex(cmd, cwd=self.path)
 
     @classmethod
     def from_potential_worktree(cls, wd):
@@ -92,109 +84,6 @@ class GitWorkdir:
         return self.do_ex(DEFAULT_DESCRIBE)
 
 
-class GitWorkdirHgClient(GitWorkdir):
-    COMMAND = "hg"
-
-    @classmethod
-    def from_potential_worktree(cls, wd):
-        require_command(cls.COMMAND)
-        root, _, ret = do_ex("hg root", wd)
-        if ret:
-            return
-        return cls(root)
-
-    def is_dirty(self):
-        out, _, _ = self.do_ex("hg id -T '{dirty}'")
-        return bool(out)
-
-    def get_branch(self):
-        branch, err, ret = self.do_ex("hg id -T {bookmarks}")
-        if ret:
-            trace("branch err", branch, err, ret)
-            return
-        return branch
-
-    def get_head_date(self):
-        date_part, err, ret = self.do_ex("hg log -r . -T {shortdate(date)}")
-        if ret:
-            trace("head date err", date_part, err, ret)
-            return
-        return datetime.strptime(date_part, r"%Y-%m-%d").date()
-
-    def is_shallow(self):
-        return False
-
-    def fetch_shallow(self):
-        pass
-
-    def get_hg_node(self):
-        node, _, ret = self.do_ex("hg log -r . -T {node}")
-        if not ret:
-            return node
-
-    def node(self):
-        hg_node = self.get_hg_node()
-        if hg_node is None:
-            return
-
-        git_node = None
-        with open(os.path.join(self.path, ".hg/git-mapfile"), "r") as file:
-            for line in file:
-                if hg_node in line:
-                    git_node, hg_node = line.split()
-                    break
-
-        if git_node is None:
-            # trying again after hg -> git
-            self.do_ex("hg gexport")
-            return self.node()
-
-        return git_node[:7]
-
-    def count_all_nodes(self):
-        revs, _, _ = self.do_ex("hg log -r 'ancestors(.)' -T '.'")
-        return len(revs) + 1
-
-    def default_describe(self):
-        """
-        Tentative to reproduce the output of
-
-        `git describe --dirty --tags --long --match *[0-9]*`
-
-        """
-        hg_tags, _, ret = self.do_ex(
-            "hg log -r reverse(ancestors(.)) -T {tags}{if(tags, ' ', '')}"
-        )
-        if ret:
-            return None, None, None
-        hg_tags = hg_tags.split()
-
-        git_tags = {}
-        with open(os.path.join(self.path, ".hg/git-tags"), "r") as file:
-            for line in file:
-                node, tag = line.split()
-                git_tags[tag] = node
-
-        # find the first hg tag which is also a git tag
-        # TODO: also check for match *[0-9]*
-        for tag in hg_tags:
-            if tag in git_tags:
-                break
-
-        out, _, ret = self.do_ex("hg log -r .::" + tag + " -T .")
-        if ret:
-            return None, None, None
-        distance = len(out) - 1
-
-        node = self.node()
-        desc = f"{tag}-{distance}-g{node}"
-
-        if self.is_dirty():
-            desc += "-dirty"
-
-        return desc, None, 0
-
-
 def warn_on_shallow(wd):
     """experimental, may change at any time"""
     if wd.is_shallow():
@@ -225,6 +114,8 @@ def parse(root, describe_command=None, pre_parse=warn_on_shallow, config=None):
 
     wd = GitWorkdir.from_potential_worktree(config.absolute_root)
     if wd is None:
+        from .hg_git import GitWorkdirHgClient
+
         wd = GitWorkdirHgClient.from_potential_worktree(config.absolute_root)
     if wd is None:
         return

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -137,11 +137,17 @@ class GitWorkdirHgClient(GitWorkdir):
         if hg_node is None:
             return
 
+        git_node = None
         with open(os.path.join(self.path, ".hg/git-mapfile"), "r") as file:
             for line in file:
                 if hg_node in line:
                     git_node, hg_node = line.split()
                     break
+
+        if git_node is None:
+            # trying again after hg -> git
+            self.do_ex("hg gexport")
+            return self.node()
 
         return git_node[:7]
 

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -46,7 +46,6 @@ class GitWorkdir(Workdir):
         branch, err, ret = self.do_ex("git rev-parse --abbrev-ref HEAD")
         if ret:
             trace("branch err", branch, err, ret)
-            # TODO: understand the diff between these 2 commands
             branch, err, ret = self.do_ex("git symbolic-ref --short HEAD")
             if ret:
                 trace("branch err (symbolic-ref)", branch, err, ret)

--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -24,10 +24,19 @@ class HgWorkdir(Workdir):
             ".", "{node}\n{tag}\n{bookmark}\n{date|shortdate}"
         ).split("\n")
 
+        # TODO: support bookmarks and topics (but nowadays bookmarks are
+        # mainly used to emulate Git branches, which is already supported with
+        # the dedicated class GitWorkdirHgClient)
+
         branch, dirty, dirty_date = self.do(
             ["hg", "id", "-T", "{branch}\n{if(dirty, 1, 0)}\n{date|shortdate}"]
         ).split("\n")
         dirty = bool(int(dirty))
+
+        if dirty:
+            date = dirty_date
+        else:
+            date = node_date
 
         if all(c == "0" for c in node):
             trace("initial node", self.path)
@@ -61,6 +70,7 @@ class HgWorkdir(Workdir):
                     dirty=dirty,
                     branch=branch,
                     config=config,
+                    node_date=date
                 )
             else:
                 return meta(tag, config=config)

--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -33,6 +33,11 @@ def _hg_tagdist_normalize_tagcommit(config, tag, dist, node, branch):
 
 
 def parse(root, config=None):
+    if os.path.exists(os.path.join(root, ".hg/git")):
+        from .git import parse as git_parse
+
+        return git_parse(root, config=config)
+
     if not config:
         config = Configuration(root=root)
 

--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -70,7 +70,7 @@ class HgWorkdir(Workdir):
                     dirty=dirty,
                     branch=branch,
                     config=config,
-                    node_date=date
+                    node_date=date,
                 )
             else:
                 return meta(tag, config=config)

--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -1,19 +1,8 @@
 import os
 from .config import Configuration
-from .utils import do_ex, do, trace, data_from_mime, require_command
-from .version import meta, tags_to_versions, tag_to_version
-
-
-class Workdir:
-    def __init__(self, path):
-        require_command(self.COMMAND)
-        self.path = path
-
-    def do_ext(self, cmd):
-        return do_ex(cmd, cwd=self.path)
-
-    def do(self, cmd):
-        return do(cmd, cwd=self.path)
+from .utils import do_ex, trace, data_from_mime, require_command
+from .version import meta, tag_to_version
+from .scm_workdir import Workdir
 
 
 class HgWorkdir(Workdir):

--- a/src/setuptools_scm/hg_git.py
+++ b/src/setuptools_scm/hg_git.py
@@ -1,0 +1,110 @@
+import os
+from datetime import datetime
+
+from .utils import trace, require_command, do_ex
+from .git import GitWorkdir
+from .hg import HgWorkdir
+
+
+class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
+    COMMAND = "hg"
+
+    @classmethod
+    def from_potential_worktree(cls, wd):
+        require_command(cls.COMMAND)
+        root, err, ret = do_ex("hg root", wd)
+        if ret:
+            print(err)
+            return
+        return cls(root)
+
+    def is_dirty(self):
+        out, _, _ = self.do_ex("hg id -T '{dirty}'")
+        return bool(out)
+
+    def get_branch(self):
+        branch, err, ret = self.do_ex("hg id -T {bookmarks}")
+        if ret:
+            trace("branch err", branch, err, ret)
+            return
+        return branch
+
+    def get_head_date(self):
+        date_part, err, ret = self.do_ex("hg log -r . -T {shortdate(date)}")
+        if ret:
+            trace("head date err", date_part, err, ret)
+            return
+        return datetime.strptime(date_part, r"%Y-%m-%d").date()
+
+    def is_shallow(self):
+        return False
+
+    def fetch_shallow(self):
+        pass
+
+    def get_hg_node(self):
+        node, _, ret = self.do_ex("hg log -r . -T {node}")
+        if not ret:
+            return node
+
+    def node(self):
+        hg_node = self.get_hg_node()
+        if hg_node is None:
+            return
+
+        git_node = None
+        with open(os.path.join(self.path, ".hg/git-mapfile"), "r") as file:
+            for line in file:
+                if hg_node in line:
+                    git_node, hg_node = line.split()
+                    break
+
+        if git_node is None:
+            # trying again after hg -> git
+            self.do_ex("hg gexport")
+            return self.node()
+
+        return git_node[:7]
+
+    def count_all_nodes(self):
+        revs, _, _ = self.do_ex("hg log -r 'ancestors(.)' -T '.'")
+        return len(revs) + 1
+
+    def default_describe(self):
+        """
+        Tentative to reproduce the output of
+
+        `git describe --dirty --tags --long --match *[0-9]*`
+
+        """
+        hg_tags, _, ret = self.do_ex(
+            "hg log -r reverse(ancestors(.)) -T {tags}{if(tags, ' ', '')}"
+        )
+        if ret:
+            return None, None, None
+        hg_tags = hg_tags.split()
+
+        git_tags = {}
+        with open(os.path.join(self.path, ".hg/git-tags"), "r") as file:
+            for line in file:
+                node, tag = line.split()
+                git_tags[tag] = node
+
+        # find the first hg tag which is also a git tag
+        # TODO: also check for match *[0-9]*
+        for tag in hg_tags:
+            if tag in git_tags:
+                break
+
+        out, _, ret = self.do_ex("hg log -r " + tag + "::. -T .")
+        if ret:
+            return None, None, None
+        distance = len(out) - 1
+
+        node = self.node()
+        desc = f"{tag}-{distance}-g{node}"
+
+        if self.is_dirty():
+            desc += "-dirty"
+
+        return desc, None, 0

--- a/src/setuptools_scm/hg_git.py
+++ b/src/setuptools_scm/hg_git.py
@@ -78,7 +78,14 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
 
         """
         hg_tags, _, ret = self.do_ex(
-            "hg log -r reverse(ancestors(.)) -T {tags}{if(tags, ' ', '')}"
+            [
+                "hg",
+                "log",
+                "-r",
+                "(reverse(ancestors(.)) and tag(r're:[0-9]'))",
+                "-T",
+                "{tags}{if(tags, ' ', '')}",
+            ]
         )
         if ret:
             return None, None, None
@@ -91,7 +98,6 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
                 git_tags[tag] = node
 
         # find the first hg tag which is also a git tag
-        # TODO: also check for match *[0-9]*
         for tag in hg_tags:
             if tag in git_tags:
                 break

--- a/src/setuptools_scm/hg_git.py
+++ b/src/setuptools_scm/hg_git.py
@@ -70,13 +70,18 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
 
             if git_node is None:
                 trace("Cannot get git node so we use hg node", hg_node)
+
+                if hg_node == "0" * len(hg_node):
+                    # mimick Git behavior
+                    return None
+
                 return hg_node
 
         return git_node[:7]
 
     def count_all_nodes(self):
         revs, _, _ = self.do_ex("hg log -r 'ancestors(.)' -T '.'")
-        return len(revs) + 1
+        return len(revs)
 
     def default_describe(self):
         """
@@ -113,7 +118,7 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
             if tag in git_tags:
                 break
 
-        out, _, ret = self.do_ex("hg log -r " + tag + "::. -T .")
+        out, _, ret = self.do_ex(["hg", "log", "-r", f"'{tag}'::.", "-T", "."])
         if ret:
             return None, None, None
         distance = len(out) - 1

--- a/src/setuptools_scm/hg_git.py
+++ b/src/setuptools_scm/hg_git.py
@@ -53,7 +53,7 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
             return
 
         git_node = None
-        with open(os.path.join(self.path, ".hg/git-mapfile"), "r") as file:
+        with open(os.path.join(self.path, ".hg/git-mapfile")) as file:
             for line in file:
                 if hg_node in line:
                     git_node, hg_node = line.split()
@@ -92,7 +92,7 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
         hg_tags = hg_tags.split()
 
         git_tags = {}
-        with open(os.path.join(self.path, ".hg/git-tags"), "r") as file:
+        with open(os.path.join(self.path, ".hg/git-tags")) as file:
             for line in file:
                 node, tag = line.split()
                 git_tags[tag] = node

--- a/src/setuptools_scm/scm_workdir.py
+++ b/src/setuptools_scm/scm_workdir.py
@@ -1,0 +1,13 @@
+from .utils import do_ex, do, require_command
+
+
+class Workdir:
+    def __init__(self, path):
+        require_command(self.COMMAND)
+        self.path = path
+
+    def do_ex(self, cmd):
+        return do_ex(cmd, cwd=self.path)
+
+    def do(self, cmd):
+        return do(cmd, cwd=self.path)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -95,3 +95,29 @@ def wd(tmp_path):
     target_wd = tmp_path.resolve() / "wd"
     target_wd.mkdir()
     return Wd(target_wd)
+
+
+@pytest.fixture
+def repositories_hg_git(tmp_path):
+    from setuptools_scm.utils import do
+
+    tmp_path = tmp_path.resolve()
+    path_git = tmp_path / "repo_git"
+    path_git.mkdir()
+
+    wd = Wd(path_git)
+    wd("git init")
+    wd("git config user.email test@example.com")
+    wd('git config user.name "a test"')
+    wd.add_command = "git add ."
+    wd.commit_command = "git commit -m test-{reason}"
+
+    path_hg = tmp_path / "repo_hg"
+    do(f"hg clone {path_git} {path_hg}")
+    assert path_hg.exists()
+
+    wd_hg = Wd(path_hg)
+    wd_hg.add_command = "hg add ."
+    wd_hg.commit_command = 'hg commit -m test-{reason} -u test -d "0 0"'
+
+    return wd_hg, wd

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -113,8 +113,11 @@ def repositories_hg_git(tmp_path):
     wd.commit_command = "git commit -m test-{reason}"
 
     path_hg = tmp_path / "repo_hg"
-    do(f"hg clone {path_git} {path_hg}")
+    do(f"hg clone {path_git} {path_hg} --config extensions.hggit=")
     assert path_hg.exists()
+
+    with open(path_hg / ".hg/hgrc", "a") as file:
+        file.write("[extensions]\nhggit =\n")
 
     wd_hg = Wd(path_hg)
     wd_hg.add_command = "hg add ."

--- a/testing/test_hg_git.py
+++ b/testing/test_hg_git.py
@@ -1,6 +1,18 @@
 import pytest
+from setuptools_scm.utils import has_command, do_ex
+
+python_hg, err, ret = do_ex("hg debuginstall --template {pythonexe}")
+
+if ret:
+    skip_no_hggit = True
+else:
+    out, err, ret = do_ex([python_hg.strip(), "-c", "import hggit"])
+    print(out, err, ret)
+    skip_no_hggit = bool(ret)
 
 
+@pytest.mark.skipif(not has_command("hg", warn=False), reason="hg executable not found")
+@pytest.mark.skipif(skip_no_hggit, reason="hg-git not installed")
 def test_base(repositories_hg_git):
     wd, wd_git = repositories_hg_git
 

--- a/testing/test_hg_git.py
+++ b/testing/test_hg_git.py
@@ -1,0 +1,60 @@
+import pytest
+
+
+def test_base(repositories_hg_git):
+    wd, wd_git = repositories_hg_git
+
+    assert wd_git.version == "0.1.dev0"
+    assert wd.version == "0.1.dev0"
+
+    wd_git.commit_testfile()
+    wd("hg pull -u")
+
+    version_git = wd_git.version
+    version = wd.version
+
+    assert version_git.startswith("0.1.dev1+g")
+    assert version.startswith("0.1.dev1+g")
+
+    assert not version_git.endswith("1-")
+    assert not version.endswith("1-")
+
+    wd_git("git tag v0.1")
+    wd("hg pull -u")
+    assert wd_git.version == "0.1"
+    assert wd.version == "0.1"
+
+    wd_git.write("test.txt", "test2")
+    wd.write("test.txt", "test2")
+    assert wd_git.version.startswith("0.2.dev0+g")
+    assert wd.version.startswith("0.2.dev0+g")
+
+    wd_git.commit_testfile()
+    wd("hg pull")
+    wd("hg up -C")
+    assert wd_git.version.startswith("0.2.dev1+g")
+    assert wd.version.startswith("0.2.dev1+g")
+
+    wd_git("git tag version-0.2")
+    wd("hg pull -u")
+    assert wd_git.version.startswith("0.2")
+    assert wd.version.startswith("0.2")
+
+    wd_git.commit_testfile()
+    wd_git("git tag version-0.2.post210+gbe48adfpost3+g0cc25f2")
+    wd("hg pull -u")
+    with pytest.warns(
+        UserWarning, match="tag '.*' will be stripped of its suffix '.*'"
+    ):
+        assert wd_git.version.startswith("0.2")
+
+    with pytest.warns(
+        UserWarning, match="tag '.*' will be stripped of its suffix '.*'"
+    ):
+        assert wd.version.startswith("0.2")
+
+    wd_git.commit_testfile()
+    wd_git("git tag 17.33.0-rc")
+    wd("hg pull -u")
+    assert wd_git.version == "17.33.0rc0"
+    assert wd.version == "17.33.0rc0"


### PR DESCRIPTION
Mercurial can be used as a Git client with hg-git. Then, one would like to get the same version as with Git (in particular, with Git sha). I tried to implement that in this PR. It's an early draft without tests!

This PR fixes #530.