### PR TITLE
Use --git-dir to avoid issues with CVE-2022-24765 mitigation

### DIFF
--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -95,6 +95,7 @@ def test_parse_call_order(wd):
 
 
 @pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/707")
+@pytest.mark.xfail(run=False, reason="This test requires passwordless sudo")
 def test_not_owner(wd):
     git_dir = opj(wd.cwd)
     original_stat = os.stat(git_dir)


### PR DESCRIPTION
This is a possible solution to https://github.com/pypa/setuptools_scm/issues/707 by explicitly passing `--git-dir=$PWD/.git` (which bypasses auto-discovery and therefore the vulnerability).

I've tried to add a test for this in b8dcd7a25d00443495bc91037eb6e5d9a8796c43. Obviously it has to change ownership to a non-existant user so it needs to use `sudo` but I don't particularly like it. I can refactor if you have better ideas or drop the test entirely if you'd prefer.