### PR TITLE
Add timeout to tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -92,6 +92,7 @@ jobs:
       # this hopefull helps with os caches, hg init sometimes gets 20s timeouts
       - run: hg version
       - run: pytest
+        timeout-minutes: 15
 
   dist_upload:
 


### PR DESCRIPTION
Just noticed that the current release workflow is hanging on the pytest run on Windows (msys2).

Looking at previous runs the tests usually don't take much longer than 5/6 minutes (10 minutes tops). Imposing a 15 minute timeout seems reasonable.