### PR TITLE
Normalize the dist-name, as per PEP503, when looking for overrides

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ breaking
   and where hiding dirty states that are now explicitly dirty
 * depend on later importlib for the full selectable api
 * move setuptools integration code to private sub-package
+* use normalized dist names for the SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${DIST_NAME}
 
 features
 --------

--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ Note that running this Dockerfile requires docker with BuildKit enabled
 `[docs] <https://github.com/moby/buildkit/blob/v0.8.3/frontend/dockerfile/docs/syntax.md>`_.
 
 To avoid BuildKit and mounting of the .git folder altogether, one can also pass the desired
-version as a build argument. Note that ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${UPPERCASED_DIST_NAME}``
+version as a build argument. Note that ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME}``
 is preferred over ``SETUPTOOLS_SCM_PRETEND_VERSION``.
 
 
@@ -500,12 +500,15 @@ Environment variables
 :SETUPTOOLS_SCM_PRETEND_VERSION:
     when defined and not empty,
     its used as the primary source for the version number
-    in which case it will be a unparsed string
+    in which case it will be an unparsed string
 
-:SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${UPPERCASED_DIST_NAME}:
+:SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME}:
     when defined and not empty,
     its used as the primary source for the version number
-    in which case it will be a unparsed string
+    in which case it will be an unparsed string
+
+    the dist name normalization follows adapted PEP-503 semantics, with one or
+    more of ".-_" being replaced by a single "_", and the name being upper-cased
 
     it takes precedence over ``SETUPTOOLS_SCM_PRETEND_VERSION``
 

--- a/src/setuptools_scm/_overrides.py
+++ b/src/setuptools_scm/_overrides.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 from . import _config
@@ -18,7 +19,10 @@ def read_named_env(
     *, tool: str = "SETUPTOOLS_SCM", name: str, dist_name: str | None
 ) -> str | None:
     if dist_name is not None:
-        val = os.environ.get(f"{tool}_{name}_FOR_{dist_name.upper()}")
+        # Normalize the dist name as per PEP 503.
+        normalized_dist_name = re.sub(r"[-_.]+", "-", dist_name)
+        env_var_dist_name = normalized_dist_name.replace("-", "_").upper()
+        val = os.environ.get(f"{tool}_{name}_FOR_{env_var_dist_name}")
         if val is not None:
             return val
     return os.environ.get(f"{tool}_{name}")

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -84,7 +84,7 @@ def test_config_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
             [tool.setuptools_scm]
             root = "."
             [project]
-            name = "test_a"
+            name = "teSt-.a"
             """
         ),
         encoding="utf-8",


### PR DESCRIPTION
Closes #829.

It is worth noting that technically this is a breaking change. I didn't aim for backwards compat, as I figured the behaviour was pretty inconvenient/unfriendly, as per the original issue.