### PR TITLE
fix: empty environment variable breaks versioning

### DIFF
--- a/src/setuptools_scm/_overrides.py
+++ b/src/setuptools_scm/_overrides.py
@@ -29,7 +29,7 @@ def _read_pretended_version_for(config: Configuration) -> Optional[ScmVersion]:
     if pretended is None:
         pretended = os.environ.get(PRETEND_KEY)
 
-    if pretended is not None:
+    if pretended:
         # we use meta here since the pretended version
         # must adhere to the pep to begin with
         return meta(tag=pretended, preformatted=True, config=config)

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -90,6 +90,19 @@ setup(use_scm_version={"fallback_version": "12.34"})
     assert res == "12.34"
 
 
+def test_empty_pretend_version(tmpdir, monkeypatch):
+    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
+    monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION", "")
+    p = tmpdir.ensure("sub/package", dir=1)
+    p.join("setup.py").write(
+        """from setuptools import setup
+setup(use_scm_version={"fallback_version": "12.34"})
+"""
+    )
+    res = do((sys.executable, "setup.py", "--version"), p)
+    assert res == "12.34"
+
+
 @pytest.mark.parametrize(
     "version", ["1.0", "1.2.3.dev1+ge871260", "1.2.3.dev15+ge871260.d20180625", "2345"]
 )

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -103,6 +103,20 @@ setup(use_scm_version={"fallback_version": "12.34"})
     assert res == "12.34"
 
 
+def test_empty_pretend_version_named(tmpdir, monkeypatch):
+    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
+    monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION", "1.23")
+    monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MYSCM", "")
+    p = tmpdir.ensure("sub/package", dir=1)
+    p.join("setup.py").write(
+        """from setuptools import setup
+setup(name="myscm", use_scm_version={"fallback_version": "12.34"})
+"""
+    )
+    res = do((sys.executable, "setup.py", "--version"), p)
+    assert res == "12.34"
+
+
 @pytest.mark.parametrize(
     "version", ["1.0", "1.2.3.dev1+ge871260", "1.2.3.dev15+ge871260.d20180625", "2345"]
 )


### PR DESCRIPTION
`pretended` should only have an effect if it is set to something - anything, even `"0"`, but not if it's an empty string. This restores that behavior instead of setting 0.0.0 automatically.

If `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_X` is an empty string, this will also cause the native behavior to be restored, giving a way to unset the `SETUPTOOLS_SCM_PRETEND_VERSION` for a single package.

If you want `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_X=""` to cause `SETUPTOOLS_SCM_PRETEND_VERSION` to be used instead, as if it was undefined, that could be done as well, it would require one more explicit None check to be broadened above.


Assuming git = 1.0, `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_X=""`,  `SETUPTOOLS_SCM_PRETEND_VERSION="2.0"`, this PR would produce 2.0 for everything except X, which would get 1.0. The alternative mentioned above would produce 2.0 for everything, including X.