### PR TITLE
RFC: Make "disable i18n" logic optional

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -103,7 +103,7 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
 
 `disable_i18n`
 :   A boolean flag indicating if the values `LC_ALL="C" LANGUAGE=""` should be
-    injected into the environment when running commands such as `git` and `hg`. 
+    injected into the environment when running commands such as `git` and `hg`.
     Defaults to `True`.
 
 ## environment variables

--- a/docs/config.md
+++ b/docs/config.md
@@ -101,6 +101,10 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
         Setuptools will still normalize it to create the final distribution,
         so as to stay compliant with the python packaging standards.
 
+`disable_i18n`
+:   A boolean flag indicating if the values `LC_ALL="C" LANGUAGE=""` should be
+    injected into the environment when running commands such as `git` and `hg`. 
+    Defaults to `True`.
 
 ## environment variables
 

--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -103,6 +103,7 @@ class Configuration:
     dist_name: str | None = None
     version_cls: type[_VersionT] = _Version
     search_parent_directories: bool = False
+    disable_i18n: bool = True
 
     parent: _t.PathT | None = None
 

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -5,15 +5,17 @@ import shlex
 import subprocess
 import textwrap
 import warnings
-from typing import Callable, Optional
+from typing import Callable
 from typing import Mapping
+from typing import Optional
 from typing import overload
 from typing import Sequence
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
-from . import _log, Configuration
+from . import _log
 from . import _types as _t
+from . import Configuration
 
 if TYPE_CHECKING:
     BaseCompletedProcess = subprocess.CompletedProcess[str]
@@ -128,7 +130,7 @@ def run(
     trace: bool = True,
     timeout: int = 20,
     check: bool = False,
-    config: Optional[Configuration] = None,
+    config: Configuration | None = None,
 ) -> CompletedProcess:
     if isinstance(cmd, str):
         cmd = shlex.split(cmd)
@@ -143,11 +145,13 @@ def run(
         HGPLAIN="1",
     )
     if not config or (config and config.disable_i18n):
-        run_env.update({
-            # try to disable i18n
-            "LC_ALL": "C",
-            "LANGUAGE": "",
-        })
+        run_env.update(
+            {
+                # try to disable i18n
+                "LC_ALL": "C",
+                "LANGUAGE": "",
+            }
+        )
     log.debug("Shell environment to be used for command: %s", run_env)
 
     res = subprocess.run(
@@ -179,7 +183,10 @@ def _unsafe_quote_for_display(item: _t.PathT) -> str:
 
 
 def has_command(
-    name: str, args: Sequence[str] = ["version"], warn: bool = True, config: Optional[Configuration] = None
+    name: str,
+    args: Sequence[str] = ["version"],
+    warn: bool = True,
+    config: Configuration | None = None,
 ) -> bool:
     try:
         p = run([name, *args], cwd=".", timeout=5, config=config)
@@ -197,6 +204,6 @@ def has_command(
     return res
 
 
-def require_command(name: str, config: Optional[Configuration] = None) -> None:
+def require_command(name: str, config: Configuration | None = None) -> None:
     if not has_command(name, warn=False, config=config):
         raise OSError(f"{name!r} was not found")

--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -5,7 +5,8 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
+from typing import TYPE_CHECKING
 
 from . import Configuration
 from ._version_cls import Version
@@ -25,10 +26,12 @@ log = logging.getLogger(__name__)
 
 @dataclass()
 class HgWorkdir(Workdir):
-    config: Optional[Configuration] = None
+    config: Configuration | None = None
 
     @classmethod
-    def from_potential_worktree(cls, wd: _t.PathT, config: Configuration) -> HgWorkdir | None:
+    def from_potential_worktree(
+        cls, wd: _t.PathT, config: Configuration
+    ) -> HgWorkdir | None:
         res = _run(["hg", "root"], wd, config=config)
         if res.returncode:
             return None
@@ -51,7 +54,7 @@ class HgWorkdir(Workdir):
             ["hg", "id", "-T", "{branch}\n{if(dirty, 1, 0)}\n{date|shortdate}"],
             cwd=self.path,
             check=True,
-            config=config
+            config=config,
         ).stdout.split("\n")
         dirty = bool(int(dirty_str))
         node_date = datetime.date.fromisoformat(dirty_date if dirty else node_date_str)


### PR DESCRIPTION
I've had issues with Mercurial refusing to run (OSError hg not found) when called by setuptools-scm. After some digging, it turns out that this is due to an ASCII-decode exception when Python loads site modules.

The run() function in _run_cmd.py overrides the LC_ALL environment variable, removing this override made hg/python happy enough to run again.

This pull request contains a first stab at making the LC_ALL override configurable. The changes are enough to solve the specific problem I am experiencing, but it is not complete. I would like to have your feedback on the general approach, before investing the time to roll out `disable_i18n` config to all of setuptools-scm.