### PR TITLE
correctly handle project config overrides when the version keyword is used together with pyproject.toml

### DIFF
--- a/changelog.d/20231002_161552_opensource_fix_938_self_reinit_fixup.md
+++ b/changelog.d/20231002_161552_opensource_fix_938_self_reinit_fixup.md
@@ -1,0 +1,6 @@
+
+### Changed
+
+- ensure the setuptools version keyword correctly load pyproject.toml configuration
+- add build and wheel to the test requirements for regression testing
+- move internal toml handling to own module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ rich = [
   "rich",
 ]
 test = [
+  "build",
   "pytest",
   "rich",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
   "build",
   "pytest",
   "rich",
+  "wheel",
 ]
 toml = [
 ]

--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -125,11 +125,14 @@ class Configuration:
         not contain the [tool.setuptools_scm] section.
         """
 
-        pyproject_data = _read_pyproject(name, _load_toml=_load_toml)
+        pyproject_data = _read_pyproject(
+            name, _load_toml=_load_toml, require_section=_require_section
+        )
         args = _get_args_for_pyproject(pyproject_data, dist_name, kwargs)
 
         args.update(read_toml_overrides(args["dist_name"]))
-        return cls.from_data(relative_to=name, data=args)
+        relative_to = args.pop("relative_to", name)
+        return cls.from_data(relative_to=relative_to, data=args)
 
     @classmethod
     def from_data(

--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -5,8 +5,8 @@ import dataclasses
 import os
 import re
 import warnings
+from pathlib import Path
 from typing import Any
-from typing import Callable
 from typing import Pattern
 from typing import Protocol
 
@@ -114,7 +114,6 @@ class Configuration:
         cls,
         name: str | os.PathLike[str] = "pyproject.toml",
         dist_name: str | None = None,
-        _load_toml: Callable[[str], dict[str, Any]] | None = None,
         _require_section: bool = True,
         **kwargs: Any,
     ) -> Configuration:
@@ -125,9 +124,7 @@ class Configuration:
         not contain the [tool.setuptools_scm] section.
         """
 
-        pyproject_data = _read_pyproject(
-            name, _load_toml=_load_toml, require_section=_require_section
-        )
+        pyproject_data = _read_pyproject(Path(name), require_section=_require_section)
         args = _get_args_for_pyproject(pyproject_data, dist_name, kwargs)
 
         args.update(read_toml_overrides(args["dist_name"]))

--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -115,6 +115,7 @@ class Configuration:
         name: str | os.PathLike[str] = "pyproject.toml",
         dist_name: str | None = None,
         _load_toml: Callable[[str], dict[str, Any]] | None = None,
+        _require_section: bool = True,
         **kwargs: Any,
     ) -> Configuration:
         """

--- a/src/setuptools_scm/_entrypoints.py
+++ b/src/setuptools_scm/_entrypoints.py
@@ -45,7 +45,7 @@ log = _log.log.getChild("entrypoints")
 
 
 def version_from_entrypoint(
-    config: Configuration, entrypoint: str, root: _t.PathT
+    config: Configuration, *, entrypoint: str, root: _t.PathT
 ) -> version.ScmVersion | None:
     from .discover import iter_matching_entrypoints
 

--- a/src/setuptools_scm/_get_version_impl.py
+++ b/src/setuptools_scm/_get_version_impl.py
@@ -32,18 +32,22 @@ def parse_scm_version(config: Configuration) -> ScmVersion | None:
                 )
             return parse_result
         else:
-            entrypoint = "setuptools_scm.parse_scm"
-            root = config.absolute_root
-            return _entrypoints.version_from_entrypoint(config, entrypoint, root)
+            return _entrypoints.version_from_entrypoint(
+                config,
+                entrypoint="setuptools_scm.parse_scm",
+                root=config.absolute_root,
+            )
     except _run_cmd.CommandNotFoundError as e:
         _log.exception("command %s not found while parsing the scm, using fallbacks", e)
         return None
 
 
 def parse_fallback_version(config: Configuration) -> ScmVersion | None:
-    entrypoint = "setuptools_scm.parse_scm_fallback"
-    root = config.fallback_root
-    return _entrypoints.version_from_entrypoint(config, entrypoint, root)
+    return _entrypoints.version_from_entrypoint(
+        config,
+        entrypoint="setuptools_scm.parse_scm_fallback",
+        root=config.fallback_root,
+    )
 
 
 def parse_version(config: Configuration) -> ScmVersion | None:

--- a/src/setuptools_scm/_integration/setuptools.py
+++ b/src/setuptools_scm/_integration/setuptools.py
@@ -9,7 +9,6 @@ from typing import Callable
 import setuptools
 
 from .. import _config
-from .._version_cls import _validate_version_cls
 
 log = logging.getLogger(__name__)
 
@@ -95,15 +94,9 @@ def version_keyword(
 
     if dist_name is None:
         dist_name = read_dist_name_from_setup_cfg()
-    version_cls = value.pop("version_cls", None)
-    normalize = value.pop("normalize", True)
-    tag_regex = _config._check_tag_regex(
-        value.pop("tag_regex", _config.DEFAULT_TAG_REGEX)
-    )
-    final_version = _validate_version_cls(version_cls, normalize)
 
-    config = _config.Configuration(
-        dist_name=dist_name, version_cls=final_version, tag_regex=tag_regex, **value
+    config = _config.Configuration.from_file(
+        dist_name=dist_name, _require_section=False, **value
     )
     _assign_version(dist, config)
 

--- a/src/setuptools_scm/_integration/toml.py
+++ b/src/setuptools_scm/_integration/toml.py
@@ -6,13 +6,16 @@ from typing import Any
 from typing import Callable
 from typing import cast
 from typing import Dict
+from typing import TYPE_CHECKING
 from typing import TypedDict
 
 if sys.version_info >= (3, 11):
     from tomllib import loads as load_toml
 else:
     from tomli import loads as load_toml
-from typing_extensions import TypeAlias
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 from .. import _log
 

--- a/src/setuptools_scm/_integration/toml.py
+++ b/src/setuptools_scm/_integration/toml.py
@@ -27,7 +27,7 @@ TOML_LOADER: TypeAlias = Callable[[str], TOML_RESULT]
 
 def read_toml_content(path: Path, default: TOML_RESULT | None = None) -> TOML_RESULT:
     try:
-        data = path.read_text()
+        data = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         if default is None:
             raise

--- a/src/setuptools_scm/_integration/toml.py
+++ b/src/setuptools_scm/_integration/toml.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import TypedDict
+
+if sys.version_info >= (3, 11):
+    from tomllib import loads as load_toml
+else:
+    from tomli import loads as load_toml
+from typing_extensions import TypeAlias
+
+from .. import _log
+
+log = _log.log.getChild("toml")
+
+TOML_RESULT: TypeAlias = Dict[str, Any]
+TOML_LOADER: TypeAlias = Callable[[str], TOML_RESULT]
+
+
+def read_toml_content(path: Path, default: TOML_RESULT | None = None) -> TOML_RESULT:
+    try:
+        data = path.read_text()
+    except FileNotFoundError:
+        if default is None:
+            raise
+        else:
+            log.debug("%s missing, presuming default %r", path, default)
+            return default
+    else:
+        return load_toml(data)
+
+
+class _CheatTomlData(TypedDict):
+    cheat: dict[str, Any]
+
+
+def load_toml_or_inline_map(data: str | None) -> dict[str, Any]:
+    """
+    load toml data - with a special hack if only a inline map is given
+    """
+    if not data:
+        return {}
+    elif data[0] == "{":
+        data = "cheat=" + data
+        loaded: _CheatTomlData = cast(_CheatTomlData, load_toml(data))
+        return loaded["cheat"]
+    return load_toml(data)

--- a/src/setuptools_scm/_overrides.py
+++ b/src/setuptools_scm/_overrides.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import os
 import re
 from typing import Any
-from typing import cast
-from typing import TypedDict
 
 from . import _config
 from . import _log
 from . import version
-from ._integration.pyproject_reading import lazy_toml_load
+from ._integration.toml import load_toml_or_inline_map
 
 log = _log.log.getChild("overrides")
 
@@ -49,23 +47,6 @@ def _read_pretended_version_for(
         return version.meta(tag=pretended, preformatted=True, config=config)
     else:
         return None
-
-
-class _CheatTomlData(TypedDict):
-    cheat: dict[str, Any]
-
-
-def load_toml_or_inline_map(data: str | None) -> dict[str, Any]:
-    """
-    load toml data - with a special hack if only a inline map is given
-    """
-    if not data:
-        return {}
-    elif data[0] == "{":
-        data = "cheat=" + data
-        loaded: _CheatTomlData = cast(_CheatTomlData, lazy_toml_load(data))
-        return loaded["cheat"]
-    return lazy_toml_load(data)
 
 
 def read_toml_overrides(dist_name: str | None) -> dict[str, Any]:

--- a/src/setuptools_scm/_version_cls.py
+++ b/src/setuptools_scm/_version_cls.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from logging import getLogger
 from typing import cast
 from typing import Type
 from typing import Union
@@ -11,6 +10,9 @@ try:
 except ImportError:
     from setuptools.extern.packaging.version import InvalidVersion  # type: ignore
     from setuptools.extern.packaging.version import Version as Version  # type: ignore
+from . import _log
+
+log = _log.log.getChild("version_cls")
 
 
 class NonNormalizedVersion(Version):
@@ -41,10 +43,8 @@ class NonNormalizedVersion(Version):
 def _version_as_tuple(version_str: str) -> tuple[int | str, ...]:
     try:
         parsed_version = Version(version_str)
-    except InvalidVersion:
-        log = getLogger(__name__).parent
-        assert log is not None
-        log.error("failed to parse version %s", version_str)
+    except InvalidVersion as e:
+        log.error("failed to parse version %s: %s", e, version_str)
         return (version_str,)
     else:
         version_fields: tuple[int | str, ...] = parsed_version.release

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -20,7 +20,7 @@ def pytest_configure() -> None:
     os.environ["SETUPTOOLS_SCM_DEBUG"] = "1"
 
 
-VERSION_PKGS = ["setuptools", "setuptools_scm", "packaging"]
+VERSION_PKGS = ["setuptools", "setuptools_scm", "packaging", "build", "wheel"]
 
 
 def pytest_report_header() -> list[str]:

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -112,7 +112,14 @@ def test_pyproject_missing_setup_hook_works(wd: WorkDir, use_scm_version: str) -
     )
     wd.write(
         "pyproject.toml",
-        """[build-system]\nrequires=["setuptools", "setuptools_scm"]\n\n[tool]""",
+        textwrap.dedent(
+            """
+            [build-system]
+            requires=["setuptools", "setuptools_scm"]
+            build-backend = "setuptools.build_meta"
+            [tool]
+            """
+        ),
     )
 
     res = subprocess.run(

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -128,8 +128,6 @@ def test_pyproject_missing_setup_hook_works(wd: WorkDir, use_scm_version: str) -
     res_build = subprocess.run(
         [sys.executable, "-m", "build", "-nxw"],
         env={k: v for k, v in os.environ.items() if k != "SETUPTOOLS_SCM_DEBUG"},
-        capture_output=True,
-        text=True,
         cwd=wd.cwd,
     )
     import pprint

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.metadata
+import os
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -97,6 +99,44 @@ def test_pyproject_support_with_git(wd: WorkDir, metadata_in: str) -> None:
     wd.write("setup.cfg", SETUP_CFG_FILES[metadata_in])
     res = wd([sys.executable, "setup.py", "--version"])
     assert res.endswith("0.1.dev0+d20090213")
+
+
+@pytest.mark.parametrize("use_scm_version", ["True", "{}", "lambda: {}"])
+def test_pyproject_missing_setup_hook_works(wd: WorkDir, use_scm_version: str) -> None:
+    wd.write(
+        "setup.py",
+        f"""__import__('setuptools').setup(
+    name="example-scm-unique",
+    use_scm_version={use_scm_version},
+    )""",
+    )
+    wd.write(
+        "pyproject.toml",
+        """[build-system]\nrequires=["setuptools", "setuptools_scm"]\n\n[tool]""",
+    )
+
+    res = subprocess.run(
+        [sys.executable, "setup.py", "--version"],
+        cwd=wd.cwd,
+        check=True,
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    stripped = res.stdout.strip()
+    assert stripped.endswith("0.1.dev0+d20090213")
+
+    res_build = subprocess.run(
+        [sys.executable, "-m", "build", "-nxw"],
+        env={k: v for k, v in os.environ.items() if k != "SETUPTOOLS_SCM_DEBUG"},
+        capture_output=True,
+        text=True,
+        cwd=wd.cwd,
+    )
+    import pprint
+
+    pprint.pprint(res_build)
+    wheel: Path = next(wd.cwd.joinpath("dist").iterdir())
+    assert "0.1.dev0+d20090213" in str(wheel)
 
 
 def test_pretend_version(monkeypatch: pytest.MonkeyPatch, wd: WorkDir) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps=
     pytest
     setuptools >= 45
     rich
+    build
 commands=
     pytest {posargs}
 


### PR DESCRIPTION
closes #933
closes #938 