### PR TITLE
minimize bootstrap - fixes #722 and #722

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+v7.0.2
+======
+
+* fix #723 and #722: remove bootstrap dependencies
+* bugfix: ensure we read the distribution name from setup.cfg
+  if needed even for pyproject
+*
+
 v7.0.1
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=45",
-    "tomli>=1.0",
     "packaging>=20.0",
-    "typing_extensions",
-    "importlib_metadata",
 ]
 build-backend = "setuptools.build_meta"

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -10,7 +10,6 @@ from typing import Any
 from typing import Callable
 from typing import TYPE_CHECKING
 
-from . import _types as _t
 from ._entrypoints import _call_entrypoint_fn
 from ._entrypoints import _version_from_entrypoints
 from ._overrides import _read_pretended_version_for
@@ -33,6 +32,7 @@ from .version import ScmVersion
 if TYPE_CHECKING:
     from typing import NoReturn
 
+    from . import _types as _t
 
 TEMPLATES = {
     ".py": """\

--- a/src/setuptools_scm/_types.py
+++ b/src/setuptools_scm/_types.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 from typing import Callable
 from typing import List
-from typing import NamedTuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
@@ -20,12 +19,6 @@ PathT = Union["os.PathLike[str]", str]
 CMD_TYPE: TypeAlias = Union[List[str], str]
 
 VERSION_SCHEME = Union[str, Callable[["version.ScmVersion"], str]]
-
-
-class CmdResult(NamedTuple):
-    out: str
-    err: str
-    returncode: int
 
 
 class EntrypointProtocol(Protocol):

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -12,13 +12,13 @@ from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
 
-from . import _types as _t
 from ._version_cls import NonNormalizedVersion
 from ._version_cls import Version
 from .utils import trace
 
 
 if TYPE_CHECKING:
+    from . import _types as _t
     from setuptools_scm.version import ScmVersion
 
 DEFAULT_TAG_REGEX = r"^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$"

--- a/src/setuptools_scm/discover.py
+++ b/src/setuptools_scm/discover.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import os
 from typing import Iterable
 from typing import Iterator
+from typing import TYPE_CHECKING
 
-from . import _types as _t
+if TYPE_CHECKING:
+    from . import _types as _t
 from .config import Configuration
 from .utils import trace
 

--- a/src/setuptools_scm/file_finder.py
+++ b/src/setuptools_scm/file_finder.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
+    from . import _types as _t
 
-from . import _types as _t
 from .utils import trace
 
 

--- a/src/setuptools_scm/file_finder_git.py
+++ b/src/setuptools_scm/file_finder_git.py
@@ -5,12 +5,16 @@ import os
 import subprocess
 import tarfile
 from typing import IO
+from typing import TYPE_CHECKING
 
-from . import _types as _t
 from .file_finder import is_toplevel_acceptable
 from .file_finder import scm_find_files
 from .utils import do_ex
 from .utils import trace
+
+if TYPE_CHECKING:
+    from . import _types as _t
+
 
 log = logging.getLogger(__name__)
 

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -11,9 +11,9 @@ from os.path import samefile
 from typing import Callable
 from typing import TYPE_CHECKING
 
-from . import _types as _t
 from .config import Configuration
 from .scm_workdir import Workdir
+from .utils import _CmdResult
 from .utils import data_from_mime
 from .utils import do_ex
 from .utils import require_command
@@ -23,6 +23,8 @@ from .version import ScmVersion
 from .version import tags_to_versions
 
 if TYPE_CHECKING:
+    from . import _types as _t
+
     from setuptools_scm.hg_git import GitWorkdirHgClient
 
 REF_TAG_RE = re.compile(r"(?<=\btag: )([^,]+)\b")
@@ -72,7 +74,7 @@ class GitWorkdir(Workdir):
 
         return cls(real_wd)
 
-    def do_ex_git(self, cmd: list[str]) -> _t.CmdResult:
+    def do_ex_git(self, cmd: list[str]) -> _CmdResult:
         return self.do_ex(["git", "--git-dir", join(self.path, ".git")] + cmd)
 
     def is_dirty(self) -> bool:
@@ -120,7 +122,7 @@ class GitWorkdir(Workdir):
         revs, _, _ = self.do_ex_git(["rev-list", "HEAD"])
         return revs.count("\n") + 1
 
-    def default_describe(self) -> _t.CmdResult:
+    def default_describe(self) -> _CmdResult:
         git_dir = join(self.path, ".git")
         return self.do_ex(
             DEFAULT_DESCRIBE[:1] + ["--git-dir", git_dir] + DEFAULT_DESCRIBE[1:]

--- a/src/setuptools_scm/hacks.py
+++ b/src/setuptools_scm/hacks.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
-from . import _types as _t
+if TYPE_CHECKING:
+    from . import _types as _t
 from .config import Configuration
 from .utils import data_from_mime
 from .utils import trace

--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import datetime
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from . import _types as _t
 from ._version_cls import Version
 from .config import Configuration
 from .scm_workdir import Workdir
@@ -15,6 +15,9 @@ from .utils import trace
 from .version import meta
 from .version import ScmVersion
 from .version import tag_to_version
+
+if TYPE_CHECKING:
+    from . import _types as _t
 
 
 class HgWorkdir(Workdir):

--- a/src/setuptools_scm/hg_git.py
+++ b/src/setuptools_scm/hg_git.py
@@ -8,12 +8,13 @@ from datetime import datetime
 from . import _types as _t
 from .git import GitWorkdir
 from .hg import HgWorkdir
+from .utils import _CmdResult
 from .utils import do_ex
 from .utils import require_command
 from .utils import trace
 
 
-_FAKE_GIT_DESCRIBE_ERROR = _t.CmdResult("<>hg git failed", "", 1)
+_FAKE_GIT_DESCRIBE_ERROR = _CmdResult("<>hg git failed", "", 1)
 
 
 class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
@@ -94,7 +95,7 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
         revs, _, _ = self.do_ex(["hg", "log", "-r", "ancestors(.)", "-T", "."])
         return len(revs)
 
-    def default_describe(self) -> _t.CmdResult:
+    def default_describe(self) -> _CmdResult:
         """
         Tentative to reproduce the output of
 
@@ -142,4 +143,4 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
         if self.is_dirty():
             desc += "-dirty"
         trace("desc", desc)
-        return _t.CmdResult(desc, "", 0)
+        return _CmdResult(desc, "", 0)

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -4,17 +4,20 @@ import os
 import warnings
 from typing import Any
 from typing import Callable
+from typing import TYPE_CHECKING
 
 import setuptools
 
 from . import _get_version
-from . import _types as _t
 from . import _version_missing
 from ._entrypoints import iter_entry_points
 from .config import _read_dist_name_from_setup_cfg
 from .config import Configuration
 from .utils import do
 from .utils import trace
+
+if TYPE_CHECKING:
+    from . import _types as _t
 
 
 def _warn_on_old_setuptools(_version: str = setuptools.__version__) -> None:

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -19,8 +19,6 @@ from .utils import trace
 if TYPE_CHECKING:
     from . import _types as _t
 
-_SKIP_PYPROJECT_HACK = False
-
 
 def _warn_on_old_setuptools(_version: str = setuptools.__version__) -> None:
     if int(_version.split(".")[0]) < 45:

--- a/src/setuptools_scm/integration.py
+++ b/src/setuptools_scm/integration.py
@@ -19,6 +19,8 @@ from .utils import trace
 if TYPE_CHECKING:
     from . import _types as _t
 
+_SKIP_PYPROJECT_HACK = False
+
 
 def _warn_on_old_setuptools(_version: str = setuptools.__version__) -> None:
     if int(_version.split(".")[0]) < 45:
@@ -107,7 +109,11 @@ def infer_version(dist: setuptools.Distribution) -> None:
         vars(dist.metadata),
     )
     dist_name = dist.metadata.name
+    if dist_name is None:
+        dist_name = _read_dist_name_from_setup_cfg()
     if not os.path.isfile("pyproject.toml"):
+        return
+    if dist_name == "setuptools_scm":
         return
     try:
         config = Configuration.from_file(dist_name=dist_name)

--- a/src/setuptools_scm/scm_workdir.py
+++ b/src/setuptools_scm/scm_workdir.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from typing import ClassVar
+from typing import TYPE_CHECKING
 
-from . import _types as _t
+from .utils import _CmdResult
 from .utils import do
 from .utils import do_ex
 from .utils import require_command
+
+if TYPE_CHECKING:
+    from . import _types as _t
 
 
 class Workdir:
@@ -15,7 +19,7 @@ class Workdir:
         require_command(self.COMMAND)
         self.path = path
 
-    def do_ex(self, cmd: _t.CMD_TYPE) -> _t.CmdResult:
+    def do_ex(self, cmd: _t.CMD_TYPE) -> _CmdResult:
         return do_ex(cmd, cwd=self.path)
 
     def do(self, cmd: _t.CMD_TYPE) -> str:

--- a/src/setuptools_scm/utils.py
+++ b/src/setuptools_scm/utils.py
@@ -13,11 +13,21 @@ from types import CodeType
 from types import FunctionType
 from typing import Iterator
 from typing import Mapping
+from typing import NamedTuple
+from typing import TYPE_CHECKING
 
-from . import _types as _t
+if TYPE_CHECKING:
+
+    from . import _types as _t
 
 DEBUG = bool(os.environ.get("SETUPTOOLS_SCM_DEBUG"))
 IS_WINDOWS = platform.system() == "Windows"
+
+
+class _CmdResult(NamedTuple):
+    out: str
+    err: str
+    returncode: int
 
 
 def no_git_env(env: Mapping[str, str]) -> dict[str, str]:
@@ -69,7 +79,7 @@ def _run(cmd: _t.CMD_TYPE, cwd: _t.PathT) -> subprocess.CompletedProcess[bytes]:
     )
 
 
-def do_ex(cmd: _t.CMD_TYPE, cwd: _t.PathT = ".") -> _t.CmdResult:
+def do_ex(cmd: _t.CMD_TYPE, cwd: _t.PathT = ".") -> _CmdResult:
     trace("cmd", repr(cmd))
     trace(" in", cwd)
     if os.name == "posix" and not isinstance(cmd, (list, tuple)):
@@ -82,7 +92,7 @@ def do_ex(cmd: _t.CMD_TYPE, cwd: _t.PathT = ".") -> _t.CmdResult:
         trace("err", repr(res.stderr))
     if res.returncode:
         trace("ret", res.returncode)
-    return _t.CmdResult(
+    return _CmdResult(
         ensure_stripped_str(res.stdout), ensure_stripped_str(res.stderr), res.returncode
     )
 

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -19,7 +19,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing_extensions import Concatenate
 
-from . import _types as _t
+    from . import _types as _t
+
 from ._version_cls import Version as PkgVersion
 from .config import Configuration
 from .config import _VersionT

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{37,38,39,310}-{test,selfcheck},check_readme,check-dist
+envlist=py{37,38,39,310}-{test,selfcheck},check_readme,check-dist,check-bootstrap
 
 [pytest]
 testpaths=testing
@@ -55,6 +55,14 @@ commands=
     python -m build
     twine check dist/*
 
+[testenv:check-bootstrap]
+deps =
+    setuptools > 45
+    packaging>20
+skip_install = true
+recreate = true
+commands =
+  python setup.py bdist_wheel
 
 
 #XXX: envs for hg versions


### PR DESCRIPTION
enable self-bootstrap without typing_extensions and importlib_metadata

they are still install requirements however

fixes #722
fixes #723 