### PR TITLE
Fix #743: Allow entrypoints in `parse_scm`

### DIFF
--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -82,7 +82,7 @@ def dump_version(
 
 
 def _get_parse_function(
-    parse: Union[MaybeConfigFunction, str],
+    parse: MaybeConfigFunction | str,
 ) -> MaybeConfigFunction:
     if callable(parse):
         return parse

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from ._entrypoints import _call_entrypoint_fn
 from ._entrypoints import _version_from_entrypoints
+from ._entrypoints import iter_entry_points
 from ._overrides import _read_pretended_version_for
 from ._overrides import PRETEND_KEY
 from ._overrides import PRETEND_KEY_NAMED
@@ -30,9 +31,10 @@ from .version import meta
 from .version import ScmVersion
 
 if TYPE_CHECKING:
-    from typing import NoReturn
+    from typing import NoReturn, Union
 
     from . import _types as _t
+    from ._entrypoints import MaybeConfigFunction
 
 TEMPLATES = {
     ".py": """\
@@ -80,11 +82,11 @@ def dump_version(
 
 
 def _get_parse_function(
-    parse: Union[_entrypoints.MaybeConfigFunction, str],
-) -> _entrypoints.MaybeConfigFunction:
+    parse: Union[MaybeConfigFunction, str],
+) -> MaybeConfigFunction:
     if callable(parse):
         return parse
-    eps = _entrypoints.iter_entry_points("setuptools_scm.parse_scm", parse)
+    eps = iter_entry_points("setuptools_scm.parse_scm", parse)
     try:
         [parse_ep] = eps
     except ValueError:

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -86,11 +86,11 @@ def _get_parse_function(
         return parse
     eps  = _entrypoints.iter_entry_points("setuptools_scm.parse_scm", parse)
     try:
-        [parse_fn] = eps
+        [parse_ep] = eps
     except ValueError:
         return lambda root, config=None: None
     else:
-        return parse_fn
+        return parse_ep.load()
 
 
 def _do_parse(config: Configuration) -> ScmVersion | None:

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -84,7 +84,7 @@ def _get_parse_function(
 ) -> _entrypoints.MaybeConfigFunction:
     if callable(parse):
         return parse
-    eps  = _entrypoints.iter_entry_points("setuptools_scm.parse_scm", parse)
+    eps = _entrypoints.iter_entry_points("setuptools_scm.parse_scm", parse)
     try:
         [parse_ep] = eps
     except ValueError:

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -57,6 +57,11 @@ def test_root_parameter_creation(monkeypatch: pytest.MonkeyPatch) -> None:
     setuptools_scm.get_version()
 
 
+def test_parse_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert_root(monkeypatch, os.getcwd())
+    setuptools_scm.get_version(parse=".git")
+
+
 def test_version_from_scm(wd: WorkDir) -> None:
     with pytest.warns(DeprecationWarning, match=".*version_from_scm.*"):
         setuptools_scm.version_from_scm(str(wd))


### PR DESCRIPTION
Unit test  added.

Full test:

```
$ git tag
1.0.0
$ python -m build --no-isolation --sdist|tail -1
...
Successfully built UNKNOWN-1.0.0.tar.gz
$  cat pyproject.toml 
[build-system]
requires = ["setuptools", "setuptools_scm"]
build-backend = "setuptools.build_meta"

[tool.setuptools_scm]
parse = ".git"
```