### PR TITLE
tests: Specify version for test PEP621 metadata

### DIFF
--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -56,7 +56,8 @@ PYPROJECT_FILES = {
         "[tool.setuptools_scm]\ndist_name='setuptools_scm_example'"
     ),
     "pyproject.project": (
-        "[project]\nname='setuptools_scm_example'\n[tool.setuptools_scm]"
+        "[project]\nname='setuptools_scm_example'\n"
+        "dynamic=['version']\n[tool.setuptools_scm]"
     ),
 }
 


### PR DESCRIPTION
According to today's specification
https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#specification

> The only keys required to be statically defined are:
>  -  name
>
> The keys which are required but may be specified either statically or listed as dynamic are:
>  - version


Fixes: https://github.com/pypa/setuptools_scm/issues/866