### PR TITLE
Add test case for #548

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -50,11 +50,16 @@ jobs:
         # environment variable is too long. Consequently, we need to shorten PATH to
         # something minimal before we can install GnuPG. For further details, see
         # <https://github.com/actions/virtual-environments/issues/2876>.
+        #
+        # Additionally, we'll explicitly set `gpg.program` to ensure Git for Windows
+        # doesn't invoke the bundled GnuPG, otherwise we'll run into
+        # <https://dev.gnupg.org/T5504>. See also: <https://dev.gnupg.org/T3020>.
         run: |
-          $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\Chocolatey\bin"
+          $env:PATH = "C:\Program Files\Git\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\Chocolatey\bin"
           [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
           choco install gnupg -y --no-progress
           echo "C:\Program Files (x86)\gnupg\bin" >> $env:GITHUB_PATH
+          git config --system gpg.program "C:\Program Files (x86)\gnupg\bin\gpg.exe"
         if: runner.os == 'Windows'
       - run: pip install -U 'setuptools>=45'
         if: matrix.python_version != 'msys2'

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,6 +38,24 @@ jobs:
           msystem: MINGW64
           install: git mingw-w64-x86_64-python mingw-w64-x86_64-python-setuptools
           update: true
+      - name: Setup GnuPG
+        # At present, the Windows VMs only come with the copy of GnuPG that's bundled
+        # with Git for Windows. If we want to use this version _and_ be able to set
+        # arbitrary GnuPG home directories, then the test would need to figure out when
+        # to convert Windows-style paths into Unix-style paths with cygpath, which is
+        # unreasonable.
+        #
+        # Instead, we'll install a version of GnuPG that can handle Windows-style paths.
+        # However, due to <https://dev.gnupg.org/T5593>, installation fails if the PATH
+        # environment variable is too long. Consequently, we need to shorten PATH to
+        # something minimal before we can install GnuPG. For further details, see
+        # <https://github.com/actions/virtual-environments/issues/2876>.
+        run: |
+          $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\Chocolatey\bin"
+          [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
+          choco install gnupg -y --no-progress
+          echo "C:\Program Files (x86)\gnupg\bin" >> $env:GITHUB_PATH
+        if: runner.os == 'Windows'
       - run: pip install -U 'setuptools>=45'
         if: matrix.python_version != 'msys2'
       - run: pip install -e .[toml,test]

--- a/src/setuptools_scm/utils.py
+++ b/src/setuptools_scm/utils.py
@@ -8,6 +8,8 @@ import shlex
 import subprocess
 import sys
 import warnings
+from typing import List
+from typing import Optional
 
 
 DEBUG = bool(os.environ.get("SETUPTOOLS_SCM_DEBUG"))
@@ -118,9 +120,10 @@ def function_has_arg(fn, argname):
     return argname in argspec
 
 
-def has_command(name: str, warn: bool = True) -> bool:
+def has_command(name: str, args: Optional[List[str]] = None, warn: bool = True) -> bool:
     try:
-        p = _popen_pipes([name, "help"], ".")
+        cmd = [name, "help"] if args is None else [name, *args]
+        p = _popen_pipes(cmd, ".")
     except OSError:
         trace(*sys.exc_info())
         res = False

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -29,6 +29,7 @@ def pytest_addoption(parser):
 
 class Wd:
     commit_command = None
+    signed_commit_command = None
     add_command = None
 
     def __repr__(self):
@@ -61,19 +62,22 @@ class Wd:
         else:
             return given_reason
 
-    def add_and_commit(self, reason=None):
+    def add_and_commit(self, reason=None, **kwargs):
         self(self.add_command)
-        self.commit(reason)
+        self.commit(reason, **kwargs)
 
-    def commit(self, reason=None):
+    def commit(self, reason=None, signed=False):
         reason = self._reason(reason)
-        self(self.commit_command, reason=reason)
+        self(
+            self.commit_command if not signed else self.signed_commit_command,
+            reason=reason,
+        )
 
-    def commit_testfile(self, reason=None):
+    def commit_testfile(self, reason=None, **kwargs):
         reason = self._reason(reason)
         self.write("test.txt", "test {reason}", reason=reason)
         self(self.add_command)
-        self.commit(reason=reason)
+        self.commit(reason=reason, **kwargs)
 
     def get_version(self, **kw):
         __tracebackhide__ = True

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -414,7 +414,8 @@ def signed_commit_wd(tmp_path, monkeypatch, wd):
         """\
 %no-protection
 %transient-key
-Key-Type: default
+Key-Type: RSA
+Key-Length: 2048
 Name-Real: a test
 Name-Email: test@example.com
 Expire-Date: 0

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -406,7 +406,7 @@ def test_git_getdate_badgit(
 
 @pytest.fixture
 def signed_commit_wd(tmp_path, monkeypatch, wd):
-    if not has_command("gpg", warn=False):
+    if not has_command("gpg", args=["--version"], warn=False):
         pytest.skip("gpg executable not found")
 
     gpg_batch_params = tmp_path / "gpg_batch_params"


### PR DESCRIPTION
Per https://github.com/pypa/setuptools_scm/pull/681#issuecomment-1031365308, this PR adds a test case for #548. This test case is split into its own PR to demonstrate that it fails without #681.

<details><summary>Test failing</summary>

```
(venv) ubuntu@ephemeral:~/setuptools_scm$ pytest -v testing/test_git.py::test_git_getdate_signed_commit
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.8.10, pytest-7.0.0, pluggy-1.0.0 -- /home/ubuntu/setuptools_scm/venv/bin/python3
cachedir: .pytest_cache
setuptools version 60.8.1 from '/home/ubuntu/setuptools_scm/venv/lib/python3.8/site-packages/setuptools/__init__.py'
setuptools_scm version 6.4.3.dev10+gcc99e20 from '/home/ubuntu/setuptools_scm/src/setuptools_scm/__init__.py'
rootdir: /home/ubuntu/setuptools_scm, configfile: tox.ini
collected 1 item                                                                                                                                                                                           

testing/test_git.py::test_git_getdate_signed_commit FAILED                                                                                                                                           [100%]

================================================================================================= FAILURES =================================================================================================
______________________________________________________________________________________ test_git_getdate_signed_commit ______________________________________________________________________________________

signed_commit_wd = <WD /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd>

    @pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/548")
    def test_git_getdate_signed_commit(signed_commit_wd):
        today = date.today()
        signed_commit_wd.commit_testfile(signed=True)
        git_wd = git.GitWorkdir(os.fspath(signed_commit_wd.cwd))
>       assert git_wd.get_head_date() == today

testing/test_git.py:436: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/setuptools_scm/git.py:81: in get_head_date
    return datetime.strptime(date_part, r"%Y-%m-%d").date()
/usr/lib/python3.8/_strptime.py:568: in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

data_string = 'gpg: Signature made Mon Feb  7 14:41:13 2022 U', format = '%Y-%m-%d'

    def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
        """Return a 2-tuple consisting of a time struct and an int containing
        the number of microseconds based on the input string and the
        format string."""
    
        for index, arg in enumerate([data_string, format]):
            if not isinstance(arg, str):
                msg = "strptime() argument {} must be str, not {}"
                raise TypeError(msg.format(index, type(arg)))
    
        global _TimeRE_cache, _regex_cache
        with _cache_lock:
            locale_time = _TimeRE_cache.locale_time
            if (_getlang() != locale_time.lang or
                time.tzname != locale_time.tzname or
                time.daylight != locale_time.daylight):
                _TimeRE_cache = TimeRE()
                _regex_cache.clear()
                locale_time = _TimeRE_cache.locale_time
            if len(_regex_cache) > _CACHE_MAX_SIZE:
                _regex_cache.clear()
            format_regex = _regex_cache.get(format)
            if not format_regex:
                try:
                    format_regex = _TimeRE_cache.compile(format)
                # KeyError raised when a bad format is found; can be specified as
                # \\, in which case it was a stray % but with a space after it
                except KeyError as err:
                    bad_directive = err.args[0]
                    if bad_directive == "\\":
                        bad_directive = "%"
                    del err
                    raise ValueError("'%s' is a bad directive in format '%s'" %
                                        (bad_directive, format)) from None
                # IndexError only occurs when the format string is "%"
                except IndexError:
                    raise ValueError("stray %% in format '%s'" % format) from None
                _regex_cache[format] = format_regex
        found = format_regex.match(data_string)
        if not found:
>           raise ValueError("time data %r does not match format %r" %
                             (data_string, format))
E           ValueError: time data 'gpg: Signature made Mon Feb  7 14:41:13 2022 U' does not match format '%Y-%m-%d'

/usr/lib/python3.8/_strptime.py:349: ValueError
------------------------------------------------------------------------------------------ Captured stderr setup -------------------------------------------------------------------------------------------
cmd 'git init'
 in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd
out b'Initialized empty Git repository in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd/.git/\n'
cmd 'git config user.email test@example.com'
 in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd
cmd 'git config user.name "a test"'
 in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd
cmd 'gpg --batch --generate-key /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/gpg_batch_params'
 in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd
err b"gpg: keybox '/tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/pubring.kbx' created\ngpg: /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/trustdb.gpg: trustdb created\ngpg: key B5A97A7C6E04EEA4 marked as ultimately trusted\ngpg: directory '/tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/openpgp-revocs.d' created\ngpg: revocation certificate stored as '/tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/openpgp-revocs.d/803A90EF1466EC24ACC11420B5A97A7C6E04EEA4.rev'\n"
cmd 'git config log.showSignature true'
 in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd
------------------------------------------------------------------------------------------- Captured stderr call -------------------------------------------------------------------------------------------
cmd 'git add .'
 in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd
cmd 'git commit -S -m test-number-0'
 in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd
out b'[master (root-commit) 24a0d67] test-number-0\n 1 file changed, 1 insertion(+)\n create mode 100644 test.txt\n'
cmd 'git log -n 1 HEAD --format=%cI'
 in /tmp/pytest-of-ubuntu/pytest-19/test_git_getdate_signed_commit0/wd
out b'gpg: Signature made Mon Feb  7 14:41:13 2022 UTC\ngpg:                using RSA key 803A90EF1466EC24ACC11420B5A97A7C6E04EEA4\ngpg:                issuer "test@example.com"\ngpg: checking the trustdb\ngpg: marginals needed: 3  completes needed: 1  trust model: pgp\ngpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u\ngpg: Good signature from "a test <test@example.com>" [ultimate]\n2022-02-07T14:41:13+00:00\n'
========================================================================================= short test summary info ==========================================================================================
FAILED testing/test_git.py::test_git_getdate_signed_commit - ValueError: time data 'gpg: Signature made Mon Feb  7 14:41:13 2022 U' does not match format '%Y-%m-%d'
============================================================================================ 1 failed in 1.38s =============================================================================================
```
</details>

<details><summary>Test skipping (due to missing <code>gpg</code>)</summary>

```
(venv) ubuntu@ephemeral:~/setuptools_scm$ pytest -v testing/test_git.py::test_git_getdate_signed_commit
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.8.10, pytest-7.0.0, pluggy-1.0.0 -- /home/ubuntu/setuptools_scm/venv/bin/python3
cachedir: .pytest_cache
setuptools version 60.8.1 from '/home/ubuntu/setuptools_scm/venv/lib/python3.8/site-packages/setuptools/__init__.py'
setuptools_scm version 6.4.3.dev10+gcc99e20 from '/home/ubuntu/setuptools_scm/src/setuptools_scm/__init__.py'
rootdir: /home/ubuntu/setuptools_scm, configfile: tox.ini
collected 1 item                                                                                                                                                                                           

testing/test_git.py::test_git_getdate_signed_commit SKIPPED (gpg executable not found)                                                                                                               [100%]

============================================================================================ 1 skipped in 0.22s ============================================================================================
```
</details>

<details><summary>Test passing (due to #681)</summary>

```
(venv) ubuntu@ephemeral:~/setuptools_scm$ pytest -v testing/test_git.py::test_git_getdate_signed_commit
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.8.10, pytest-7.0.0, pluggy-1.0.0 -- /home/ubuntu/setuptools_scm/venv/bin/python3
cachedir: .pytest_cache
setuptools version 60.8.1 from '/home/ubuntu/setuptools_scm/venv/lib/python3.8/site-packages/setuptools/__init__.py'
setuptools_scm version 6.4.3.dev10+gcc99e20 from '/home/ubuntu/setuptools_scm/src/setuptools_scm/__init__.py'
rootdir: /home/ubuntu/setuptools_scm, configfile: tox.ini
collected 1 item                                                                                                                                                                                           

testing/test_git.py::test_git_getdate_signed_commit PASSED                                                                                                                                           [100%]

============================================================================================ 1 passed in 1.54s =============================================================================================
```
</details>