### PR TITLE
docs: correct word and space in `SETUPTOOLS_SCM_PRETEND_VERSION` warning

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -108,7 +108,7 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
 :   used as the primary source for the version number
     in which case it will be an unparsed string
 
-    !!! warning "its strongly  recommended to use use distribution name specific pretend versions"
+    !!! warning "it is strongly recommended to use use distribution name specific pretend versions"
 
 
 `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME}`


### PR DESCRIPTION
* Replaces `its` with `it is`. The word `its` means something else; `it's` was definitely intended.
* Removes an extra space.

NOTE: I am debugging my project's version files are no longer being generated, both locally and in CI but I came across this doc issue so I thought I'd open the PR... But really, my priority here is to figure out why my version file doesn't get created anymore. I tried switching `write_to` to `version_file` but that did not seem to work.

I have been looking at https://github.com/pypa/setuptools_scm/pull/870 to try and find answers.