### PR TITLE
README: remove incorrect mention of pkg_resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,7 +192,7 @@ Usage from Sphinx
 -----------------
 
 It is discouraged to use ``setuptools_scm`` from Sphinx itself,
-instead use ``pkg_resources`` after editable/real installation:
+instead use ``importlib.metadata`` after editable/real installation:
 
 .. code:: python
 


### PR DESCRIPTION
Hi,
Apparently 4393e97cf2e9f524ceb0032860de91661470527b changed the Sphinx example to `importlib.metadata` but the sentence preceding it still mentioned `pkg_resources`.