### PR TITLE
Stated which version of setuptools is required in the error message

### DIFF
--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -20,6 +20,7 @@ def _warn_on_old_setuptools(_version=setuptools.__version__):
 ERROR: setuptools=={_version} is used in combination with setuptools_scm>=6.x
 
 Your build configuration is incomplete and previously worked by accident!
+setuptools_scm requires setuptools>=45
 
 
 This happens as setuptools is unable to replace itself when a activated build dependency


### PR DESCRIPTION
At the moment the error message is very confusing if you have `setuptools>=42,<45`.  The message only mentions needing version `>= 42` but is triggered if `< 45`.  I don't know why `>= 45` is required. but at least we can state It's required in the error message.