### PR TITLE
ignore jupyter notebooks by default

### DIFF
--- a/src/setuptools_scm/_file_finders/__init__.py
+++ b/src/setuptools_scm/_file_finders/__init__.py
@@ -70,6 +70,16 @@ def scm_find_files(
         for filename in filenames:
             if not force_all_files and _link_not_in_scm(filename):
                 continue
+            if not force_all_files and filename.lower().endswith(".ipynb"):
+                # ignore jupyter notebooks by default.
+                # they can be included with a MANIFEST.in
+                # 1) jupyter notebooks are ubiquitous in python repositories,
+                # they are saved in git and detected by setuptools-scm.
+                # 2) it's common for a notebook file to reach dozens
+                # or hundreds of MB (jupyter saves the content of each cell on save).
+                # 3) there is no expectation of these files to be included in
+                # or distributed via the python wheel.
+                continue
             # dirpath + filename with symlinks preserved
             fullfilename = os.path.join(dirpath, filename)
             is_tracked = os.path.normcase(os.path.realpath(fullfilename)) in scm_files


### PR DESCRIPTION
hello,

could you consider excluding jupyter notebook files by default?

notebooks are stored in source control and they end up in the python package when using setuptools-scm.

notebooks are quite problematic for both the git repo and the python package.
they cache the content of each jupyter cell on save. it's very easy for users to accidentally make notebooks that are many many MB, just for loading a bit of data to play with. 
I've seen quite a few accidents where (very) large jupyter notebooks got included in a wheel, making the wheel much larger than necessary.

it would be nice to ignore them by default.
I don't think there is any use case where jupyter notebooks are expected to be included in source dist or wheels, but I could be wrong about that. 

thank you