### PR TITLE
Drop a redundant virtualenv test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ rich = [
 test = [
   "pytest",
   "rich",
-  "virtualenv>20",
 ]
 toml = [
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ usedevelop=True
 deps=
     pytest
     setuptools >= 45
-    virtualenv>20
     rich
 commands=
     pytest []


### PR DESCRIPTION
It was needed for test_distlib_setuptools_works only, which was removed in d78d9ccf062ad114e727718edd7a0d386bed3f85.