### PR TITLE
Fix setup install setuptools-scm with a Mercurial repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,14 @@ def scm_version():
     from setuptools_scm import get_version
     from setuptools_scm.hacks import parse_pkginfo
     from setuptools_scm import git
+    from setuptools_scm import hg
     from setuptools_scm.version import guess_next_dev_version, get_local_node_and_date
 
     def parse(root, config):
         try:
             return parse_pkginfo(root, config)
         except OSError:
-            return git.parse(root, config=config)
+            return git.parse(root, config=config) or hg.parse(root, config=config)
 
     return get_version(
         root=here,


### PR DESCRIPTION
It's no longer possible to run `python setup.py develop` for the setuptools-scm repository if one use Mercurial as a Git client.

This is in particular because the "bootstrapping" in setup.py directly call `setuptools_scm.git.parse`, i.e. it is assumed that the repo has been cloned with Git.

This PR fixes this by also calling `setuptools_scm.hg.parse` in case `setuptools_scm.git.parse` return `None`.