### PR TITLE
Use `typing.TYPE_CHECKING` in _own_version_helper.py

### DIFF
--- a/_own_version_helper.py
+++ b/_own_version_helper.py
@@ -22,9 +22,9 @@ from setuptools_scm.version import guess_next_dev_version
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    
-    from setuptools_scm import _types as _t
+
     from setuptools_scm import Configuration
+    from setuptools_scm import _types as _t
     from setuptools_scm.version import ScmVersion
 
 

--- a/_own_version_helper.py
+++ b/_own_version_helper.py
@@ -10,18 +10,23 @@ from __future__ import annotations
 
 import logging
 
-from typing import Callable
+from typing import TYPE_CHECKING
 
 from setuptools import build_meta as build_meta
-from setuptools_scm import Configuration
-from setuptools_scm import _types as _t
 from setuptools_scm import get_version
 from setuptools_scm import git
 from setuptools_scm import hg
 from setuptools_scm.fallbacks import parse_pkginfo
-from setuptools_scm.version import ScmVersion
 from setuptools_scm.version import get_local_node_and_date
 from setuptools_scm.version import guess_next_dev_version
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    
+    from setuptools_scm import _types as _t
+    from setuptools_scm import Configuration
+    from setuptools_scm.version import ScmVersion
+
 
 log = logging.getLogger("setuptools_scm")
 # todo: take fake entrypoints from pyproject.toml


### PR DESCRIPTION
Separated typing-only imports from runtime imports as part of my open-source mission to improve typing across Python packages.