### PR TITLE
Fix setuptools_scm installation instruction for pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ built step by specifying it as one of the build requirements.
 
     # pyproject.toml
     [build-system]
-    requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+    requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 
 
 That will be sufficient to require ``setuptools_scm`` for projects


### PR DESCRIPTION
I believe, `[toml]` extra dependency is crucial to make the recipe work.
At least I was unable to setup SCM using `pyproject.toml` only (without mentioning `setuptools_scm` in `setup.py`/`setup.cfg`).