### PR TITLE
Only depend on typing_extensions for Python < 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "packaging>=20",
   "setuptools",
   'tomli>=1; python_version < "3.11"',
-  "typing-extensions",
+  'typing-extensions; python_version < "3.10"',
 ]
 [project.optional-dependencies]
 docs = [
@@ -61,6 +61,7 @@ test = [
   "build",
   "pytest",
   "rich",
+  'typing-extensions; python_version < "3.11"',
   "wheel",
 ]
 toml = [

--- a/src/setuptools_scm/_file_finders/__init__.py
+++ b/src/setuptools_scm/_file_finders/__init__.py
@@ -12,7 +12,12 @@ from .._entrypoints import iter_entry_points
 from .pathtools import norm_real
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeGuard
+    import sys
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard
+    else:
+        from typing_extensions import TypeGuard
 
 
 log = _log.log.getChild("file_finder")

--- a/src/setuptools_scm/_integration/toml.py
+++ b/src/setuptools_scm/_integration/toml.py
@@ -16,7 +16,10 @@ else:
     from tomli import loads as load_toml
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 from .. import _log
 

--- a/src/setuptools_scm/_types.py
+++ b/src/setuptools_scm/_types.py
@@ -10,7 +10,12 @@ from typing import Tuple
 from typing import Union
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    import sys
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
     from . import version
 

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -18,8 +18,14 @@ from . import _entrypoints
 from . import _modify_version
 
 if TYPE_CHECKING:
-    from typing_extensions import Concatenate
-    from typing_extensions import ParamSpec
+    import sys
+
+    if sys.version_info >= (3, 10):
+        from typing import Concatenate
+        from typing import ParamSpec
+    else:
+        from typing_extensions import Concatenate
+        from typing_extensions import ParamSpec
 
     _P = ParamSpec("_P")
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 
 from pathlib import Path
 from types import TracebackType
@@ -11,7 +12,11 @@ from typing import Iterator
 import pytest
 
 from setuptools_scm._run_cmd import run
-from typing_extensions import Self
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from .wd_wrapper import WorkDir
 


### PR DESCRIPTION
All required types are part of the stdlib as of Python 3.10