### PR TITLE
Clarify pip+git install example

### DIFF
--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -113,7 +113,7 @@ def _version_missing(config: Configuration) -> NoReturn:
         "metadata and will not work.\n\n"
         "For example, if you're using pip, instead of "
         "https://github.com/user/proj/archive/master.zip "
-        "use git+https://github.com/user/proj.git#egg=proj"
+        "use git+https://github.com/user/proj.git@master#egg=proj"
     )
 
 


### PR DESCRIPTION
The example does not clarify how to install a specific revision with the required method.