### PR TITLE
Fix #557 - Use packaging.version for version_tuple

### DIFF
--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -5,6 +5,11 @@
 import os
 import warnings
 
+try:
+    from packaging.version import parse
+except ImportError:
+    from pkg_resources import parse_version as parse
+
 from .config import (
     Configuration,
     DEFAULT_VERSION_SCHEME,
@@ -83,15 +88,12 @@ def dump_version(root, version, write_to, template=None):
             )
         )
 
-    # version_tuple: each field is converted to an int if possible or kept as string
-    fields = tuple(version.split("."))
-    version_fields = []
-    for field in fields:
-        try:
-            v = int(field)
-        except ValueError:
-            v = field
-        version_fields.append(v)
+    parsed_version = parse(version)
+    version_fields = parsed_version.release
+    if parsed_version.dev is not None:
+        version_fields += (f"dev{parsed_version.dev}",)
+    if parsed_version.local is not None:
+        version_fields += (parsed_version.local,)
 
     with open(target, "w") as fp:
         fp.write(template.format(version=version, version_tuple=tuple(version_fields)))

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -112,6 +112,18 @@ def test_dump_version(tmpdir):
     assert "version = '1.0.dev42'" in lines
     assert "version_tuple = (1, 0, 'dev42')" in lines
 
+    dump_version(sp, "1.0.1+g4ac9d2c", "second.py")
+    content = tmpdir.join("second.py").read()
+    lines = content.splitlines()
+    assert "version = '1.0.1+g4ac9d2c'" in lines
+    assert "version_tuple = (1, 0, 1, 'g4ac9d2c')" in lines
+
+    dump_version(sp, "1.2.3.dev18+gb366d8b.d20210415", "third.py")
+    content = tmpdir.join("third.py").read()
+    lines = content.splitlines()
+    assert "version = '1.2.3.dev18+gb366d8b.d20210415'" in lines
+    assert "version_tuple = (1, 2, 3, 'dev18', 'gb366d8b.d20210415')" in lines
+
     import ast
 
     ast.parse(content)


### PR DESCRIPTION
This pull request updates the tuple parser to use `packaging.version`'s parser to retrieve the release tuple. This then checks for the dev and local attributes, including those if applicable.