### PR TITLE
Avoid rich as a build backend dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@
 [build-system]
 build-backend = "_own_version_helper:build_meta"
 requires = [
-  "rich",
   "setuptools>=61",
   'tomli; python_version < "3.11"',
 ]


### PR DESCRIPTION
It was only added for debugging and it is not actually needed.

Fixes https://github.com/pypa/setuptools_scm/issues/941