### PR TITLE
Makes .py output black compliant

### DIFF
--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -62,10 +62,11 @@ def dump_version(
     version_tuple = _version_as_tuple(version)
 
     if ext == ".py":
-        template = template.replace("'", '"')
-
-    with target.open("w") as fp:
-        fp.write(template.format(version=version, version_tuple=version_tuple))
+        with target.open("w") as fp:
+            fp.write(template.format(version=version, version_tuple=version_tuple).replace("'", '"'))
+    else:
+        with target.open("w") as fp:
+            fp.write(template.format(version=version, version_tuple=version_tuple))
 
 
 def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
@@ -78,9 +79,7 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
     if config.parse:
         parse_result = config.parse(config.absolute_root, config=config)
         if isinstance(parse_result, str):
-            raise TypeError(
-                f"version parse result was {str!r}\nplease return a parsed version"
-            )
+            raise TypeError(f"version parse result was {str!r}\nplease return a parsed version")
 
         if parse_result:
             assert isinstance(parse_result, ScmVersion)
@@ -89,9 +88,7 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
             parsed_version = _version_from_entrypoints(config, fallback=True)
     else:
         # include fallbacks after dropping them from the main entrypoint
-        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(
-            config, fallback=True
-        )
+        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(config, fallback=True)
 
     return parsed_version
 

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -4,7 +4,7 @@
 """
 from __future__ import annotations
 
-import os
+from pathlib import Path
 import re
 from typing import Any
 from typing import Pattern
@@ -46,8 +46,8 @@ def dump_version(
     template: str | None = None,
 ) -> None:
     assert isinstance(version, str)
-    target = os.path.normpath(os.path.join(root, write_to))
-    ext = os.path.splitext(target)[1]
+    target = Path(root) / Path(write_to)
+    ext = target.suffix
     template = template or TEMPLATES.get(ext)
     from ._trace import trace
 
@@ -55,13 +55,14 @@ def dump_version(
     if template is None:
         raise ValueError(
             "bad file format: '{}' (of {}) \nonly *.txt and *.py are supported".format(
-                os.path.splitext(target)[1], target
+                ext,
+                target,
             )
         )
     version_tuple = _version_as_tuple(version)
 
-    with open(target, "w") as fp:
-        fp.write(template.format(version=version, version_tuple=version_tuple))
+    with target.open("w") as fp:
+        fp.write(template.format(version=version, version_tuple=version_tuple).replace(".", '"'))
 
 
 def _do_parse(config: Configuration) -> _t.SCMVERSION | None:

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -78,7 +78,9 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
     if config.parse:
         parse_result = config.parse(config.absolute_root, config=config)
         if isinstance(parse_result, str):
-            raise TypeError(f"version parse result was {str!r}\nplease return a parsed version")
+            raise TypeError(
+                f"version parse result was {str!r}\nplease return a parsed version"
+            )
 
         if parse_result:
             assert isinstance(parse_result, ScmVersion)
@@ -87,7 +89,9 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
             parsed_version = _version_from_entrypoints(config, fallback=True)
     else:
         # include fallbacks after dropping them from the main entrypoint
-        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(config, fallback=True)
+        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(
+            config, fallback=True
+        )
 
     return parsed_version
 

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -62,7 +62,11 @@ def dump_version(
     version_tuple = _version_as_tuple(version)
 
     with target.open("w") as fp:
-        fp.write(template.format(version=version, version_tuple=version_tuple).replace("'", '"'))
+        fp.write(
+            template.format(version=version, version_tuple=version_tuple).replace(
+                "'", '"'
+            )
+        )
 
 
 def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
@@ -75,7 +79,9 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
     if config.parse:
         parse_result = config.parse(config.absolute_root, config=config)
         if isinstance(parse_result, str):
-            raise TypeError(f"version parse result was {str!r}\nplease return a parsed version")
+            raise TypeError(
+                f"version parse result was {str!r}\nplease return a parsed version"
+            )
 
         if parse_result:
             assert isinstance(parse_result, ScmVersion)
@@ -84,7 +90,9 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
             parsed_version = _version_from_entrypoints(config, fallback=True)
     else:
         # include fallbacks after dropping them from the main entrypoint
-        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(config, fallback=True)
+        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(
+            config, fallback=True
+        )
 
     return parsed_version
 

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -63,7 +63,11 @@ def dump_version(
 
     if ext == ".py":
         with target.open("w") as fp:
-            fp.write(template.format(version=version, version_tuple=version_tuple).replace("'", '"'))
+            fp.write(
+                template.format(version=version, version_tuple=version_tuple).replace(
+                    "'", '"'
+                )
+            )
     else:
         with target.open("w") as fp:
             fp.write(template.format(version=version, version_tuple=version_tuple))
@@ -79,7 +83,9 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
     if config.parse:
         parse_result = config.parse(config.absolute_root, config=config)
         if isinstance(parse_result, str):
-            raise TypeError(f"version parse result was {str!r}\nplease return a parsed version")
+            raise TypeError(
+                f"version parse result was {str!r}\nplease return a parsed version"
+            )
 
         if parse_result:
             assert isinstance(parse_result, ScmVersion)
@@ -88,7 +94,9 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
             parsed_version = _version_from_entrypoints(config, fallback=True)
     else:
         # include fallbacks after dropping them from the main entrypoint
-        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(config, fallback=True)
+        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(
+            config, fallback=True
+        )
 
     return parsed_version
 

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -62,11 +62,7 @@ def dump_version(
     version_tuple = _version_as_tuple(version)
 
     with target.open("w") as fp:
-        fp.write(
-            template.format(version=version, version_tuple=version_tuple).replace(
-                ".", '"'
-            )
-        )
+        fp.write(template.format(version=version, version_tuple=version_tuple).replace("'", '"'))
 
 
 def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
@@ -79,9 +75,7 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
     if config.parse:
         parse_result = config.parse(config.absolute_root, config=config)
         if isinstance(parse_result, str):
-            raise TypeError(
-                f"version parse result was {str!r}\nplease return a parsed version"
-            )
+            raise TypeError(f"version parse result was {str!r}\nplease return a parsed version")
 
         if parse_result:
             assert isinstance(parse_result, ScmVersion)
@@ -90,9 +84,7 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
             parsed_version = _version_from_entrypoints(config, fallback=True)
     else:
         # include fallbacks after dropping them from the main entrypoint
-        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(
-            config, fallback=True
-        )
+        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(config, fallback=True)
 
     return parsed_version
 

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -4,8 +4,8 @@
 """
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Any
 from typing import Pattern
 from typing import TYPE_CHECKING
@@ -62,7 +62,11 @@ def dump_version(
     version_tuple = _version_as_tuple(version)
 
     with target.open("w") as fp:
-        fp.write(template.format(version=version, version_tuple=version_tuple).replace(".", '"'))
+        fp.write(
+            template.format(version=version, version_tuple=version_tuple).replace(
+                ".", '"'
+            )
+        )
 
 
 def _do_parse(config: Configuration) -> _t.SCMVERSION | None:

--- a/src/setuptools_scm/__init__.py
+++ b/src/setuptools_scm/__init__.py
@@ -61,12 +61,11 @@ def dump_version(
         )
     version_tuple = _version_as_tuple(version)
 
+    if ext == ".py":
+        template = template.replace("'", '"')
+
     with target.open("w") as fp:
-        fp.write(
-            template.format(version=version, version_tuple=version_tuple).replace(
-                "'", '"'
-            )
-        )
+        fp.write(template.format(version=version, version_tuple=version_tuple))
 
 
 def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
@@ -79,9 +78,7 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
     if config.parse:
         parse_result = config.parse(config.absolute_root, config=config)
         if isinstance(parse_result, str):
-            raise TypeError(
-                f"version parse result was {str!r}\nplease return a parsed version"
-            )
+            raise TypeError(f"version parse result was {str!r}\nplease return a parsed version")
 
         if parse_result:
             assert isinstance(parse_result, ScmVersion)
@@ -90,9 +87,7 @@ def _do_parse(config: Configuration) -> _t.SCMVERSION | None:
             parsed_version = _version_from_entrypoints(config, fallback=True)
     else:
         # include fallbacks after dropping them from the main entrypoint
-        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(
-            config, fallback=True
-        )
+        parsed_version = _version_from_entrypoints(config) or _version_from_entrypoints(config, fallback=True)
 
     return parsed_version
 

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -58,9 +58,7 @@ def test_root_parameter_creation(monkeypatch: pytest.MonkeyPatch) -> None:
     setuptools_scm.get_version()
 
 
-def test_root_parameter_pass_by(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_root_parameter_pass_by(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert_root(monkeypatch, os.fspath(tmp_path))
     setuptools_scm.get_version(root=os.fspath(tmp_path))
     setuptools_scm.get_version(
@@ -108,9 +106,7 @@ setup(use_scm_version={"fallback_version": "12.34"})
     assert res.stdout == "12.34"
 
 
-def test_empty_pretend_version_named(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_empty_pretend_version_named(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION", "1.23")
     monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MYSCM", "")
@@ -126,9 +122,7 @@ setup(name="myscm", use_scm_version={"fallback_version": "12.34"})
     assert res.stdout == "12.34"
 
 
-@pytest.mark.parametrize(
-    "version", ["1.0", "1.2.3.dev1+ge871260", "1.2.3.dev15+ge871260.d20180625", "2345"]
-)
+@pytest.mark.parametrize("version", ["1.0", "1.2.3.dev1+ge871260", "1.2.3.dev15+ge871260.d20180625", "2345"])
 def test_pretended(version: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(setuptools_scm.PRETEND_KEY, version)
     assert setuptools_scm.get_version() == version
@@ -162,21 +156,18 @@ def test_dump_version(tmp_path: Path) -> None:
 
     dump_version(tmp_path, "1.0.dev42", "first.py")
     lines = read("first.py").splitlines()
-    assert "__version__ = version = '1.0.dev42'" in lines
-    assert "__version_tuple__ = version_tuple = (1, 0, 'dev42')" in lines
+    assert '__version__ = version = "1.0.dev42"' in lines
+    assert '__version_tuple__ = version_tuple = (1, 0, "dev42")' in lines
 
     dump_version(tmp_path, "1.0.1+g4ac9d2c", "second.py")
     lines = read("second.py").splitlines()
-    assert "__version__ = version = '1.0.1+g4ac9d2c'" in lines
-    assert "__version_tuple__ = version_tuple = (1, 0, 1, 'g4ac9d2c')" in lines
+    assert '__version__ = version = "1.0.1+g4ac9d2c"' in lines
+    assert '__version_tuple__ = version_tuple = (1, 0, 1, "g4ac9d2c")' in lines
 
     dump_version(tmp_path, "1.2.3.dev18+gb366d8b.d20210415", "third.py")
     lines = read("third.py").splitlines()
-    assert "__version__ = version = '1.2.3.dev18+gb366d8b.d20210415'" in lines
-    assert (
-        "__version_tuple__ = version_tuple = (1, 2, 3, 'dev18', 'gb366d8b.d20210415')"
-        in lines
-    )
+    assert '__version__ = version = "1.2.3.dev18+gb366d8b.d20210415"' in lines
+    assert '__version_tuple__ = version_tuple = (1, 2, 3, "dev18", "gb366d8b.d20210415")' in lines
 
     import ast
 

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -58,7 +58,9 @@ def test_root_parameter_creation(monkeypatch: pytest.MonkeyPatch) -> None:
     setuptools_scm.get_version()
 
 
-def test_root_parameter_pass_by(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_root_parameter_pass_by(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     assert_root(monkeypatch, os.fspath(tmp_path))
     setuptools_scm.get_version(root=os.fspath(tmp_path))
     setuptools_scm.get_version(
@@ -106,7 +108,9 @@ setup(use_scm_version={"fallback_version": "12.34"})
     assert res.stdout == "12.34"
 
 
-def test_empty_pretend_version_named(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_empty_pretend_version_named(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION", "1.23")
     monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MYSCM", "")
@@ -122,7 +126,9 @@ setup(name="myscm", use_scm_version={"fallback_version": "12.34"})
     assert res.stdout == "12.34"
 
 
-@pytest.mark.parametrize("version", ["1.0", "1.2.3.dev1+ge871260", "1.2.3.dev15+ge871260.d20180625", "2345"])
+@pytest.mark.parametrize(
+    "version", ["1.0", "1.2.3.dev1+ge871260", "1.2.3.dev15+ge871260.d20180625", "2345"]
+)
 def test_pretended(version: str, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(setuptools_scm.PRETEND_KEY, version)
     assert setuptools_scm.get_version() == version
@@ -167,7 +173,10 @@ def test_dump_version(tmp_path: Path) -> None:
     dump_version(tmp_path, "1.2.3.dev18+gb366d8b.d20210415", "third.py")
     lines = read("third.py").splitlines()
     assert '__version__ = version = "1.2.3.dev18+gb366d8b.d20210415"' in lines
-    assert '__version_tuple__ = version_tuple = (1, 2, 3, "dev18", "gb366d8b.d20210415")' in lines
+    assert (
+        '__version_tuple__ = version_tuple = (1, 2, 3, "dev18", "gb366d8b.d20210415")'
+        in lines
+    )
 
     import ast
 

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -27,7 +27,9 @@ from setuptools_scm.git import archival_to_version
 from setuptools_scm.utils import has_command
 from setuptools_scm.version import format_version
 
-pytestmark = pytest.mark.skipif(not has_command("git", warn=False), reason="git executable not found")
+pytestmark = pytest.mark.skipif(
+    not has_command("git", warn=False), reason="git executable not found"
+)
 
 
 @pytest.fixture(name="wd")
@@ -50,7 +52,9 @@ def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch, debug_mode: DebugMode) -> W
         ("17.33.0-rc-17-g38c3047c0", "17.33.0-rc", 17, "g38c3047c0", False),
     ],
 )
-def test_parse_describe_output(given: str, tag: str, number: int, node: str, dirty: bool) -> None:
+def test_parse_describe_output(
+    given: str, tag: str, number: int, node: str, dirty: bool
+) -> None:
     parsed = git._git_parse_describe(given)
     assert parsed == (tag, number, node, dirty)
 
@@ -69,7 +73,9 @@ setup(use_scm_version={"root": "../..",
     assert res.stdout == "0.1.dev0"
 
 
-def test_root_search_parent_directories(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_root_search_parent_directories(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     p = wd.cwd.joinpath("sub/package")
     p.mkdir(parents=True)
@@ -110,11 +116,15 @@ def test_not_owner(wd: WorkDir) -> None:
     if not shutil.which("sudo"):
         pytest.skip("sudo executable not found")
 
-    proc = subprocess.run(["sudo", "chown", "-R", "12345", git_dir], stdin=subprocess.DEVNULL)
+    proc = subprocess.run(
+        ["sudo", "chown", "-R", "12345", git_dir], stdin=subprocess.DEVNULL
+    )
     if proc.returncode != 0:
         pytest.skip("Failed to change ownership, is passwordless sudo available?")
     try:
-        subprocess.run(["sudo", "chmod", "a+r", git_dir], stdin=subprocess.DEVNULL, check=True)
+        subprocess.run(
+            ["sudo", "chmod", "a+r", git_dir], stdin=subprocess.DEVNULL, check=True
+        )
         subprocess.run(
             ["sudo", "chgrp", "-R", "12345", git_dir],
             stdin=subprocess.DEVNULL,
@@ -159,7 +169,9 @@ def test_version_from_git(wd: WorkDir) -> None:
 
     wd.commit_testfile()
     wd("git tag version-0.2.post210+gbe48adfpost3+g0cc25f2")
-    with pytest.warns(UserWarning, match="tag '.*' will be stripped of its suffix '.*'"):
+    with pytest.warns(
+        UserWarning, match="tag '.*' will be stripped of its suffix '.*'"
+    ):
         assert wd.version.startswith("0.2")
 
     wd.commit_testfile()
@@ -169,7 +181,10 @@ def test_version_from_git(wd: WorkDir) -> None:
     # custom normalization
     assert wd.get_version(normalize=False) == "17.33.0-rc"
     assert wd.get_version(version_cls=NonNormalizedVersion) == "17.33.0-rc"
-    assert wd.get_version(version_cls="setuptools_scm.NonNormalizedVersion") == "17.33.0-rc"
+    assert (
+        wd.get_version(version_cls="setuptools_scm.NonNormalizedVersion")
+        == "17.33.0-rc"
+    )
 
 
 setup_py_with_normalize: dict[str, str] = {
@@ -203,7 +218,9 @@ setup_py_with_normalize: dict[str, str] = {
     "setup_py_txt",
     [pytest.param(text, id=key) for key, text in setup_py_with_normalize.items()],
 )
-def test_git_version_unnormalized_setuptools(setup_py_txt: str, wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_git_version_unnormalized_setuptools(
+    setup_py_txt: str, wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """
     Test that when integrating with setuptools without normalization,
     the version is not normalized in write_to files,
@@ -244,7 +261,9 @@ def test_git_worktree(wd: WorkDir) -> None:
 
 @pytest.mark.issue(86)
 @pytest.mark.parametrize("today", [False, True])
-def test_git_dirty_notag(today: bool, wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_git_dirty_notag(
+    today: bool, wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
     if today:
         monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
     wd.commit_testfile()
@@ -282,7 +301,9 @@ def shallow_wd(wd: WorkDir, tmp_path: Path) -> Path:
     return target
 
 
-def test_git_parse_shallow_warns(shallow_wd: Path, recwarn: pytest.WarningsRecorder) -> None:
+def test_git_parse_shallow_warns(
+    shallow_wd: Path, recwarn: pytest.WarningsRecorder
+) -> None:
     git.parse(str(shallow_wd), Configuration())
     msg = recwarn.pop()
     assert "is shallow and may cause errors" in str(msg.message)
@@ -293,7 +314,9 @@ def test_git_parse_shallow_fail(shallow_wd: Path) -> None:
         git.parse(str(shallow_wd), Configuration(), pre_parse=git.fail_on_shallow)
 
 
-def test_git_shallow_autocorrect(shallow_wd: Path, recwarn: pytest.WarningsRecorder) -> None:
+def test_git_shallow_autocorrect(
+    shallow_wd: Path, recwarn: pytest.WarningsRecorder
+) -> None:
     git.parse(str(shallow_wd), Configuration(), pre_parse=git.fetch_on_shallow)
     msg = recwarn.pop()
     assert "git fetch was used to rectify" in str(msg.message)
@@ -320,7 +343,9 @@ def test_alphanumeric_tags_match(wd: WorkDir) -> None:
     assert wd.version.startswith("0.1.dev1+g")
 
 
-def test_git_archive_export_ignore(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_git_archive_export_ignore(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
     wd.write("test1.txt", "test")
     wd.write("test2.txt", "test")
     wd.write(
@@ -342,11 +367,15 @@ def test_git_archive_subdirectory(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) 
     wd("git add foobar")
     wd.commit()
     monkeypatch.chdir(wd.cwd)
-    assert setuptools_scm._file_finders.find_files(".") == [opj(".", "foobar", "test1.txt")]
+    assert setuptools_scm._file_finders.find_files(".") == [
+        opj(".", "foobar", "test1.txt")
+    ]
 
 
 @pytest.mark.issue(251)
-def test_git_archive_run_from_subdirectory(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_git_archive_run_from_subdirectory(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
     os.mkdir(wd.cwd / "foobar")
     wd.write("foobar/test1.txt", "test")
     wd("git add foobar")
@@ -505,7 +534,12 @@ def test_git_archival_to_version(expected: str, from_data: dict[str, str]) -> No
     config = Configuration()
     version = archival_to_version(from_data, config=config)
     assert version is not None
-    assert format_version(version, version_scheme="guess-next-dev", local_scheme="node-and-date") == expected
+    assert (
+        format_version(
+            version, version_scheme="guess-next-dev", local_scheme="node-and-date"
+        )
+        == expected
+    )
 
 
 @pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/727")

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -27,9 +27,7 @@ from setuptools_scm.git import archival_to_version
 from setuptools_scm.utils import has_command
 from setuptools_scm.version import format_version
 
-pytestmark = pytest.mark.skipif(
-    not has_command("git", warn=False), reason="git executable not found"
-)
+pytestmark = pytest.mark.skipif(not has_command("git", warn=False), reason="git executable not found")
 
 
 @pytest.fixture(name="wd")
@@ -52,9 +50,7 @@ def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch, debug_mode: DebugMode) -> W
         ("17.33.0-rc-17-g38c3047c0", "17.33.0-rc", 17, "g38c3047c0", False),
     ],
 )
-def test_parse_describe_output(
-    given: str, tag: str, number: int, node: str, dirty: bool
-) -> None:
+def test_parse_describe_output(given: str, tag: str, number: int, node: str, dirty: bool) -> None:
     parsed = git._git_parse_describe(given)
     assert parsed == (tag, number, node, dirty)
 
@@ -73,9 +69,7 @@ setup(use_scm_version={"root": "../..",
     assert res.stdout == "0.1.dev0"
 
 
-def test_root_search_parent_directories(
-    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_root_search_parent_directories(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     p = wd.cwd.joinpath("sub/package")
     p.mkdir(parents=True)
@@ -116,15 +110,11 @@ def test_not_owner(wd: WorkDir) -> None:
     if not shutil.which("sudo"):
         pytest.skip("sudo executable not found")
 
-    proc = subprocess.run(
-        ["sudo", "chown", "-R", "12345", git_dir], stdin=subprocess.DEVNULL
-    )
+    proc = subprocess.run(["sudo", "chown", "-R", "12345", git_dir], stdin=subprocess.DEVNULL)
     if proc.returncode != 0:
         pytest.skip("Failed to change ownership, is passwordless sudo available?")
     try:
-        subprocess.run(
-            ["sudo", "chmod", "a+r", git_dir], stdin=subprocess.DEVNULL, check=True
-        )
+        subprocess.run(["sudo", "chmod", "a+r", git_dir], stdin=subprocess.DEVNULL, check=True)
         subprocess.run(
             ["sudo", "chgrp", "-R", "12345", git_dir],
             stdin=subprocess.DEVNULL,
@@ -169,9 +159,7 @@ def test_version_from_git(wd: WorkDir) -> None:
 
     wd.commit_testfile()
     wd("git tag version-0.2.post210+gbe48adfpost3+g0cc25f2")
-    with pytest.warns(
-        UserWarning, match="tag '.*' will be stripped of its suffix '.*'"
-    ):
+    with pytest.warns(UserWarning, match="tag '.*' will be stripped of its suffix '.*'"):
         assert wd.version.startswith("0.2")
 
     wd.commit_testfile()
@@ -181,10 +169,7 @@ def test_version_from_git(wd: WorkDir) -> None:
     # custom normalization
     assert wd.get_version(normalize=False) == "17.33.0-rc"
     assert wd.get_version(version_cls=NonNormalizedVersion) == "17.33.0-rc"
-    assert (
-        wd.get_version(version_cls="setuptools_scm.NonNormalizedVersion")
-        == "17.33.0-rc"
-    )
+    assert wd.get_version(version_cls="setuptools_scm.NonNormalizedVersion") == "17.33.0-rc"
 
 
 setup_py_with_normalize: dict[str, str] = {
@@ -218,9 +203,7 @@ setup_py_with_normalize: dict[str, str] = {
     "setup_py_txt",
     [pytest.param(text, id=key) for key, text in setup_py_with_normalize.items()],
 )
-def test_git_version_unnormalized_setuptools(
-    setup_py_txt: str, wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_git_version_unnormalized_setuptools(setup_py_txt: str, wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Test that when integrating with setuptools without normalization,
     the version is not normalized in write_to files,
@@ -236,6 +219,7 @@ def test_git_version_unnormalized_setuptools(
 
     # setuptools still normalizes using packaging.Version (removing the dash)
     res = wd([sys.executable, "setup.py", "--version"])
+    print(f"res : {res}")
     assert res == "17.33.0rc1"
 
     # but the version tag in the file is non-normalized (with the dash)
@@ -260,9 +244,7 @@ def test_git_worktree(wd: WorkDir) -> None:
 
 @pytest.mark.issue(86)
 @pytest.mark.parametrize("today", [False, True])
-def test_git_dirty_notag(
-    today: bool, wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_git_dirty_notag(today: bool, wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
     if today:
         monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
     wd.commit_testfile()
@@ -300,9 +282,7 @@ def shallow_wd(wd: WorkDir, tmp_path: Path) -> Path:
     return target
 
 
-def test_git_parse_shallow_warns(
-    shallow_wd: Path, recwarn: pytest.WarningsRecorder
-) -> None:
+def test_git_parse_shallow_warns(shallow_wd: Path, recwarn: pytest.WarningsRecorder) -> None:
     git.parse(str(shallow_wd), Configuration())
     msg = recwarn.pop()
     assert "is shallow and may cause errors" in str(msg.message)
@@ -313,9 +293,7 @@ def test_git_parse_shallow_fail(shallow_wd: Path) -> None:
         git.parse(str(shallow_wd), Configuration(), pre_parse=git.fail_on_shallow)
 
 
-def test_git_shallow_autocorrect(
-    shallow_wd: Path, recwarn: pytest.WarningsRecorder
-) -> None:
+def test_git_shallow_autocorrect(shallow_wd: Path, recwarn: pytest.WarningsRecorder) -> None:
     git.parse(str(shallow_wd), Configuration(), pre_parse=git.fetch_on_shallow)
     msg = recwarn.pop()
     assert "git fetch was used to rectify" in str(msg.message)
@@ -342,9 +320,7 @@ def test_alphanumeric_tags_match(wd: WorkDir) -> None:
     assert wd.version.startswith("0.1.dev1+g")
 
 
-def test_git_archive_export_ignore(
-    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_git_archive_export_ignore(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
     wd.write("test1.txt", "test")
     wd.write("test2.txt", "test")
     wd.write(
@@ -366,15 +342,11 @@ def test_git_archive_subdirectory(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) 
     wd("git add foobar")
     wd.commit()
     monkeypatch.chdir(wd.cwd)
-    assert setuptools_scm._file_finders.find_files(".") == [
-        opj(".", "foobar", "test1.txt")
-    ]
+    assert setuptools_scm._file_finders.find_files(".") == [opj(".", "foobar", "test1.txt")]
 
 
 @pytest.mark.issue(251)
-def test_git_archive_run_from_subdirectory(
-    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_git_archive_run_from_subdirectory(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
     os.mkdir(wd.cwd / "foobar")
     wd.write("foobar/test1.txt", "test")
     wd("git add foobar")
@@ -533,12 +505,7 @@ def test_git_archival_to_version(expected: str, from_data: dict[str, str]) -> No
     config = Configuration()
     version = archival_to_version(from_data, config=config)
     assert version is not None
-    assert (
-        format_version(
-            version, version_scheme="guess-next-dev", local_scheme="node-and-date"
-        )
-        == expected
-    )
+    assert format_version(version, version_scheme="guess-next-dev", local_scheme="node-and-date") == expected
 
 
 @pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/727")


### PR DESCRIPTION
Closes #482

* Replaces single with double quotes in output.
* Updates tests in light of this.