### PR TITLE
add importlib_resources to setup_requires for Python < 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     setuptools
     tomli>=1.0.0 # keep in sync
     typing-extensions
-    importlib-metadata; python_version < "3.8"
+    importlib-metadata;python_version < "3.8"
 python_requires = >=3.7
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     setuptools
     tomli>=1.0.0 # keep in sync
     typing-extensions
+    importlib-metadata; python_version < "3.8"
 python_requires = >=3.7
 package_dir =
     =src


### PR DESCRIPTION
https://github.com/pypa/setuptools_scm/blob/d57a5546d9c054e55972b475d5a346cbdd0c874a/src/setuptools_scm/_entrypoints.py#L74