### PR TITLE
Rename license_file to license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/pypa/setuptools_scm/
 author = Ronny Pfannschmidt
 author_email = opensource@ronnypfannschmidt.de
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ url = https://github.com/pypa/setuptools_scm/
 author = Ronny Pfannschmidt
 author_email = opensource@ronnypfannschmidt.de
 license = MIT
+license_file = LICENSE
 license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Rename license_file to license_files

This fixes a deprecation warning.
