### PR TITLE
Use UTF-8 encoding when reading pyproject.toml

### DIFF
--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -167,7 +167,7 @@ class Configuration:
         not installed or the file has invalid format or does
         not contain the [tool.setuptools_scm] section.
         """
-        with open(name) as strm:
+        with open(name, encoding="UTF-8") as strm:
             defn = __import__("toml").load(strm)
         section = defn.get("tool", {})["setuptools_scm"]
         return cls(dist_name=dist_name, **section)

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -40,7 +40,7 @@ def _args_from_toml(name="pyproject.toml"):
     # move this helper back to config and unify it with the code from get_config
     import tomli
 
-    with open(name) as strm:
+    with open(name, encoding="UTF-8") as strm:
         defn = tomli.load(strm)
     return defn.get("tool", {})["setuptools_scm"]
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from setuptools_scm.config import Configuration
 import re
 import pytest
@@ -27,7 +29,17 @@ def test_tag_regex(tag, expected_version):
 
 def test_config_from_pyproject(tmpdir):
     fn = tmpdir / "pyproject.toml"
-    fn.write_text("[tool.setuptools_scm]\n", encoding="utf-8")
+    fn.write_text(
+        textwrap.dedent(
+            """
+            [tool.setuptools_scm]
+            [project]
+            description = "Factory ⸻ A code generator 🏭"
+            authors = [{name = "Łukasz Langa"}]
+            """
+        ),
+        encoding="utf-8",
+    )
     assert Configuration.from_file(str(fn))
 
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,7 +1,6 @@
-import textwrap
-
 from setuptools_scm.config import Configuration
 import re
+import textwrap
 import pytest
 
 

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -280,7 +280,7 @@ def test_git_archive_export_ignore(wd, monkeypatch):
 
 @pytest.mark.issue(228)
 def test_git_archive_subdirectory(wd, monkeypatch):
-    wd("mkdir foobar")
+    os.mkdir(wd.cwd / "foobar")
     wd.write("foobar/test1.txt", "test")
     wd("git add foobar")
     wd.commit()
@@ -290,7 +290,7 @@ def test_git_archive_subdirectory(wd, monkeypatch):
 
 @pytest.mark.issue(251)
 def test_git_archive_run_from_subdirectory(wd, monkeypatch):
-    wd("mkdir foobar")
+    os.mkdir(wd.cwd / "foobar")
     wd.write("foobar/test1.txt", "test")
     wd("git add foobar")
     wd.commit()

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import textwrap
 
 import pytest
 
@@ -21,10 +22,17 @@ def test_pyproject_support(tmpdir, monkeypatch):
     pytest.importorskip("toml")
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     pkg = tmpdir.ensure("package", dir=42)
-    pkg.join("pyproject.toml").write(
-        """[tool.setuptools_scm]
-fallback_version = "12.34"
-"""
+    pkg.join("pyproject.toml").write_text(
+        textwrap.dedent(
+            """
+            [tool.setuptools_scm]
+            fallback_version = "12.34"
+            [project]
+            description = "Factory ⸻ A code generator 🏭"
+            authors = [{name = "Łukasz Langa"}]
+            """
+        ),
+        encoding="utf-8",
     )
     pkg.join("setup.py").write("__import__('setuptools').setup()")
     res = do((sys.executable, "setup.py", "--version"), pkg)


### PR DESCRIPTION
This avoids a `UnicodeDecodeError` when reading `pyproject.toml` files containing unicode characters on Windows. These characters may be present in a project's metadata, such as its description or an author's name.

```python
>>> from setuptools_scm.config import Configuration
>>> Configuration.from_file()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lib\site-packages\setuptools_scm\config.py", line 137, in from_file
    defn = __import__("toml").load(strm)
  File "lib\site-packages\toml\decoder.py", line 156, in load
    return loads(f.read(), _dict, decoder)
  File "lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 242: character maps to <undefined>
```

Furthermore, the [TOML specification](https://toml.io/en/v1.0.0#spec) requires files to be encoded in UTF-8.