### PR TITLE
handle setuptools install deprecation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+6.3.4
+======
+
+* compatibility adjustments for setuptools >58
+
 6.3.3
 ======
 

--- a/testing/test_setuptools_support.py
+++ b/testing/test_setuptools_support.py
@@ -7,9 +7,21 @@ import subprocess
 import sys
 
 import pytest
-from virtualenv.run import cli_run
 
-pytestmark = pytest.mark.filterwarnings(r"ignore:.*tool\.setuptools_scm.*")
+
+def cli_run(*k, **kw):
+    """this defers the virtualenv import
+    it helps to avoid warnings from the furthermore imported setuptools
+    """
+    global cli_run
+    from virtualenv.run import cli_run
+
+    return cli_run(*k, **kw)
+
+
+pytestmark = pytest.mark.filterwarnings(
+    r"ignore:.*tool\.setuptools_scm.*", r"always:.*setup.py install is deprecated.*"
+)
 
 
 ROOT = pathlib.Path(__file__).parent.parent


### PR DESCRIPTION
* defer virtualenv imports to avoid import time warnings
* ensure tests warn instead of failing