### PR TITLE
Delay setting default Configuration root

### DIFF
--- a/src/setuptools_scm/__main__.py
+++ b/src/setuptools_scm/__main__.py
@@ -10,12 +10,10 @@ from setuptools_scm.integration import find_files
 
 def main() -> None:
     opts = _get_cli_opts()
-    root = opts.root or "."
 
     try:
-        pyproject = opts.config or _find_pyproject(root)
-        root = opts.root or os.path.relpath(os.path.dirname(pyproject))
-        config = Configuration.from_file(pyproject, root=root)
+        pyproject = opts.config or _find_pyproject(opts.root or ".")
+        config = Configuration.from_file(pyproject, root=opts.root)
     except (LookupError, FileNotFoundError) as ex:
         # no pyproject.toml OR no [tool.setuptools_scm]
         print(
@@ -24,7 +22,7 @@ def main() -> None:
             f" Reason: {ex}.",
             file=sys.stderr,
         )
-        config = Configuration(root=root)
+        config = Configuration(root=opts.root or ".")
 
     version = _get_version(config)
     assert version is not None

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -179,7 +179,8 @@ class Configuration:
     @classmethod
     def from_file(
         cls,
-        name: str = "pyproject.toml",
+        name: str = "./pyproject.toml",
+        root = None,
         dist_name=None,  # type: str | None
         _load_toml=_lazy_tomli_load,
         **kwargs,
@@ -212,6 +213,14 @@ class Configuration:
                 dist_name = defn["project"].get("name")
         if dist_name is None:
             dist_name = _read_dist_name_from_setup_cfg()
+
+        if root is not None:
+            # Supercede config file root with parameter
+            section["root"] = root
+        else:
+            if "root" not in section:
+                # Set root to directory of pyproject.toml
+                section["root"] = os.path.relpath(os.path.dirname(name))
 
         return cls(dist_name=dist_name, **section, **kwargs)
 

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -180,7 +180,7 @@ class Configuration:
     def from_file(
         cls,
         name: str = "./pyproject.toml",
-        root = None,
+        root=None,
         dist_name=None,  # type: str | None
         _load_toml=_lazy_tomli_load,
         **kwargs,


### PR DESCRIPTION
I have experienced the same issue reported in #691. This change is intended to fix it.

As far as I can tell, in projects where `pyproject.toml` is not in the root, `pip install` will not work without `root` (and `relative_to`) defined in the `pyproject.toml`, but if it is defined in `pyproject.toml` then `python -m setuptools_scm` will not work - it gives a duplicate keyword argument error:

```
▶ python -m setuptools_scm 
Traceback (most recent call last):
  File "/dls_sw/prod/tools/RHEL7-x86_64/Python3/3-7-2dls1/prefix/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/dls_sw/prod/tools/RHEL7-x86_64/Python3/3-7-2dls1/prefix/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/scratch/development/setuptools_scm/src/setuptools_scm/__main__.py", line 83, in <module>
    main()
  File "/scratch/development/setuptools_scm/src/setuptools_scm/__main__.py", line 18, in main
    config = Configuration.from_file(pyproject, root=root)
  File "/scratch/development/setuptools_scm/src/setuptools_scm/config.py", line 216, in from_file
    return cls(dist_name=dist_name, **section, **kwargs)
TypeError: type object got multiple values for keyword argument 'root'
```

The problem is that it falls back to the setting root to be the same directory as `pyproject.toml` if `--root` is not passed as an option and passes that into `Configuration.from_file`, so `root` appears in both `**section` and `**kwargs` in `cls()` call.

This change moves the setting of this default down into `Configuration.from_file`, so that it can check if it already has a root from the config file. The effect is that `--root` will supercede the config file, but if `--root` is not passed and it exists in the config file, it will use that (where currently it throws an error). The behaviour of using `--root` (or `"."` if it is not given) to search for the config file and to create the default Configuration is maintained.

Fixes #691 