### PR TITLE
Read branch data from Mercurial archives

### DIFF
--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -179,6 +179,7 @@ def archival_to_version(data: dict[str, str], config: Configuration) -> ScmVersi
             data["latesttag"],
             distance=int(data["latesttagdistance"]),
             node=node,
+            branch=data.get("branch"),
             config=config,
         )
     else:

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -31,9 +31,15 @@ def wd(wd: WorkDir) -> WorkDir:
 
 archival_mapping = {
     "1.0": {"tag": "1.0"},
-    "1.1.dev3+h000000000000": {
+    "1.1.0.dev3+h000000000000": {
         "latesttag": "1.0",
         "latesttagdistance": "3",
+        "node": "0" * 20,
+    },
+    "1.0.1.dev3+h000000000000": {
+        "latesttag": "1.0.0",
+        "latesttagdistance": "3",
+        "branch": "1.0",
         "node": "0" * 20,
     },
     "0.0": {"node": "0" * 20},
@@ -45,7 +51,7 @@ archival_mapping = {
 @pytest.mark.parametrize(("expected", "data"), sorted(archival_mapping.items()))
 def test_archival_to_version(expected: str, data: dict[str, str]) -> None:
     config = Configuration(
-        version_scheme="guess-next-dev", local_scheme="node-and-date"
+        version_scheme="release-branch-semver", local_scheme="node-and-date"
     )
     version = archival_to_version(data, config=config)
     assert format_version(version) == expected


### PR DESCRIPTION
Mercurial has included branches in `.hg_archival.txt` since about 2009. To easily test this, I adjusted the archival test to use the `release-branch-semver` scheme.