### PR TITLE
Fix TypeError in version.py

### DIFF
--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -16,7 +16,7 @@ SEMVER_LEN = 3
 
 
 def _parse_version_tag(tag, config):
-    tagstring = tag if not isinstance(tag, str) else str(tag)
+    tagstring = tag if isinstance(tag, str) else str(tag)
     match = config.tag_regex.match(tagstring)
 
     result = None


### PR DESCRIPTION
I was using this with the setuptools_scm_git_archive plugin and came across a `TypeError: expected string or bytes-like object` in version.py:20. I had a quick look at the code and found that it seems to convert to a string only when it's already a string - I'm guessing that was an accident :) After double-checking, something (possibly setuptools_scm_git_archive) was passing in a `packaging.version.Version` instance, so the TypeError makes sense.

I didn't make an issue, as it looks like a simple fix.