### PR TITLE
Accept branches start with 'v' as being a release branch.

### DIFF
--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -275,11 +275,15 @@ def release_branch_semver_version(version):
         # Does the branch name (stripped of namespace) parse as a version?
         branch_ver = _parse_version_tag(version.branch.split("/")[-1], version.config)
         if branch_ver is not None:
+            branch_ver = branch_ver["version"]
+            if branch_ver[0] == "v":
+                # Allow branches that start with 'v', similar to Version.
+                branch_ver = branch_ver[1:]
             # Does the branch version up to the minor part match the tag? If not it
             # might be like, an issue number or something and not a version number, so
             # we only want to use it if it matches.
             tag_ver_up_to_minor = str(version.tag).split(".")[:SEMVER_MINOR]
-            branch_ver_up_to_minor = branch_ver["version"].split(".")[:SEMVER_MINOR]
+            branch_ver_up_to_minor = branch_ver.split(".")[:SEMVER_MINOR]
             if branch_ver_up_to_minor == tag_ver_up_to_minor:
                 # We're in a release/maintenance branch, next is a patch/rc/beta bump:
                 return version.format_next_version(guess_next_version)

--- a/testing/test_version.py
+++ b/testing/test_version.py
@@ -83,6 +83,11 @@ def test_next_semver_bad_tag():
             id="release_branch_legacy_version",
         ),
         pytest.param(
+            meta("1.0.0", distance=2, branch="v1.0.x", config=c),
+            "1.0.1.dev2",
+            id="release_branch_with_v_prefix",
+        ),
+        pytest.param(
             meta("1.0.0", distance=2, branch="release-1.0", config=c),
             "1.0.1.dev2",
             id="release_branch_with_prefix",


### PR DESCRIPTION
This seems to be the most straightforward way to implement it, as it matches the `VERSION_REGEX` in `packaging` that just has `v?{other stuff}`.
 
Fixes #571.