### PR TITLE
Add support for non-root modules for version hooks.

### DIFF
--- a/src/setuptools_scm/_entrypoints.py
+++ b/src/setuptools_scm/_entrypoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from typing import Any
 from typing import Callable
@@ -85,11 +86,21 @@ def _get_ep(group: str, name: str) -> Any | None:
 
 def _get_from_object_reference_str(path: str, group: str) -> Any | None:
     # todo: remove for importlib native spelling
+
+    # Split module path from entrypoint (e.g. 'version_tools/module.submodule:version_hook')
+    module_path = os.getcwd()
+    if "/" in group:
+        nested_path, group = group.rsplit("/", 1)
+        module_path = os.path.join(module_path, nested_path)
+    sys.path.insert(0, module_path)
+
     ep: EntrypointProtocol = EntryPoint(path, path, group)
     try:
         return ep.load()
     except (AttributeError, ModuleNotFoundError):
         return None
+    finally:
+        sys.path.pop(0)
 
 
 def _iter_version_schemes(


### PR DESCRIPTION
Greetings!

I have been using `setuptools_scm` via `hatch-vcs` for a while now, and love it. Thanks for putting this together!

Due to us wanting to ship out feature branches for testing into our internal PyPI, we have customised the versioning sheme using `version_scheme = "version:get_version", local_scheme = "version:get_local"` in our `pyproject.toml` file. This works well when directly using `hatch`, but fails when using `python -m build`. After digging into this I found that it was because the build process is carried out in a subprocess where the python path no longer includes the current working directory. This improves build isolation, but breaks `setuptools_scm`'s loading of custom entrypoints such as we use here.

A quick workaround is to prefix the build commands with `PYTHON_PATH="$(pwd)"` but that is annoying to do, and so I thought I'd offer up a patch to fix this within `setuptools_scm`. In doing so, I thought I might also fix another gripe whereby the custom module could only be in the project root. If I have to modify the path anyway, I might as well parse out  any parent path before adding to the Python path.

Thus, this patch set addresses two issues:

* Building via `python -m build` when custom version hooks have been set.
* Allowing version hooks to be located at some another directory without a direct top-level module to import.

Happy to modify documentation/etc as necessary if you are willing to accept this patch.