### PR TITLE
Stop suggesting to put wheel in `pyproject.toml`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ built step by specifying it as one of the build requirements.
 
     # pyproject.toml
     [build-system]
-    requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
+    requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 
 
 That will be sufficient to require ``setuptools_scm`` for projects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=45",
-    "wheel",
     "tomli>=1.0",
     "packaging>=20.0"
 ]

--- a/testing/test_setuptools_support.py
+++ b/testing/test_setuptools_support.py
@@ -122,7 +122,7 @@ setup(use_scm_version={"write_to": "pkg_version.py"})
 PYPROJECT_TOML_WITH_KEY = """
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>45", "wheel"]  # PEP 508 specifications.
+requires = ["setuptools>45"]  # PEP 508 specifications.
 [tool.setuptools_scm]
 write_to = "pkg_version.py"
 """


### PR DESCRIPTION
This is a known misconception that it's necessary. It's actually been
automatically exposed by `setuptools.build_meta` since it got
introduced.

Ref: https://github.com/pypa/setuptools/pull/3056.