### PR TITLE
Share the stderr with the user, when non-zero exit code

### DIFF
--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -203,6 +203,7 @@ class CommandNotFoundError(LookupError, FileNotFoundError):
 
 def require_command(name: str) -> None:
     if not (result := has_command(name, warn=False)):
-        log.error(f"There was a failure running require_command('{name}'). Below is the stderr from the attempt:")
+        log.error(f"There was a failure running require_command('{name}'). Below is "
+                  "the stderr from the attempt:")
         log.error(result.message)
         raise CommandNotFoundError(name)

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -187,10 +187,8 @@ def has_command(
 
     else:
         res = not p.returncode
-
     if not res and warn:
         warnings.warn("%r was not found" % name, category=RuntimeWarning)
-
     return res
 
 

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -203,6 +203,8 @@ class CommandNotFoundError(LookupError, FileNotFoundError):
 
 def require_command(name: str) -> None:
     if not (result := has_command(name, warn=False)):
-        log.error(f"There was a failure running require_command('{name}'). Below is the stderr from the attempt:")
+        log.error(
+            f"There was a failure running require_command('{name}'). Below is the stderr from the attempt:"
+        )
         log.error(result.message)
         raise CommandNotFoundError(name)

--- a/src/setuptools_scm/_types.py
+++ b/src/setuptools_scm/_types.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from typing import Callable
 from typing import List
-from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import TYPE_CHECKING
@@ -21,14 +20,3 @@ CMD_TYPE: TypeAlias = Union[Sequence[PathT], str]
 VERSION_SCHEME: TypeAlias = Union[str, Callable[["version.ScmVersion"], str]]
 VERSION_SCHEMES: TypeAlias = Union[List[str], Tuple[str, ...], VERSION_SCHEME]
 SCMVERSION: TypeAlias = "version.ScmVersion"
-
-
-class Result:
-    """Just like a normal bool, but with a slot for a message"""
-
-    def __init__(self, status: bool, message: str | None = None):
-        self.status: bool = status
-        self.message: str = message or ""
-
-    def __bool__(self) -> bool:
-        return self.status

--- a/src/setuptools_scm/_types.py
+++ b/src/setuptools_scm/_types.py
@@ -24,8 +24,9 @@ SCMVERSION: TypeAlias = "version.ScmVersion"
 
 
 class Result:
-    """ Just like a normal bool, but with a slot for a message """
-    def __init__(self, status: bool, message: Optional[str] = None):
+    """Just like a normal bool, but with a slot for a message"""
+
+    def __init__(self, status: bool, message: str | None = None):
         self.status: bool = status
         self.message: str = message or ""
 

--- a/src/setuptools_scm/_types.py
+++ b/src/setuptools_scm/_types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from typing import Callable
 from typing import List
+from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import TYPE_CHECKING
@@ -20,3 +21,13 @@ CMD_TYPE: TypeAlias = Union[Sequence[PathT], str]
 VERSION_SCHEME: TypeAlias = Union[str, Callable[["version.ScmVersion"], str]]
 VERSION_SCHEMES: TypeAlias = Union[List[str], Tuple[str, ...], VERSION_SCHEME]
 SCMVERSION: TypeAlias = "version.ScmVersion"
+
+
+class Result:
+    """ Just like a normal bool, but with a slot for a message """
+    def __init__(self, status: bool, message: Optional[str] = None):
+        self.status: bool = status
+        self.message: str = message or ""
+
+    def __bool__(self) -> bool:
+        return self.status

--- a/testing/test_functions.py
+++ b/testing/test_functions.py
@@ -153,6 +153,20 @@ def test_has_command() -> None:
         assert not has_command("yadayada_setuptools_aint_ne")
 
 
+def test_has_command_logs_stderr(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    If the name provided to has_command() exists as a command, but gives a non-zero
+    return code, there should be a log message generated.
+    """
+    with pytest.warns(RuntimeWarning, match="ls"):
+        has_command("ls", ["--a-flag-that-doesnt-exist-should-give-output-on-stderr"])
+    found_it = False
+    for record in caplog.records:
+        if "returned non-zero. This is stderr" in record.message:
+            found_it = True
+    assert found_it, "Did not find expected log record for "
+
+
 @pytest.mark.parametrize(
     "tag, expected_version",
     [


### PR DESCRIPTION
When a has_command() returns False, we eat all the output and just say that it was not found. In case the False return is due to a non-zero exit status from a command we did actually find, this makes it quite messy to figure out what went wrong.

This is an attempt to let output from the failing command bubble up the stack, with a minimal amount of disruption to surrounding code.