### PR TITLE
Update setup.py syntax so RuntimeError is properly raised

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ class bdist_egg(original_bdist_egg):
     def run(self):
         raise SystemExit(
             "%s is forbidden, "
-            "please update to setuptools>=45 which uses pip"
-            % type(self).__name__)
+            "please update to setuptools>=45 which uses pip" % type(self).__name__
+        )
 
 
 def scm_version():

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ from setuptools.command.bdist_egg import bdist_egg as original_bdist_egg
 class bdist_egg(original_bdist_egg):
     def run(self):
         raise SystemExit(
-            f"{type(self).__name__} is forbidden, "
+            "%s is forbidden, "
             "please update to setuptools>=45 which uses pip"
-        )
+            % type(self).__name__)
 
 
 def scm_version():


### PR DESCRIPTION
Something I noticed is that if you tried running setup.py with older versions of Python, you'd see:
```
  File "setup.py", line 22
    f"{type(self).__name__} is forbidden, "
                                          ^
SyntaxError: invalid syntax
```
I made a minor adjustment so that if someone was running Python 2.7 for instance, the proper exception gets raised:
```
RuntimeError: support for python < 3.6 has been removed in setuptools_scm>=6.0.0
```
I know support for older Python versions is deprecated, but I think it'd be a good fix so other developers are more aware of their mistake.