### PR TITLE
Reword docker usage hint

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -141,10 +141,12 @@ prevents using needless volatile data there.
 ## with Docker/Podman
 
 
-By default, Docker will not copy the `.git`  folder into your container.
-Therefore, builds with version inference might fail.
-Consequently, you can use the following snippet to infer the version from
-the host OS without copying the entire `.git` folder to your `Dockerfile`.
+In some situations, Docker may not copy the `.git`  into the container when
+building images. Because of this, builds with version inference may fail.
+
+The following snippet exposes the external `.git` directory without copying.
+This allows the version to be inferred properly form inside the container
+without copying the entire `.git` folder into the container image.
 
 ```dockerfile
 RUN --mount=source=.git,target=.git,type=bind \


### PR DESCRIPTION
By default docker copies `.git`, so reworded that a bit. Note that, it **is** good practice to avoid copying `.git` into container images.

The provided snippet doesn't infer the version in the host; it merely mounts the git directory so that the version is inferred inside the container build environment. Corrected this clarification.