### PR TITLE
Updated `entangled-cli` to account for not having `rich` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 docs = [
-  "entangled_cli[rich]",
+  "entangled-cli~=2.0",
   "mkdocs",
   "mkdocs-entangled-plugin",
   "mkdocs-material",


### PR DESCRIPTION
I observed this message:

```
> pip install -e .[docs]
...
WARNING: entangled-cli 2.0.2 does not provide the extra 'rich'
```

Investigating, I came to https://github.com/entangled/entangled.py/commit/5ae36abbf9dc8ba73906c1a8554e4dc0846eca88, which removes the `extras` for `rich`.

This PR updates the `docs` extra here to match