### PR TITLE
Add pre-commit hook to update editable install versions

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,20 @@
+---
+
+- id: update-egg-info
+  name: update-egg-info
+  description: "Runs setup.py egg_info to update version info"
+  entry: python -m setuptools_scm.pre_commit_hook
+  language: python
+  always_run: true
+  stages: [post-checkout, post-commit, post-merge]
+  verbose: true
+- id: update-egg-info-rewrite
+  name: update-egg-info-rewrite
+  description: >
+    post-commit for auto_egg skips egg_info during rebases.
+    This forces a egg_info after the rebase.
+  entry: python -m setuptools_scm.pre_commit_hook --post-rewrite
+  language: python
+  always_run: true
+  stages: [post-rewrite]
+  verbose: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
 
 - id: update-egg-info
   name: update-egg-info
-  description: "Runs setup.py egg_info to update version info"
+  description: "Updates version info for editable pip packages on update"
   entry: python -m setuptools_scm.pre_commit_hook
   language: python
   always_run: true
@@ -11,7 +11,7 @@
 - id: update-egg-info-rewrite
   name: update-egg-info-rewrite
   description: >
-    post-commit for auto_egg skips egg_info during rebases.
+    post-commit for update-egg-info skips egg_info during rebases.
     This forces a egg_info after the rebase.
   entry: python -m setuptools_scm.pre_commit_hook --post-rewrite
   language: python

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 exclude *.nix
 exclude .pre-commit-config.yaml
+include .pre-commit-hooks.yaml
 include *.py
 include testing/*.py
 include tox.ini

--- a/README.rst
+++ b/README.rst
@@ -669,18 +669,35 @@ repo, the version of your editable pip package will be kept up to date.
 Customizing the Build Command
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default update-egg-info will use the command ``python setup.py egg_info``, this takes
-the least amount of time to update the version metadata for a standard setuptools_scm
-editable install to update the version information. However if you need to customize the
-build command you can pass a custom build command to each hook.
+By default update-egg-info will create a virtualenv named `.setuptools_scm` in the root
+of your git repo and use `pip install -e . --no-deps` to update the version info of your
+repo.
+
+If desired, you can customize the name of the virtualenv by specifying the venv_name
+property.
 
 .. code-block:: yaml
 
         hooks:
           - id: update-egg-info
-            args: ["python", "setup.py", "bdist_wheel"]
+            args: ["--venv-name", ".st_venv"]
           - id: update-egg-info-rewrite
-            args: ["python", "setup.py", "bdist_wheel"]
+            args: ["--venv-name", ".st_venv"]
+
+
+You can replace this workflow by passing a build command, this will disable creating
+the virtualenv and simply run the specified build command. For non PEP 660 projects
+using the command ``python setup.py egg_info`` likely will suffice. This takes the
+least amount of time to update the version metadata for a standard setuptools_scm
+editable install to update the version information.
+
+.. code-block:: yaml
+
+        hooks:
+          - id: update-egg-info
+            args: ["python", "setup.py", "egg_info"]
+          - id: update-egg-info-rewrite
+            args: ["python", "setup.py", "egg_info"]
 
 
 Code of Conduct

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -57,6 +57,11 @@ class GitWorkdir(Workdir):
                 branch = None
         return branch
 
+    def get_git_dir(self):
+        """Returns the absolute path to the .git directory"""
+        out, err, ret = self.do_ex("git rev-parse --absolute-git-dir")
+        return out.strip()
+
     def get_head_date(self):
         timestamp, err, ret = self.do_ex("git log -n 1 HEAD --format=%cI")
         if ret:

--- a/src/setuptools_scm/pre_commit_hook.py
+++ b/src/setuptools_scm/pre_commit_hook.py
@@ -1,0 +1,120 @@
+import os
+import sys
+
+from setuptools_scm.git import GitWorkdir
+
+
+class PreCommitHook:
+    def __init__(self, repo_dir, build_command):
+        self.build_command = build_command
+        self.work_dir = GitWorkdir.from_potential_worktree(repo_dir)
+
+    def is_git_rebasing(self):
+        """Checks if git is currently in rebase mode and returns the output of build_command.
+
+        This detection code could be improved, Here is a summary of how well this
+        handles various git operations.
+        Rebase: A series of post-commit hooks where `is_git_rebasing` returns true,
+            and finally the post-rewrite hook is called. This is why we have a separate
+            `update-egg-info-rewrite` hook that passes `--post-rewrite` to force the
+            running of build_command.
+        Squash: For each commit being squashed, `is_git_rebasing` returns true for
+            the post-commit hook, but the post-rewrite hook is called several times,
+            calling build_command each of those times.
+        Amend: This ends up calling build_command twice.
+        """
+        git_dir = self.work_dir.get_git_dir()
+        rebase_merge = os.path.join(git_dir, "rebase-merge")
+        rebase_apply = os.path.join(git_dir, "rebase-apply")
+        return os.path.exists(rebase_merge) or os.path.exists(rebase_apply)
+
+    def update_egg_info(self, force_on_rebase=False):
+        """Run the `python setup.py egg_info` if this is a editable install."""
+
+        # Allow users to temporarily disable the hook. `is_git_rebasing` doesn't work
+        # in all cases and there may be cases where you want to disable this hook to
+        # speed up git operations. Running egg_info adds some slowness to the git
+        # commands, especially for large packages with a lot of files.
+        if os.getenv("SETUPTOOLS_SCM_SKIP_UPDATE_EGG_INFO", "0") != "0":
+            output = (
+                'update-egg-info: Skipping, "SETUPTOOLS_SCM_SKIP_UPDATE_EGG_INFO" '
+                "env var set."
+            )
+            return output, 0
+
+        # If this is not an editable install there is no need to run it
+        contents = os.listdir(self.work_dir.path)
+
+        # If there is not a setup.cfg or setup.py file then this can't be an editable
+        # install, no need to try to run build_command.
+        if "setup.cfg" not in contents and "setup.py" not in contents:
+            output = "update-egg-info: Skipping, no setup script found."
+            return output, 0
+
+        # If a egg_info directory doesn't exist its not currently an editable install
+        # don't turn it into one.
+        if not any(filter(lambda i: os.path.splitext(i)[-1] == ".egg-info", contents)):
+            output = "update-egg-info: Skipping, no .egg-info directory found."
+            return output, 0
+
+        # Check if git is currently rebasing, if so and force_on_rebase is False, this
+        # is likely a post-commit call, and the post-rewrite hook will be called later,
+        # skip running build_command for now.
+        if not force_on_rebase and self.is_git_rebasing():
+            output = "update-egg-info: Skipping, rebase in progress."
+            return output, 0
+
+        # Run the build command
+        output = [f"update-egg-info: Running command: {self.build_command}"]
+        cmd_out, error, returncode = self.work_dir.do_ex(self.build_command)
+
+        if cmd_out:
+            output += cmd_out
+        if returncode and error:
+            output.append("update-egg-info: Error running build_command:")
+            output.append(error)
+
+        output = "\n".join(output)
+        return output, returncode
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Pre-commit hook interface for automatically updating egg-info of "
+            "editable installs."
+        )
+    )
+    parser.add_argument(
+        "--post-rewrite",
+        action="store_true",
+        help=(
+            "Force running `command` after a rebase. update-egg-info skips calling "
+            "`command` if it detects that git is performing a rebase as generating the"
+            "egg_info takes extra time, especially for larger packages."
+        ),
+    )
+    parser.add_argument(
+        "command",
+        default=["python", "setup.py", "egg_info"],
+        nargs="*",
+        help=(
+            "The command the hook will run to update the editable "
+            'install. Defaults to: "python setup.py egg_info"'
+        ),
+    )
+    args = parser.parse_args()
+
+    hook = PreCommitHook(os.getcwd(), build_command=args.command)
+    output, returncode = hook.update_egg_info(force_on_rebase=args.post_rewrite)
+
+    print(output)
+
+    # Return the error code so pre-commit can report the failure.
+    sys.exit(returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -448,7 +448,7 @@ def do_interactive(cwd, branch="master"):
     env["GIT_SEQUENCE_EDITOR"] = "sed -i -re 's/^noop/e HEAD/'"
 
     proc = subprocess.Popen(
-        f"git rebase -i {branch}",
+        ["git", "rebase", "-i", branch],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=str(cwd),


### PR DESCRIPTION
This adds a pre-commit hook to setuptools_scm that will automatically update the .egg-info for a setuptools_scm enabled project. It uses the newer post-commit, post-merge, post-checkout, post-rewrite hooks that pre-commit supports.

This MR is working for me, but still needs some work before it would be ready to merge into setuptools_scm. I'm providing this MR as a proof of concept and to ask if its something that can/should be added to setuptools_scm, or if I should make my own package.

I have a few TODO's that will need looked into:
- I'm using setup.py but that is deprecated, update this to use pyproject.toml and if desired, support the other deprecated methods of building the egg_info.
- Improve the detection of rebase, squash commits so it can skip calling egg_info repeatedly after every time that process does a commit.
- Should we create a `console_scripts` `entry_point` instead of using `__main__.py`? Ie `python -m setuptools_scm post-commit`
- Potentially use argproperty or click to parse the required cli arguments of `__main__.py` or the console_script.
- Testing.