### PR TITLE
Allow opt-out of find_files behavior. (issue 561)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,10 @@ or in a SCM managed file.
 
 Additionally ``setuptools_scm`` provides setuptools with a list of
 files that are managed by the SCM (i.e. it automatically adds all of
-the SCM-managed files to the sdist). This is opt-in, by supplying
-config argument: ``enable_find_files``. Once opted in unwanted files
-must be excluded by discarding them via ``MANIFEST.in``.
+the SCM-managed files to the sdist). Unwanted files must be excluded
+by discarding them via ``MANIFEST.in``. It is also possible to
+opt-out of this behavior by setting the ``enable_find_files`` config
+argument to false.
 
 ``setuptools_scm`` supports the following scm out of the box:
 

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,9 @@ or in a SCM managed file.
 
 Additionally ``setuptools_scm`` provides setuptools with a list of
 files that are managed by the SCM (i.e. it automatically adds all of
-the SCM-managed files to the sdist). Unwanted files must be excluded
-by discarding them via ``MANIFEST.in``.
+the SCM-managed files to the sdist). This is opt-in, by supplying
+config argument: ``enable_find_files``. Once opted in unwanted files
+must be excluded by discarding them via ``MANIFEST.in``.
 
 ``setuptools_scm`` supports the following scm out of the box:
 
@@ -77,6 +78,7 @@ to be supplied to ``get_version()``. For example:
     # pyproject.toml
     [tool.setuptools_scm]
     write_to = "pkg/_version.py"
+    enable_find_files = true
 
 Where ``pkg`` is the name of your package.
 

--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -90,7 +90,7 @@ class Configuration:
     dist_name: str | None = None
     version_cls: type[_VersionT] = _Version
     search_parent_directories: bool = False
-    enable_find_files: bool = False
+    enable_find_files: bool = True
 
     parent: _t.PathT | None = None
 

--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -90,6 +90,7 @@ class Configuration:
     dist_name: str | None = None
     version_cls: type[_VersionT] = _Version
     search_parent_directories: bool = False
+    enable_find_files: bool = False
 
     parent: _t.PathT | None = None
 

--- a/src/setuptools_scm/_file_finders/__init__.py
+++ b/src/setuptools_scm/_file_finders/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import itertools
 import os
 from typing import Callable
-from typing import Optional
 from typing import TYPE_CHECKING
 
 from .. import _config

--- a/src/setuptools_scm/_file_finders/__init__.py
+++ b/src/setuptools_scm/_file_finders/__init__.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import itertools
 import os
-from typing import Callable, Optional
+from typing import Callable
+from typing import Optional
 from typing import TYPE_CHECKING
 
 from .. import _config
@@ -96,9 +97,9 @@ def is_toplevel_acceptable(toplevel: str | None) -> TypeGuard[str]:
     return toplevel not in ignored
 
 
-def _get_config() -> Optional[_config.Configuration]:
-    dist_name: Optional[str] = None
-    config: Optional[_config.Configuration] = None
+def _get_config() -> _config.Configuration | None:
+    dist_name: str | None = None
+    config: _config.Configuration | None = None
     if dist_name is None:
         dist_name = read_dist_name_from_setup_cfg()
     if not os.path.isfile("pyproject.toml"):

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -45,10 +45,10 @@ def pytest_addoption(parser: Any) -> None:
 def write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
     with open(directory / "pyproject.toml", "w") as fh:
         fh.write(
-            f'[project]\n'
+            f"[project]\n"
             f'name = "test"\n'
-            f'[tool.setuptools_scm]\n'
-            f'enable_find_files = {str(enable_find_files).lower()}\n'
+            f"[tool.setuptools_scm]\n"
+            f"enable_find_files = {str(enable_find_files).lower()}\n"
         )
 
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -42,6 +42,16 @@ def pytest_addoption(parser: Any) -> None:
     )
 
 
+def write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
+    with open(directory / "pyproject.toml", "w") as fh:
+        fh.write(
+            f'[project]\n'
+            f'name = "test"\n'
+            f'[tool.setuptools_scm]\n'
+            f'enable_find_files = {str(enable_find_files).lower()}\n'
+        )
+
+
 class DebugMode(contextlib.AbstractContextManager):  # type: ignore[type-arg]
     from setuptools_scm import _log as __module
 

--- a/testing/test_file_finder.py
+++ b/testing/test_file_finder.py
@@ -13,8 +13,10 @@ from setuptools_scm._file_finders import find_files
 
 
 def _write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
-    with open(directory / "pyproject.toml", "wt") as fh:
-        fh.write(f"[project]\nname = \"test\"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n")
+    with open(directory / "pyproject.toml", "w") as fh:
+        fh.write(
+            f'[project]\nname = "test"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n'
+        )
 
 
 @pytest.fixture(params=["git", "hg"])
@@ -188,7 +190,7 @@ def test_double_include_through_symlink(inwd: WorkDir) -> None:
             "adir/filea",
             "bdir/fileb",
             "data/datafile",
-            "pyproject.toml"
+            "pyproject.toml",
         }
     )
 
@@ -208,7 +210,7 @@ def test_symlink_not_in_scm_while_target_is(inwd: WorkDir) -> None:
             # because the symlink_to themselves are not in scm
             "bdir/fileb",
             "data/datafile",
-            "pyproject.toml"
+            "pyproject.toml",
         }
     )
 
@@ -248,4 +250,6 @@ def test_archive(
     else:
         os.link("data/datafile", datalink)
 
-    assert set(find_files()) == _sep({archive_file, "data/datafile", "data/datalink", "pyproject.toml"})
+    assert set(find_files()) == _sep(
+        {archive_file, "data/datafile", "data/datalink", "pyproject.toml"}
+    )

--- a/testing/test_file_finder.py
+++ b/testing/test_file_finder.py
@@ -2,21 +2,14 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
 from typing import Generator
 from typing import Iterable
 
 import pytest
 
+from .conftest import write_pyproject_config
 from .wd_wrapper import WorkDir
 from setuptools_scm._file_finders import find_files
-
-
-def _write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
-    with open(directory / "pyproject.toml", "w") as fh:
-        fh.write(
-            f'[project]\nname = "test"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n'
-        )
 
 
 @pytest.fixture(params=["git", "hg"])
@@ -50,7 +43,7 @@ def inwd(
     if request.node.get_closest_marker("skip_commit") is None:
         wd.add_and_commit()
     monkeypatch.chdir(wd.cwd)
-    _write_pyproject_config(wd.cwd, True)
+    write_pyproject_config(wd.cwd, True)
     yield wd
 
 
@@ -65,7 +58,7 @@ def test_basic(inwd: WorkDir) -> None:
 
 
 def test_basic_find_files_disabled(inwd: WorkDir) -> None:
-    _write_pyproject_config(inwd.cwd, False)
+    write_pyproject_config(inwd.cwd, False)
     assert find_files() == []
     assert find_files(".") == []
     assert find_files("adir") == []
@@ -225,7 +218,7 @@ def test_unexpanded_git_archival(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -
     # When substitutions in `.git_archival.txt` are not expanded, files should
     # not be automatically listed.
     monkeypatch.chdir(wd.cwd)
-    _write_pyproject_config(wd.cwd, True)
+    write_pyproject_config(wd.cwd, True)
     (wd.cwd / ".git_archival.txt").write_text("node: $Format:%H$", encoding="utf-8")
     (wd.cwd / "file1.txt").touch()
     assert find_files() == []
@@ -238,7 +231,7 @@ def test_archive(
     # When substitutions in `.git_archival.txt` are not expanded, files should
     # not be automatically listed.
     monkeypatch.chdir(wd.cwd)
-    _write_pyproject_config(wd.cwd, True)
+    write_pyproject_config(wd.cwd, True)
     sha = "a1bda3d984d1a40d7b00ae1d0869354d6d503001"
     (wd.cwd / archive_file).write_text(f"node: {sha}", encoding="utf-8")
     (wd.cwd / "data").mkdir()

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 import pytest
 
 import setuptools_scm._file_finders
-from .conftest import DebugMode
+from .conftest import DebugMode, write_pyproject_config
 from .wd_wrapper import WorkDir
 from setuptools_scm import Configuration
 from setuptools_scm import git
@@ -31,13 +31,6 @@ from setuptools_scm.version import format_version
 pytestmark = pytest.mark.skipif(
     not has_command("git", warn=False), reason="git executable not found"
 )
-
-
-def _write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
-    with open(directory / "pyproject.toml", "w") as fh:
-        fh.write(
-            f'[project]\nname = "test"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n'
-        )
 
 
 @pytest.fixture(name="wd")
@@ -105,7 +98,7 @@ def test_git_gone(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/298")
 @pytest.mark.issue(403)
 def test_file_finder_no_history(wd: WorkDir, caplog: pytest.LogCaptureFixture) -> None:
-    _write_pyproject_config(wd.cwd, True)
+    write_pyproject_config(wd.cwd, True)
     file_list = git_find_files(str(wd.cwd))
     assert file_list == []
 
@@ -367,7 +360,7 @@ def test_git_archive_export_ignore(
     wd("git add test1.txt test2.txt")
     wd.commit()
     monkeypatch.chdir(wd.cwd)
-    _write_pyproject_config(wd.cwd, True)
+    write_pyproject_config(wd.cwd, True)
     assert setuptools_scm._file_finders.find_files(".") == [opj(".", "test1.txt")]
 
 
@@ -378,7 +371,7 @@ def test_git_archive_subdirectory(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) 
     wd("git add foobar")
     wd.commit()
     monkeypatch.chdir(wd.cwd)
-    _write_pyproject_config(wd.cwd, True)
+    write_pyproject_config(wd.cwd, True)
     assert setuptools_scm._file_finders.find_files(".") == [
         opj(".", "foobar", "test1.txt")
     ]
@@ -393,7 +386,7 @@ def test_git_archive_run_from_subdirectory(
     wd("git add foobar")
     wd.commit()
     monkeypatch.chdir(wd.cwd / "foobar")
-    _write_pyproject_config(wd.cwd / "foobar", True)
+    write_pyproject_config(wd.cwd / "foobar", True)
     assert setuptools_scm._file_finders.find_files(".") == [opj(".", "test1.txt")]
 
 

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -16,7 +16,8 @@ from unittest.mock import patch
 import pytest
 
 import setuptools_scm._file_finders
-from .conftest import DebugMode, write_pyproject_config
+from .conftest import DebugMode
+from .conftest import write_pyproject_config
 from .wd_wrapper import WorkDir
 from setuptools_scm import Configuration
 from setuptools_scm import git

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -33,6 +33,11 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
+    with open(directory / "pyproject.toml", "wt") as fh:
+        fh.write(f"[project]\nname = \"test\"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n")
+
+
 @pytest.fixture(name="wd")
 def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch, debug_mode: DebugMode) -> WorkDir:
     debug_mode.disable()
@@ -98,6 +103,7 @@ def test_git_gone(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.issue("https://github.com/pypa/setuptools_scm/issues/298")
 @pytest.mark.issue(403)
 def test_file_finder_no_history(wd: WorkDir, caplog: pytest.LogCaptureFixture) -> None:
+    _write_pyproject_config(wd.cwd, True)
     file_list = git_find_files(str(wd.cwd))
     assert file_list == []
 
@@ -359,6 +365,7 @@ def test_git_archive_export_ignore(
     wd("git add test1.txt test2.txt")
     wd.commit()
     monkeypatch.chdir(wd.cwd)
+    _write_pyproject_config(wd.cwd, True)
     assert setuptools_scm._file_finders.find_files(".") == [opj(".", "test1.txt")]
 
 
@@ -369,6 +376,7 @@ def test_git_archive_subdirectory(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) 
     wd("git add foobar")
     wd.commit()
     monkeypatch.chdir(wd.cwd)
+    _write_pyproject_config(wd.cwd, True)
     assert setuptools_scm._file_finders.find_files(".") == [
         opj(".", "foobar", "test1.txt")
     ]
@@ -383,6 +391,7 @@ def test_git_archive_run_from_subdirectory(
     wd("git add foobar")
     wd.commit()
     monkeypatch.chdir(wd.cwd / "foobar")
+    _write_pyproject_config(wd.cwd / "foobar", True)
     assert setuptools_scm._file_finders.find_files(".") == [opj(".", "test1.txt")]
 
 

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -34,8 +34,10 @@ pytestmark = pytest.mark.skipif(
 
 
 def _write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
-    with open(directory / "pyproject.toml", "wt") as fh:
-        fh.write(f"[project]\nname = \"test\"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n")
+    with open(directory / "pyproject.toml", "w") as fh:
+        fh.write(
+            f'[project]\nname = "test"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n'
+        )
 
 
 @pytest.fixture(name="wd")

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -19,6 +19,11 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
+    with open(directory / "pyproject.toml", "wt") as fh:
+        fh.write(f"[project]\nname = \"test\"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n")
+
+
 @pytest.fixture
 def wd(wd: WorkDir) -> WorkDir:
     wd("hg init")
@@ -71,6 +76,7 @@ def test_find_files_stop_at_root_hg(
     # issue 251
     wd.add_and_commit()
     monkeypatch.chdir(project)
+    _write_pyproject_config(project, True)
     assert setuptools_scm._file_finders.find_files() == ["setup.cfg"]
 
 

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -20,8 +20,10 @@ pytestmark = pytest.mark.skipif(
 
 
 def _write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
-    with open(directory / "pyproject.toml", "wt") as fh:
-        fh.write(f"[project]\nname = \"test\"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n")
+    with open(directory / "pyproject.toml", "w") as fh:
+        fh.write(
+            f'[project]\nname = "test"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n'
+        )
 
 
 @pytest.fixture

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 import setuptools_scm._file_finders
+from .conftest import write_pyproject_config
 from setuptools_scm import Configuration
 from setuptools_scm._run_cmd import has_command
 from setuptools_scm.hg import archival_to_version
@@ -17,13 +18,6 @@ from testing.wd_wrapper import WorkDir
 pytestmark = pytest.mark.skipif(
     not has_command("hg", warn=False), reason="hg executable not found"
 )
-
-
-def _write_pyproject_config(directory: Path, enable_find_files: bool) -> None:
-    with open(directory / "pyproject.toml", "w") as fh:
-        fh.write(
-            f'[project]\nname = "test"\n[tool.setuptools_scm]\nenable_find_files = {str(enable_find_files).lower()}\n'
-        )
 
 
 @pytest.fixture
@@ -78,7 +72,7 @@ def test_find_files_stop_at_root_hg(
     # issue 251
     wd.add_and_commit()
     monkeypatch.chdir(project)
-    _write_pyproject_config(project, True)
+    write_pyproject_config(project, True)
     assert setuptools_scm._file_finders.find_files() == ["setup.cfg"]
 
 


### PR DESCRIPTION
~Changes it so find_files is only enabled with config parameter `enable_find_files` is set to true, otherwise will always return empty list.~

Adds config argument `enable_find_files` that when set to `false` allows `find_files` behavior to be disabled.

Addresses https://github.com/pypa/setuptools_scm/issues/561