### PR TITLE
Make Sphinx usage example clearer

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -122,7 +122,7 @@ except PackageNotFoundError:
 
 ``` {.python file=docs/.entangled/sphinx_conf.py}
 from importlib.metadata import version as get_version
-release: str = get_version('setuptools_scm')
+release: str = get_version("package-name")
 # for example take major/minor
 version: str = ".".join(release.split('.')[:2])
 ```


### PR DESCRIPTION
Fixes #972 

Follows previous _version at runtime_ usage example in using `"package-name"` as placeholder argument to `importlib.metadata.version` rather than `'setuptools_scm'` to make it clearer that this needs to be changed to relevant package name.