### PR TITLE
add command support for the libgit2 cli

### DIFF
--- a/src/setuptools_scm/utils.py
+++ b/src/setuptools_scm/utils.py
@@ -154,7 +154,7 @@ def function_has_arg(fn: object | FunctionType, argname: str) -> bool:
 
 def has_command(name: str, args: list[str] | None = None, warn: bool = True) -> bool:
     try:
-        cmd = [name, "help"] if args is None else [name, *args]
+        cmd = [name, "version"] if args is None else [name, *args]
         p = _run(cmd, ".")
     except OSError:
         trace(*sys.exc_info())


### PR DESCRIPTION
This pull requests makes small changes so the codebase has enough functionality with libgit2 to install itself.

The libgit2 example cli is at https://github.com/libgit2/libgit2/blob/main/examples/lg2.c . This git replacement is used by a-shell at https://github.com/holzschu/a-shell .

- specified the dirty text in describe, lg2 requires
- the default lg2 code does not implement —abbrev-ref, so a whole ref is used if that fails
- most log flags are missing. -n is present as —max-count, which i changed, but it falls back to retrieving unformatted output and parsing it, if dateutil is present to do so. the code calling the function defaults to the system time if None is returned.
- GitWorkdir.from_potential_worktree calls an unsupported command line and i didn’t discern the intended logic of the function to patch it, it looks like it ends up returning data that was passed to it (the root dir parenting the git dir), so i made an alternate condition that defaults to this. is it to handle git dirs that are outside work trees?
- when detecting a command, lg2 returns a failure code for help, but both lg2 and git return a success code for version, so i changed the probe to check version