### PR TITLE
remove typing_extensions runtime dep on >= py3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
   "packaging>=20",
   "setuptools>=55",
   'tomli; python_version < "3.11"',
-  "typing_extensions",
+  'typing_extensions; python_version < "3.8"',
 ]
 
 [project]
@@ -45,7 +45,7 @@ dependencies = [
   "packaging>=20",
   "setuptools",
   'tomli>=1; python_version < "3.11"',
-  "typing-extensions",
+  'typing-extensions; python_version < "3.11"',
 ]
 [project.optional-dependencies]
 rich = [

--- a/src/setuptools_scm/_entrypoints.py
+++ b/src/setuptools_scm/_entrypoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -7,7 +8,10 @@ from typing import Iterator
 from typing import overload
 from typing import TYPE_CHECKING
 
-from typing_extensions import Protocol
+if sys.version_info[:2] >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 from . import _log
 from . import version

--- a/src/setuptools_scm/_file_finders/__init__.py
+++ b/src/setuptools_scm/_file_finders/__init__.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import itertools
 import os
 from typing import Callable
-
-from typing_extensions import TypeGuard
+from typing import TYPE_CHECKING
 
 from .. import _log
 from .. import _types as _t
 from .._entrypoints import iter_entry_points
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeGuard
+
 
 log = _log.log.getChild("file_finder")
 

--- a/src/setuptools_scm/_integration/pyproject_reading.py
+++ b/src/setuptools_scm/_integration/pyproject_reading.py
@@ -7,10 +7,12 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import NamedTuple
-
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING
 
 from .setuptools import read_dist_name_from_setup_cfg
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 _ROOT = "root"
 TOML_RESULT: TypeAlias = Dict[str, Any]

--- a/src/setuptools_scm/_types.py
+++ b/src/setuptools_scm/_types.py
@@ -8,9 +8,9 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
 
-from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
     from . import version
 
 PathT: TypeAlias = Union["os.PathLike[str]", str]

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ deps=
     pytest
     setuptools >= 45
     virtualenv>20
-    typing_extensions
 commands=
     pytest []
 
@@ -39,7 +38,7 @@ deps=
     check-manifest
     docutils
     pygments
-    typing_extensions
+    typing_extensions; python_version<'3.8'
     hatchling
 commands=
     rst2html.py README.rst {envlogdir}/README.html --strict []


### PR DESCRIPTION
This makes it easier to bootstrap setuptools_scm and makes builds quicker, as pip doesn't need to download/install an extra package when preforming isolated builds.