### PR TITLE
add 'info' command to cli

### DIFF
--- a/src/setuptools_scm/__main__.py
+++ b/src/setuptools_scm/__main__.py
@@ -3,4 +3,4 @@ from __future__ import annotations
 from ._cli import main
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/setuptools_scm/_cli.py
+++ b/src/setuptools_scm/_cli.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
+from typing import Any
 
 from setuptools_scm import Configuration
 from setuptools_scm._file_finders import find_files
@@ -10,7 +12,7 @@ from setuptools_scm._get_version_impl import _get_version
 from setuptools_scm.discover import walk_potential_roots
 
 
-def main(args: list[str] | None = None) -> None:
+def main(args: list[str] | None = None) -> int:
     opts = _get_cli_opts(args)
     inferred_root: str = opts.root or "."
 
@@ -36,11 +38,8 @@ def main(args: list[str] | None = None) -> None:
         raise SystemExit("ERROR: no version found for", opts)
     if opts.strip_dev:
         version = version.partition(".dev")[0]
-    print(version)
 
-    if opts.command == "ls":
-        for fname in find_files(config.root):
-            print(fname)
+    return command(opts, version, config)
 
 
 def _get_cli_opts(args: list[str] | None) -> argparse.Namespace:
@@ -67,11 +66,104 @@ def _get_cli_opts(args: list[str] | None) -> argparse.Namespace:
         action="store_true",
         help="remove the dev/local parts of the version before printing the version",
     )
+    parser.add_argument(
+        "-N",
+        "--no-version",
+        action="store_true",
+        help="do not include package version in the output",
+    )
+    output_formats = ["json", "plain", "key-value"]
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str.casefold,
+        default="plain",
+        help="specify output format",
+        choices=output_formats,
+    )
+    parser.add_argument(
+        "-q",
+        "--query",
+        type=str.casefold,
+        nargs="*",
+        help="display setuptools_scm settings according to query, "
+        "e.g. dist_name, do not supply an argument in order to "
+        "print a list of valid queries.",
+    )
     sub = parser.add_subparsers(title="extra commands", dest="command", metavar="")
     # We avoid `metavar` to prevent printing repetitive information
-    desc = "List files managed by the SCM"
+    desc = "List information about the package, e.g. included files"
     sub.add_parser("ls", help=desc[0].lower() + desc[1:], description=desc)
     return parser.parse_args(args)
+
+
+# flake8: noqa: C901
+def command(opts: argparse.Namespace, version: str, config: Configuration) -> int:
+    data: dict[str, Any] = {}
+
+    if opts.command == "ls":
+        opts.query = ["files"]
+
+    if opts.query == []:
+        opts.no_version = True
+        sys.stderr.write("Available queries:\n\n")
+        opts.query = ["queries"]
+        data["queries"] = ["files"] + list(config.__dataclass_fields__.keys())
+
+    if opts.query is None:
+        opts.query = []
+
+    if opts.no_version is False:
+        data["version"] = version
+
+    if "files" in opts.query:
+        data["files"] = find_files(config.root)
+
+    for q in opts.query:
+        if q in ["files", "queries", "version"]:
+            continue
+
+        try:
+            if q.startswith("_"):
+                raise AttributeError()
+            data[q] = getattr(config, q)
+        except AttributeError:
+            sys.stderr.write(f"Error: unknown query: '{q}'\n")
+            return 1
+
+    if opts.format == "json":
+        print(json.dumps(data, indent=2))
+
+    if opts.format == "plain":
+        _print_plain(data)
+
+    if opts.format == "key-value":
+        _print_key_value(data)
+
+    return 0
+
+
+def _print_plain(data: dict[Any, Any]) -> None:
+    version = data.pop("version", None)
+    if version:
+        print(version)
+    files = data.pop("files", [])
+    for file_ in files:
+        print(file_)
+    queries = data.pop("queries", [])
+    for query in queries:
+        print(query)
+    if data:
+        print("\n".join(data.values()))
+
+
+def _print_key_value(data: dict[Any, Any]) -> None:
+    for key, value in data.items():
+        if isinstance(value, str):
+            print(f"{key} = {value}")
+        else:
+            str_value = "\n  ".join(value)
+            print(f"{key} = {str_value}")
 
 
 def _find_pyproject(parent: str) -> str:

--- a/src/setuptools_scm/_cli.py
+++ b/src/setuptools_scm/_cli.py
@@ -113,7 +113,7 @@ def command(opts: argparse.Namespace, version: str, config: Configuration) -> in
     if opts.query is None:
         opts.query = []
 
-    if opts.no_version is False:
+    if not opts.no_version:
         data["version"] = version
 
     if "files" in opts.query:
@@ -143,7 +143,7 @@ def command(opts: argparse.Namespace, version: str, config: Configuration) -> in
     return 0
 
 
-def _print_plain(data: dict[Any, Any]) -> None:
+def _print_plain(data: dict[str, Any]) -> None:
     version = data.pop("version", None)
     if version:
         print(version)
@@ -157,7 +157,7 @@ def _print_plain(data: dict[Any, Any]) -> None:
         print("\n".join(data.values()))
 
 
-def _print_key_value(data: dict[Any, Any]) -> None:
+def _print_key_value(data: dict[str, Any]) -> None:
     for key, value in data.items():
         if isinstance(value, str):
             print(f"{key} = {value}")

--- a/src/setuptools_scm/_cli.py
+++ b/src/setuptools_scm/_cli.py
@@ -117,7 +117,7 @@ def command(opts: argparse.Namespace, version: str, config: Configuration) -> in
         opts.no_version = True
         sys.stderr.write("Available queries:\n\n")
         opts.query = ["queries"]
-        data["queries"] = ["files"] + list(config.__dataclass_fields__.keys())
+        data["queries"] = ["files", *config.__dataclass_fields__]
 
     if opts.query is None:
         opts.query = []

--- a/src/setuptools_scm/_cli.py
+++ b/src/setuptools_scm/_cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import sys
+
 from typing import Any
 
 from setuptools_scm import Configuration
@@ -97,7 +98,6 @@ def _get_cli_opts(args: list[str] | None) -> argparse.Namespace:
         action="store_true",
         help="trigger to write the content of the version files\n"
         "its recommended to use normal/editable installation instead)",
-
     )
     sub = parser.add_subparsers(title="extra commands", dest="command", metavar="")
     # We avoid `metavar` to prevent printing repetitive information


### PR DESCRIPTION
Adds an `info` command to the `setuptools_scm` command line. This info command can be used to print settings, like so:

```shell
$ python -m setuptools_scm info dist_name parent root relative_to version_scheme local_scheme tag_regex
dist_name = setuptools-scm
parent = /home/jan/devel/python/setuptools_scm
root = .
relative_to = /home/jan/devel/python/setuptools_scm/pyproject.toml
version_scheme = guess-next-dev
local_scheme = node-and-date
tag_regex = re.compile('^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$')
```

This is only a proof of concept implementation, I could work on tests, stabilization and a proper implementation if that was desired.

### More details and examples:

```shell
$ python -m setuptools_scm --help
usage: python -m setuptools_scm [-h] [-r ROOT] [-c PATH] [--strip-dev]  ...

Print project version according to SCM metadata

options:
  -h, --help            show this help message and exit
  -r ROOT, --root ROOT  directory managed by the SCM, default: inferred from config file, or "."
  -c PATH, --config PATH
                        path to 'pyproject.toml' with setuptools_scm config, default: looked up in the current or parent directories
  --strip-dev           remove the dev/local parts of the version before printing the version

extra commands:
  
    ls                  list files managed by the SCM
    info                display setuptools_scm settings according to query e.g. dist_name

$ python -m setuptools_scm info --help
usage: python -m setuptools_scm info [-h] [query ...]

Display setuptools_scm settings according to query e.g. dist_name

positional arguments:
  query       query string(s) for the desired information, omit for list of valid query strings

options:
  -h, --help  show this help message and exit

$ python -m setuptools_scm info
relative_to
root
version_scheme
local_scheme
tag_regex
parentdir_prefix_version
fallback_version
fallback_root
write_to
write_to_template
version_file
version_file_template
parse
git_describe_command
dist_name
version_cls
search_parent_directories
parent
```