### PR TITLE
Exclude bots from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
The generated release notes at https://github.com/pypa/setuptools_scm/releases/tag/v8.1.0 are quite hard to read, they're nearly all dependency updates, for things that don't affect end user changes, making it hard to find the real end-user changes.

![image](https://github.com/pypa/setuptools_scm/assets/1324225/e767e036-dfdb-4a93-bfee-a6c9e38cc586)

The good news is GitHub allows us to easily filter those out via `changelog.exclude.authors` in a config file:

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options

Let's use automation to improve the automation :) :robot: :rocket:

See https://github.com/tox-dev/tox-ini-fmt/pull/120 for another example.
