### PR TITLE
Fix non-escaped markdown in docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -124,7 +124,7 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
     also using ``setuptools_scm``
 
     the dist name normalization follows adapted PEP 503 semantics, with one or
-    more of ".-_" being replaced by a single "_", and the name being upper-cased
+    more of ".-\_" being replaced by a single "\_", and the name being upper-cased
 
     this will take precedence over ``SETUPTOOLS_SCM_PRETEND_VERSION``
 


### PR DESCRIPTION
The docs presently render a bit strangely due to `_` not being escaped:

<img width="682" alt="Screenshot 2024-02-21 at 08 11 44" src="https://github.com/pypa/setuptools_scm/assets/25671271/d94b4bba-c3c9-4e01-a9a2-e26cfa9a44f4">