### PR TITLE
fix #738: protect relative_to of Configuration.from_file

### DIFF
--- a/src/setuptools_scm/_integration/pyproject_reading.py
+++ b/src/setuptools_scm/_integration/pyproject_reading.py
@@ -18,6 +18,7 @@ TOML_LOADER: TypeAlias = Callable[[str], TOML_RESULT]
 
 
 class PyProjectData(NamedTuple):
+    name: str
     tool_name: str
     project: TOML_RESULT
     section: TOML_RESULT
@@ -48,7 +49,7 @@ def read_pyproject(
     except LookupError as e:
         raise LookupError(f"{name} does not contain a tool.{tool_name} section") from e
     project = defn.get("project", {})
-    return PyProjectData(tool_name, project, section)
+    return PyProjectData(name, tool_name, project, section)
 
 
 def get_args_for_pyproject(
@@ -59,7 +60,13 @@ def get_args_for_pyproject(
     """drops problematic details and figures the distribution name"""
     section = pyproject.section.copy()
     kwargs = kwargs.copy()
-
+    if "relative_to" in section:
+        relative = section.pop("relative_to")
+        warnings.warn(
+            f"{pyproject.name}: at [tool.{pyproject.tool_name}]\n"
+            f"ignoring value relative_to={relative!r}"
+            " as its always relative to the config file"
+        )
     if "dist_name" in section:
         if dist_name is None:
             dist_name = section.pop("dist_name")

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -51,3 +51,26 @@ def test_config_regex_init() -> None:
     tag_regex = re.compile(r"v(\d+)")
     conf = Configuration(tag_regex=tag_regex)
     assert conf.tag_regex is tag_regex
+
+
+def test_config_from_file_protects_relative_to(tmp_path: Path) -> None:
+    fn = tmp_path / "pyproject.toml"
+    fn.write_text(
+        textwrap.dedent(
+            """
+            [tool.setuptools_scm]
+            relative_to = "dont_use_me"
+            [project]
+            description = "Factory ⸻ A code generator 🏭"
+            authors = [{name = "Łukasz Langa"}]
+            """
+        ),
+        encoding="utf-8",
+    )
+    with pytest.warns(
+        UserWarning,
+        match=".*pyproject.toml: at \\[tool.setuptools_scm\\]\n"
+        "ignoring value relative_to='dont_use_me'"
+        " as its always relative to the config file",
+    ):
+        assert Configuration.from_file(str(fn))


### PR DESCRIPTION
users assumed it makes sense to use in the configfile,
where we actually have to use the config file name itself as ancor

closes #738 