### PR TITLE
Add `strip-dev` as `get_version` argument

### DIFF
--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -134,6 +134,7 @@ def get_version(
     version_cls: Any | None = None,
     normalize: bool = True,
     search_parent_directories: bool = False,
+    strip_dev: bool = False,
 ) -> str:
     """
     If supplied, relative_to should be a file from which root may
@@ -165,6 +166,9 @@ def _get_version(config: Configuration) -> str | None:
             write_to=config.write_to,
             template=config.write_to_template,
         )
+
+    if config.strip_dev:
+        version_string = version_string.partition(".dev")[0]
 
     return version_string
 

--- a/src/setuptools_scm/_cli.py
+++ b/src/setuptools_scm/_cli.py
@@ -32,11 +32,10 @@ def main(args: list[str] | None = None) -> None:
         )
         config = Configuration(inferred_root)
 
+    config.strip_dev = opts.strip_dev
     version = _get_version(config)
     if version is None:
         raise SystemExit("ERROR: no version found for", opts)
-    if opts.strip_dev:
-        version = version.partition(".dev")[0]
     print(version)
 
     if opts.command == "ls":
@@ -60,8 +59,10 @@ def _get_cli_opts(args: list[str] | None) -> argparse.Namespace:
         "--config",
         default=None,
         metavar="PATH",
-        help="path to 'pyproject.toml' with setuptools_scm config, "
-        "default: looked up in the current or parent directories",
+        help=(
+            "path to 'pyproject.toml' with setuptools_scm config, "
+            "default: looked up in the current or parent directories"
+        ),
     )
     parser.add_argument(
         "--strip-dev",

--- a/src/setuptools_scm/config.py
+++ b/src/setuptools_scm/config.py
@@ -131,6 +131,7 @@ class Configuration:
         version_cls: type[_VersionT] | type | str | None = None,
         normalize: bool = True,
         search_parent_directories: bool = False,
+        strip_dev: bool = False,
     ):
         # TODO:
         self._relative_to = None if relative_to is None else os.fspath(relative_to)
@@ -152,6 +153,8 @@ class Configuration:
         self.parent = None
 
         self.version_cls = _validate_version_cls(version_cls, normalize)
+
+        self.strip_dev = strip_dev
 
     @property
     def fallback_root(self) -> str:

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -138,6 +138,24 @@ def test_pretended(version: str, monkeypatch: pytest.MonkeyPatch) -> None:
     assert setuptools_scm.get_version() == version
 
 
+@pytest.mark.parametrize(
+    ["version", "striped_version"],
+    [
+        ["1.0", "1.0"],
+        ["1.2.3.dev1+ge871260", "1.2.3"],
+        ["1.2.3.dev15+ge871260.d20180625", "1.2.3"],
+        ["2345", "2345"],
+        ["1.2.3.rc0.dev1+ge871260", "1.2.3.rc0"],
+        ["1.2.3.rc1.dev15+ge871260.d20180625", "1.2.3.rc1"],
+    ],
+)
+def test_strip_dev(
+    version: str, striped_version: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(setuptools_scm.PRETEND_KEY, version)
+    assert setuptools_scm.get_version(strip_dev=True) == striped_version
+
+
 def test_root_relative_to(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     tmp_path.joinpath("setup.cfg").touch()
     assert_root(monkeypatch, str(tmp_path / "alt"))


### PR DESCRIPTION
Hi, I'm @dariocurr and I am part of @buildnn.

We are trying to integrate `setuptools-scm` into our CI/CD, and it would be really helpful if we could use the `strip-dev` option through the python interface as well as from the CLI. That's why, with a few modifications, I made it possible.

I added some tests to make sure everything works as it should