### PR TITLE
Ensure UTC is used everywhere

### DIFF
--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -1,6 +1,5 @@
 import os
 import re
-import time
 import warnings
 from datetime import datetime
 from datetime import timezone
@@ -119,9 +118,11 @@ class ScmVersion:
         self.distance = distance
         self.node = node
         self.node_date = node_date
-        self.time = datetime.utcfromtimestamp(
-            int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
-        )
+        if "SOURCE_DATE_EPOCH" in os.environ:
+            date_epoch = int(os.environ["SOURCE_DATE_EPOCH"])
+            self.time = datetime.fromtimestamp(date_epoch, timezone.utc)
+        else:
+            self.time = datetime.now(timezone.utc)
         self._extra = kw
         self.dirty = dirty
         self.preformatted = preformatted

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -1,8 +1,9 @@
-import datetime
 import os
 import re
 import time
 import warnings
+from datetime import datetime
+from datetime import timezone
 from typing import Callable
 from typing import Iterator
 from typing import List
@@ -118,7 +119,7 @@ class ScmVersion:
         self.distance = distance
         self.node = node
         self.node_date = node_date
-        self.time = datetime.datetime.utcfromtimestamp(
+        self.time = datetime.utcfromtimestamp(
             int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
         )
         self._extra = kw
@@ -351,12 +352,13 @@ def guess_next_date_ver(version, node_date=None, date_fmt=None, version_cls=None
     # deduct date format if not provided
     if date_fmt is None:
         date_fmt = "%Y.%m.%d" if len(match.group("year")) == 4 else "%y.%m.%d"
-    head_date = node_date or datetime.date.today()
+    today = datetime.now(timezone.utc).date()
+    head_date = node_date or today
     # compute patch
     if match is None:
-        tag_date = datetime.date.today()
+        tag_date = today
     else:
-        tag_date = datetime.datetime.strptime(match.group("date"), date_fmt).date()
+        tag_date = datetime.strptime(match.group("date"), date_fmt).date()
     if tag_date == head_date:
         patch = "0" if match is None else (match.group("patch") or "0")
         patch = int(patch) + 1

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -2,6 +2,7 @@ import os
 import sys
 from datetime import date
 from datetime import datetime
+from datetime import timezone
 from os.path import join as opj
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -215,7 +216,7 @@ def test_git_dirty_notag(today, wd, monkeypatch):
     assert wd.version.startswith("0.1.dev1")
     if today:
         # the date on the tag is in UTC
-        tag = datetime.utcnow().date().strftime(".d%Y%m%d")
+        tag = datetime.now(timezone.utc).date().strftime(".d%Y%m%d")
     else:
         tag = ".d20090213"
     # we are dirty, check for the tag


### PR DESCRIPTION
## Motivation

I noticed recently that setuptools-scm code seem to use UTC in some places: https://github.com/pypa/setuptools_scm/blob/088c652ec755f0982b3705272a1e6aa3e07c71ef/src/setuptools_scm/version.py#L116

but the local date in others: https://github.com/pypa/setuptools_scm/blob/088c652ec755f0982b3705272a1e6aa3e07c71ef/src/setuptools_scm/version.py#L336

## Changes proposed in this PR:

- Change `datetime.date.today()` to its UTC version.
- Replace `utcnow` and `utcfromtimestamp` with explicit `timezone.utc`. This change is advised by Python's official documentation: [Ref1](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow), [Ref2](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp)