### PR TITLE
Bump `pypa/gh-action-pypi-publish` to `release/v1`

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -116,7 +116,6 @@ jobs:
         name: Packages
         path: dist
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
         password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
`master` is long-outdated and hasn't gotten any updates for quite a while now.