### PR TITLE
Escape glob pattern in git describe to avoid shell expansion.

### DIFF
--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -16,7 +16,15 @@ from .version import meta
 # If testing command in shell make sure to quote the match argument like
 # '*[0-9]*' as it will expand before being sent to git if there are any matching
 # files in current directory.
-DEFAULT_DESCRIBE = ["git", "describe", "--dirty", "--tags", "--long", "--match", "*[0-9]*"]
+DEFAULT_DESCRIBE = [
+    "git",
+    "describe",
+    "--dirty",
+    "--tags",
+    "--long",
+    "--match",
+    "*[0-9]*",
+]
 
 
 class GitWorkdir(Workdir):

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -13,7 +13,7 @@ from .utils import require_command
 from .utils import trace
 from .version import meta
 
-DEFAULT_DESCRIBE = "git describe --dirty --tags --long --match *[0-9]*"
+DEFAULT_DESCRIBE = "git describe --dirty --tags --long --match '*[0-9]*'"
 
 
 class GitWorkdir(Workdir):

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -13,7 +13,10 @@ from .utils import require_command
 from .utils import trace
 from .version import meta
 
-DEFAULT_DESCRIBE = "git describe --dirty --tags --long --match '*[0-9]*'"
+# If testing command in shell make sure to quote the match argument like
+# '*[0-9]*' as it will expand before being sent to git if there are any matching
+# files in current directory.
+DEFAULT_DESCRIBE = ["git", "describe", "--dirty", "--tags", "--long", "--match", "*[0-9]*"]
 
 
 class GitWorkdir(Workdir):


### PR DESCRIPTION
To fix #643. I do realize now that this isn't a real problem as it's used here since the command is not actually run through a shell but it did bite me when copying it to a CI script to check the version and shouldn't hurt.

Feel free to close the PR and issue if you don't think it's necessary though.