### PR TITLE
fix #728: remove git arguments that triggered wrong branch names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
+v7.0.3
+=======
+* fix mercurial usage when pip primes a isolated environment
+* fix regression for branch names on git + add a test
+
 v7.0.2
-======
+=======
 
 * fix #723 and #722: remove bootstrap dependencies
 * bugfix: ensure we read the distribution name from setup.cfg

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -82,10 +82,10 @@ class GitWorkdir(Workdir):
         return bool(out)
 
     def get_branch(self) -> str | None:
-        branch, err, ret = self.do_ex_git(["rev-parse", "--abbrev-ref", "HEAD", "--"])
+        branch, err, ret = self.do_ex_git(["rev-parse", "--abbrev-ref", "HEAD"])
         if ret:
             trace("branch err", branch, err, ret)
-            branch, err, ret = self.do_ex_git(["symbolic-ref", "--short", "HEAD", "--"])
+            branch, err, ret = self.do_ex_git(["symbolic-ref", "--short", "HEAD"])
             if ret:
                 trace("branch err (symbolic-ref)", branch, err, ret)
                 return None

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -378,6 +378,14 @@ def test_git_archive_run_from_subdirectory(
     assert integration.find_files(".") == [opj(".", "test1.txt")]
 
 
+@pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/728")
+def test_git_branch_names_correct(wd: WorkDir) -> None:
+    wd.commit_testfile()
+    wd("git checkout -b test/fun")
+    wd_git = git.GitWorkdir(os.fspath(wd.cwd))
+    assert wd_git.get_branch() == "test/fun"
+
+
 def test_git_feature_branch_increments_major(wd: WorkDir) -> None:
     wd.commit_testfile()
     wd("git tag 1.0.0")


### PR DESCRIPTION
also added a test that will catch this