### PR TITLE
Use fallback_version in repos when git/hg is not available.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,9 @@
 
+next
+====
+
+* fallback_version is also used in repositories if the corresponding SCM command is not available
+
 v7.0.5
 =======
 

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -16,6 +16,7 @@ from .scm_workdir import Workdir
 from .utils import _CmdResult
 from .utils import data_from_mime
 from .utils import do_ex
+from .utils import has_command
 from .utils import require_command
 from .utils import trace
 from .version import meta
@@ -175,6 +176,8 @@ def parse(
     """
     if not config:
         config = Configuration(root=root)
+    if config.fallback_version is not None and not has_command("git", warn=False):
+        return None
 
     wd = get_working_directory(config)
     if wd:

--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -10,6 +10,7 @@ from .config import Configuration
 from .scm_workdir import Workdir
 from .utils import data_from_mime
 from .utils import do_ex
+from .utils import has_command
 from .utils import require_command
 from .utils import trace
 from .version import meta
@@ -146,6 +147,8 @@ class HgWorkdir(Workdir):
 def parse(root: _t.PathT, config: Configuration | None = None) -> ScmVersion | None:
     if not config:
         config = Configuration(root=root)
+    if config.fallback_version is not None and not has_command("hg", warn=False):
+        return None
 
     if os.path.exists(os.path.join(root, ".hg/git")):
         paths, _, ret = do_ex("hg path", root)

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -98,6 +98,24 @@ setup(use_scm_version={"fallback_version": "12.34"})
     assert res == "12.34"
 
 
+@pytest.mark.parametrize("scm", ["git", "hg"])
+def test_fallback_scm_absent(
+    scm: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
+    p = tmp_path / "sub/package"
+    p.mkdir(parents=True)
+    p.joinpath("setup.py").write_text(
+        """from setuptools import setup
+setup(use_scm_version={"fallback_version": "12.34"})
+"""
+    )
+    monkeypatch.setenv("PATH", "")
+    p.joinpath(f".{scm}").mkdir()
+    res = do([sys.executable, "setup.py", "--version"], p)
+    assert res == "12.34"
+
+
 def test_empty_pretend_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION", "")


### PR DESCRIPTION
Closes #549.