### PR TITLE
ci: test building the wheel from the SDist

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -90,7 +90,7 @@ jobs:
         pip install --upgrade wheel setuptools build
 
     - name: Build package
-      run: python -m build -s -w -o dist/
+      run: python -m build -o dist/
     - uses: actions/upload-artifact@v2
       with:
         name: dist


### PR DESCRIPTION
This is currently building the wheel from source; it's better to build the wheel from the SDist.

Also, I'd recommend switching to pipx here, which drops a few lines and upgrades. I also recommend using full option names in CI, short-options are only for quick usage on the command line. I can make those changes if you want as well.