### PR TITLE
Use an UTF8 enabled locale for the run() environment.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ bugfixes
 
 * fix #883: use HeadersParser to ensure only mime metadata in headers is used
 * fix #884: parse calver dates from versions with the v prefix
+* don't use a C locale without UTF-8 support, when running commands.
 
 v7.1.0
 ======

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -143,7 +143,7 @@ def run(
             avoid_pip_isolation(no_git_env(os.environ)),
             # os.environ,
             # try to disable i18n
-            LC_ALL="C",
+            LC_ALL="C.UTF-8",
             LANGUAGE="",
             HGPLAIN="1",
         ),

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -142,7 +142,7 @@ def run(
         env=dict(
             avoid_pip_isolation(no_git_env(os.environ)),
             # os.environ,
-            # try to disable i18n
+            # try to disable i18n, but still allow UTF-8 encoded text.
             LC_ALL="C.UTF-8",
             LANGUAGE="",
             HGPLAIN="1",


### PR DESCRIPTION
I have not managed to make a unit test that recreates the problem. While failing with that, I think I have narrowed down the true origin of the problem: 

It is not mercurial having trouble with LC_ALL=C. It is Python itself that fails during start-up, when it encounters a pth-file in site-packages, that has a non-ascii character inside of it. This in turn only happens when I initiate the `pip wheel` command while my virtualenv (with an editable install of the project) is active.

In order to make a test for this, one would need to prep the test by installing an (in)appropriate package in the test environment. I do not want to take on that type of effort, so I'll just leave this one-liner here for you to accept or reject!

With my findning on the core of the problem, I have a solid work-around available (just don't run pip wheel with an active virtualenv), so I don't feel very strongly about the issue any more.

Kind regards,
Arvid