### PR TITLE
fix: still including py2 tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,3 @@ toml =
 
 [options.packages.find]
 where = src
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
This would still produce a wheel with a py2.py3 tag.