### PR TITLE
Drop support for python 3.7

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.7', '3.8', '3.9', '3.10', '3.11.0-alpha - 3.11.0', 'pypy-3.8' ]
+        python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12.0-beta - 3.12', 'pypy-3.8' ]
         os: [windows-latest, ubuntu-latest] #, macos-latest]
         include:
         - os: windows-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v3.9.0
     hooks:
     -   id: reorder-python-imports
-        args: [ "--application-directories=.:src" , --py37-plus, --add-import, 'from __future__ import annotations']
+        args: [ "--application-directories=.:src" , --py38-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -26,7 +26,7 @@ repos:
     rev: v3.4.0
     hooks:
     - id: pyupgrade
-      args: [--py37-plus]
+      args: [--py38-plus]
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: "0.11.2"
   hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ breaking
 * depend on later importlib for the full selectable api
 * move setuptools integration code to private sub-package
 * use normalized dist names for the SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${DIST_NAME}
+* drop support for python 3.7
 
 features
 --------

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 warn_return_any = True
 warn_unused_configs = True
 mypy_path = $MYPY_CONFIG_FILE_DIR/src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,13 @@ license.file = "LICENSE"
 authors = [
     {name="Ronny Pfannschmidt", email="opensource@ronnypfannschmidt.de"}
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/src/setuptools_scm/_entrypoints.py
+++ b/src/setuptools_scm/_entrypoints.py
@@ -6,12 +6,8 @@ from typing import Callable
 from typing import cast
 from typing import Iterator
 from typing import overload
+from typing import Protocol
 from typing import TYPE_CHECKING
-
-if sys.version_info[:2] >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 
 from . import _log
 from . import version
@@ -53,12 +49,12 @@ def _version_from_entrypoints(
     return None
 
 
-try:
+if sys.version_info[:2] < (3, 10):
     from importlib_metadata import entry_points
     from importlib_metadata import EntryPoint
-except ImportError:
-    from importlib.metadata import entry_points  # type: ignore [no-redef, import]
-    from importlib.metadata import EntryPoint  # type: ignore [no-redef]
+else:
+    from importlib.metadata import entry_points
+    from importlib.metadata import EntryPoint
 
 
 def iter_entry_points(

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -23,10 +23,8 @@ VERSION_PKGS = ["setuptools", "setuptools_scm", "packaging"]
 
 
 def pytest_report_header() -> list[str]:
-    try:
-        from importlib.metadata import version  # type: ignore
-    except ImportError:
-        from importlib_metadata import version
+    from importlib.metadata import version
+
     res = []
     for pkg in VERSION_PKGS:
         pkg_version = version(pkg)

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -147,13 +147,11 @@ def testwarn_on_broken_setuptools() -> None:
 
 @pytest.mark.issue(611)
 def test_distribution_provides_extras() -> None:
-    try:
-        from importlib.metadata import distribution  # type: ignore
-    except ImportError:
-        from importlib_metadata import distribution
+    from importlib.metadata import distribution
 
     dist = distribution("setuptools_scm")
-    assert sorted(dist.metadata.get_all("Provides-Extra")) == ["rich", "test", "toml"]
+    pe: list[str] = dist.metadata.get_all("Provides-Extra", [])
+    assert sorted(pe) == ["rich", "test", "toml"]
 
 
 @pytest.mark.issue(760)

--- a/testing/test_regressions.py
+++ b/testing/test_regressions.py
@@ -3,20 +3,15 @@ from __future__ import annotations
 import pprint
 import subprocess
 import sys
-from typing import Callable
-
-if sys.version_info >= (3, 8):
-    distribution: Callable[[str], EntryPoint]
-    from importlib.metadata import distribution, EntryPoint
-else:
-    from importlib_metadata import distribution, EntryPoint
+from importlib.metadata import distribution
+from importlib.metadata import EntryPoint
 from pathlib import Path
 
 import pytest
 
 from setuptools_scm import Configuration
-from setuptools_scm.git import parse
 from setuptools_scm._run_cmd import run
+from setuptools_scm.git import parse
 
 
 def test_pkginfo_noscmroot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
this was triggered by markdown-it dropping support for python3.7 and no trivial mypy config to keep things working