### PR TITLE
fix regressions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: [  '3.6', '3.9', 'pypy3' ]
-        installer: ["pip install", easy_install]
+        installer: ["pip install"]
     name: check self install - Python ${{ matrix.python_version }} via ${{ matrix.installer }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -67,7 +67,7 @@ jobs:
       # self install testing needs some clarity
       # so its being executed without any other tools running
       # setuptools smaller 52 is needed too di easy_install
-      - run: pip install -U "setuptools<52"
+      - run: pip install -U "setuptools<52" tomli
       - run: python setup.py egg_info
       - run: python setup.py sdist
       - run: ${{ matrix.installer }} dist/*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+v6.1.1
+=======
+
+* fix #605: completely disallow bdist_egg - modern enough setuptools>=45 uses pip
+* fix #606: re-integrate and harden toml parsing
+
 v6.1.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ v6.1.1
 
 * fix #605: completely disallow bdist_egg - modern enough setuptools>=45 uses pip
 * fix #606: re-integrate and harden toml parsing
+* fix #597: harden and expand support for figuring the current distribution name from
+  `pyproject.toml` (`project.name` or `tool.setuptools_scm.dist_name`) section or `setup.cfg` (`metadata.name`)
 
 v6.1.0
 ======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=45", "wheel"]
+requires = ["setuptools>=45", "wheel", "tomli"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,4 @@ def scm_config():
 
 
 if __name__ == "__main__":
-    setuptools.setup(setup_requires=["setuptools>=45"], **scm_config())
+    setuptools.setup(setup_requires=["setuptools>=45", "tomli"], **scm_config())

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,8 @@ def scm_config():
     has_entrypoints = os.path.isdir(egg_info)
     import pkg_resources
 
-    pkg_resources.require("setuptools>=45")
-
     sys.path.insert(0, src)
     pkg_resources.working_set.add_entry(src)
-    # FIXME: remove debug
-    print(src)
-    print(pkg_resources.working_set)
 
     from setuptools_scm.hacks import parse_pkginfo
     from setuptools_scm.git import parse as parse_git
@@ -50,13 +45,22 @@ def scm_config():
         version_scheme=guess_next_dev_version, local_scheme=get_local_node_and_date
     )
 
+    from setuptools.command.bdist_egg import bdist_egg as original_bdist_egg
+
+    class bdist_egg(original_bdist_egg):
+        def run(self):
+            raise SystemExit("bdist_egg is forbidden, please update to setuptools>=45")
+
     if has_entrypoints:
-        return dict(use_scm_version=config)
+        return dict(use_scm_version=config, cmdclass={"bdist_egg": bdist_egg})
     else:
         from setuptools_scm import get_version
 
-        return dict(version=get_version(root=here, parse=parse, **config))
+        return dict(
+            version=get_version(root=here, parse=parse, **config),
+            cmdclass={"bdist_egg": bdist_egg},
+        )
 
 
 if __name__ == "__main__":
-    setuptools.setup(**scm_config())
+    setuptools.setup(setup_requires=["setuptools>=45"], **scm_config())

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -205,7 +205,7 @@ class Configuration:
             # minimal effort to read dist_name off setup.cfg metadata
             import configparser
 
-            parser = configparser.SafeConfigParser()
+            parser = configparser.ConfigParser()
             parser.read(["setup.cfg"])
             dist_name = parser.get("metadata", "name", fallback=None)
 

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -1,12 +1,15 @@
+import warnings
+
+import setuptools
+
 from . import _get_version
 from . import Configuration
 from .utils import do
 from .utils import iter_entry_points
 from .utils import trace
-from .utils import trace_exception
 
 
-def version_keyword(dist, keyword, value):
+def version_keyword(dist: setuptools.Distribution, keyword, value):
     if not value:
         return
     if value is True:
@@ -39,17 +42,7 @@ def find_files(path=""):
     return []
 
 
-def _args_from_toml(name="pyproject.toml"):
-    # todo: more sensible config initialization
-    # move this helper back to config and unify it with the code from get_config
-    import tomli
-
-    with open(name, encoding="UTF-8") as strm:
-        defn = tomli.load(strm)
-    return defn.get("tool", {})["setuptools_scm"]
-
-
-def infer_version(dist):
+def infer_version(dist: setuptools.Distribution):
     trace(
         "finalize hook",
         vars(dist.metadata),
@@ -57,6 +50,7 @@ def infer_version(dist):
     dist_name = dist.metadata.name
     try:
         config = Configuration.from_file(dist_name=dist_name)
-    except Exception:
-        return trace_exception()
-    dist.metadata.version = _get_version(config)
+    except FileNotFoundError as e:
+        warnings.warn(str(e))
+    else:
+        dist.metadata.version = _get_version(config)


### PR DESCRIPTION
- fix #605: completely disallow bdist_egg - modern enough setuptools>=45 uses pip
- fix #606: re-integrate and harden toml parsing
- fix #597: harden and expand finding the distribution name when its not in setup.py