### PR TITLE
fix #587 - stop file finding on missing commits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 In progress
 ===========
 
+* fix #587: don't fail file finders when distribution is not given
 * fix #524: new parameters ``normalize`` and ``version_cls`` to customize the version normalization class.
 * fix #585: switch from toml to tomli
 

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -5,6 +5,7 @@ import tarfile
 
 from .file_finder import is_toplevel_acceptable
 from .file_finder import scm_find_files
+from .utils import do_ex
 from .utils import trace
 
 log = logging.getLogger(__name__)
@@ -13,13 +14,17 @@ log = logging.getLogger(__name__)
 def _git_toplevel(path):
     try:
         cwd = os.path.abspath(path or ".")
-        with open(os.devnull, "wb") as devnull:
-            out = subprocess.check_output(
-                ["git", "rev-parse", "--show-prefix"],
-                cwd=cwd,
-                universal_newlines=True,
-                stderr=devnull,
-            )
+        out, err, ret = do_ex(["git", "rev-parse", "HEAD"], cwd=cwd)
+        if ret != 0:
+            # BAIL if there is no commit
+            log.error("listing git files failed - pretending there aren't any")
+            return None
+        out, err, ret = do_ex(
+            ["git", "rev-parse", "--show-prefix"],
+            cwd=cwd,
+        )
+        if ret != 0:
+            return None
         out = out.strip()[:-1]  # remove the trailing pathsep
         if not out:
             out = cwd
@@ -28,7 +33,7 @@ def _git_toplevel(path):
             # ``cwd`` is absolute path to current working directory.
             # the below method removes the length of ``out`` from
             # ``cwd``, which gives the git toplevel
-            assert cwd.replace("\\", "/").endswith(out)
+            assert cwd.replace("\\", "/").endswith(out), f"cwd={cwd!r}\nout={out!r}"
             # In windows cwd contains ``\`` which should be replaced by ``/``
             # for this assertion to work. Length of string isn't changed by replace
             # ``\\`` is just and escape for `\`
@@ -59,8 +64,11 @@ def _git_interpret_archive(fd, toplevel):
 def _git_ls_files_and_dirs(toplevel):
     # use git archive instead of git ls-file to honor
     # export-ignore git attribute
+
     cmd = ["git", "archive", "--prefix", toplevel + os.path.sep, "HEAD"]
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=toplevel)
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, cwd=toplevel, stderr=subprocess.DEVNULL
+    )
     try:
         try:
             return _git_interpret_archive(proc.stdout, toplevel)
@@ -70,7 +78,7 @@ def _git_ls_files_and_dirs(toplevel):
             proc.terminate()
     except Exception:
         if proc.wait() != 0:
-            log.exception("listing git files failed - pretending there aren't any")
+            log.error("listing git files failed - pretending there aren't any")
         return (), ()
 
 

--- a/src/setuptools_scm/file_finder_hg.py
+++ b/src/setuptools_scm/file_finder_hg.py
@@ -3,6 +3,7 @@ import subprocess
 
 from .file_finder import is_toplevel_acceptable
 from .file_finder import scm_find_files
+from .utils import do_ex
 
 
 def _hg_toplevel(path):
@@ -26,9 +27,9 @@ def _hg_toplevel(path):
 def _hg_ls_files_and_dirs(toplevel):
     hg_files = set()
     hg_dirs = {toplevel}
-    out = subprocess.check_output(
-        ["hg", "files"], cwd=toplevel, universal_newlines=True
-    )
+    out, err, ret = do_ex(["hg", "files"], cwd=toplevel)
+    if ret:
+        (), ()
     for name in out.splitlines():
         name = os.path.normcase(name).replace("/", os.path.sep)
         fullname = os.path.join(toplevel, name)

--- a/testing/test_file_finder.py
+++ b/testing/test_file_finder.py
@@ -31,7 +31,8 @@ def inwd(request, wd, monkeypatch):
     bdir = wd.cwd / "bdir"
     bdir.mkdir()
     (bdir / "fileb").touch()
-    wd.add_and_commit()
+    if request.node.get_closest_marker("skip_commit") is None:
+        wd.add_and_commit()
     monkeypatch.chdir(wd.cwd)
     yield wd
 
@@ -184,3 +185,9 @@ def test_symlink_not_in_scm_while_target_is(inwd):
             "data/datafile",
         }
     )
+
+
+@pytest.mark.issue(587)
+@pytest.mark.skip_commit
+def test_not_commited(inwd):
+    assert find_files() == []

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ testpaths=testing
 filterwarnings=error
 markers=
     issue(id): reference to github issue
+    skip_commit: allows to skip commiting in the helpers
 # disable unraisable until investigated
 addopts = -p no:unraisableexception
 


### PR DESCRIPTION
on a repository without a commit we cannot tell the valid files, so we don't
