### PR TITLE
Add note for conda users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -677,7 +677,7 @@ Note for Conda Users
 Setuptools-scm will not set the correct version by default when built with conda. In order
 for it to work, the conda recipe needs to be modified to use the
 SETUPTOOLS_SCM_PRETEND_VERSION env variable.
-[Here](https://github.com/conda-forge/pint-feedstock/commit/b107bcafd4a8571b416bd06b7c292eccc62ef3fc)
+`Here <lhttps://github.com/conda-forge/pint-feedstock/commit/b107bcafd4a8571b416bd06b7c292eccc62ef3fc>`_
 is an example of how to do this.
 
 

--- a/README.rst
+++ b/README.rst
@@ -675,8 +675,8 @@ Note for Conda Users
 ~~~~~~~~~~~~~~~~~~~~
 
 Setuptools-scm will not set the correct version by default when built with conda. In order
-for it to work, the conda recipe needs to be modified to use the 
-SETUPTOOLS_SCM_PRETEND_VERSION env variable. 
+for it to work, the conda recipe needs to be modified to use the
+SETUPTOOLS_SCM_PRETEND_VERSION env variable.
 [Here](https://github.com/conda-forge/pint-feedstock/commit/b107bcafd4a8571b416bd06b7c292eccc62ef3fc)
 is an example of how to do this.
 

--- a/README.rst
+++ b/README.rst
@@ -677,7 +677,7 @@ Note for Conda Users
 Setuptools-scm will not set the correct version by default when built with conda. In order
 for it to work, the conda recipe needs to be modified to use the
 SETUPTOOLS_SCM_PRETEND_VERSION env variable.
-`Here <lhttps://github.com/conda-forge/pint-feedstock/commit/b107bcafd4a8571b416bd06b7c292eccc62ef3fc>`_
+`Here <https://github.com/conda-forge/pint-feedstock/commit/b107bcafd4a8571b416bd06b7c292eccc62ef3fc>`_
 is an example of how to do this.
 
 

--- a/README.rst
+++ b/README.rst
@@ -671,6 +671,16 @@ some environments require a test prior to install,
   $ PYTHONPATH=$PWD:$PWD/src pytest
 
 
+Note for Conda Users
+~~~~~~~~~~~~~~~~~~~~
+
+Setuptools-scm will not set the correct version by default when built with conda. In order
+for it to work, the conda recipe needs to be modified to use the 
+SETUPTOOLS_SCM_PRETEND_VERSION env variable. 
+[Here](https://github.com/conda-forge/pint-feedstock/commit/b107bcafd4a8571b416bd06b7c292eccc62ef3fc)
+is an example of how to do this.
+
+
 Interaction with Enterprise Distributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
By default, when setuptools-scm projects are built with conda the version returned by `importlib.metadata.version` is always  0.0.0. It took me a few hours to track down why and find a solution, so I have included a small note in the readme and a link to an example on how to fix this to save someone else time in the future. 