### PR TITLE
Fix "not enough values to unpack" when parsing .git_archival.txt from a tagged commit; also fix #759

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,4 @@
 node: $Format:%H$
 node-date: $Format:%cI$
-describe-name: $Format:%(describe)$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ref-names: $Format:%D$

--- a/README.rst
+++ b/README.rst
@@ -316,7 +316,7 @@ and copy-paste this into it::
 
     node: $Format:%H$
     node-date: $Format:%cI$
-    describe-name: $Format:%(describe:tags=true)$
+    describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
     ref-names: $Format:%D$
 
 Create the ``.gitattributes`` file in the root directory of your repository

--- a/src/setuptools_scm/.git_archival.txt
+++ b/src/setuptools_scm/.git_archival.txt
@@ -1,4 +1,4 @@
 node: $Format:%H$
 node-date: $Format:%cI$
-describe-name: $Format:%(describe)$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ref-names: $Format:%D$

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -232,9 +232,11 @@ def _git_parse_inner(
     )
 
 
-def _git_parse_describe(describe_output: str) -> tuple[str, int, str, bool]:
+def _git_parse_describe(describe_output: str) -> tuple[str, int | None, str | None, bool]:
     # 'describe_output' looks e.g. like 'v1.5.0-0-g4060507' or
     # 'v1.15.1rc1-37-g9bd1298-dirty'.
+    # It may also just be a bare tag name if this is a tagged commit and we are
+    # parsing a .git_archival.txt file.
 
     if describe_output.endswith("-dirty"):
         dirty = True
@@ -242,8 +244,15 @@ def _git_parse_describe(describe_output: str) -> tuple[str, int, str, bool]:
     else:
         dirty = False
 
-    tag, number, node = describe_output.rsplit("-", 2)
-    return tag, int(number), node, dirty
+    split = describe_output.rsplit("-", 2)
+    if len(split) < 3:  # probably a tagged commit
+        tag = describe_output
+        number = None
+        node = None
+    else:
+        tag, number_, node = split
+        number = int(number_)
+    return tag, number, node, dirty
 
 
 def search_parent(dirname: _t.PathT) -> GitWorkdir | None:

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -232,7 +232,9 @@ def _git_parse_inner(
     )
 
 
-def _git_parse_describe(describe_output: str) -> tuple[str, int | None, str | None, bool]:
+def _git_parse_describe(
+    describe_output: str,
+) -> tuple[str, int | None, str | None, bool]:
     # 'describe_output' looks e.g. like 'v1.5.0-0-g4060507' or
     # 'v1.15.1rc1-37-g9bd1298-dirty'.
     # It may also just be a bare tag name if this is a tagged commit and we are

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -523,6 +523,7 @@ def test_git_getdate_signed_commit(signed_commit_wd: WorkDir) -> None:
         ("0.0", {"node": "0" * 20}),
         ("1.2.2", {"describe-name": "release-1.2.2-0-g00000"}),
         ("1.2.2.dev0", {"ref-names": "tag: release-1.2.2.dev"}),
+        ("1.2.2", {"describe-name": "v1.2.2"}),
     ],
 )
 @pytest.mark.filterwarnings("ignore:git archive did not support describe output")


### PR DESCRIPTION
Given `.git_archival.txt` content like this:

    node: 3634907645428b9542cfb4fd1ceef08f14526cb8
    node-date: 2022-10-13T20:38:09-06:00
    describe-name: v0.0.5
    ref-names: HEAD -> main, tag: v0.0.5

setuptools_scm fails with an exception like this:

```console
$ python3 -m setuptools_scm
Traceback (most recent call last):
  [..snip..]
  File ".../setuptools_scm/git.py", line 312, in parse_archival
    return archival_to_version(data, config=config)
  File ".../setuptools_scm/git.py", line 286, in archival_to_version
    tag, number, node, _ = _git_parse_describe(archival_describe)
  File ".../setuptools_scm/git.py", line 245, in _git_parse_describe
    tag, number, node = describe_output.rsplit("-", 2)
ValueError: not enough values to unpack (expected 3, got 1)
```

The problem here is that the describe-name field is "v0.0.5" instead of
something like "v0.0.5-0-g3634907", so the tuple unpacking fails.

So, it works correctly with untagged versions of the repo:

```console
$ tmpdir=$(mktemp -d)
$ git archive HEAD | tar -C "$tmpdir" -xf -
$ ( cd "$tmpdir" ; python3 -m setuptools_scm )
0.0.1.dev7+gb03bd8b
```

But if we tag the repo and create another archive, the exception occurs:

```console
$ git tag v0.0.1 HEAD
$ tmpdir=$(mktemp -d)
$ git archive HEAD | tar -C "$tmpdir" -xf -
$ ( cd "$tmpdir" ; python3 -m setuptools_scm )
Traceback (most recent call last):
  [..snip..]
  File "/usr/lib/python3/dist-packages/setuptools_scm/git.py", line 316, in parse_archival
    return archival_to_version(data, config=config)
  File "/usr/lib/python3/dist-packages/setuptools_scm/git.py", line 290, in archival_to_version
    tag, number, node, _ = _git_parse_describe(archival_describe)
  File "/usr/lib/python3/dist-packages/setuptools_scm/git.py", line 245, in _git_parse_describe
    tag, number, node = describe_output.rsplit("-", 2)
ValueError: not enough values to unpack (expected 3, got 1)
```

Version information:

```console
$ pip show setuptools_scm | grep ^Version
Version: 7.0.5
$ dpkg -s python3-setuptools-scm | grep ^Version
Version: 7.0.5-1
```

The first commit of the pull-request proposes a fix for that.

The second commit fixes #759.
