### PR TITLE
support `pipx run setuptools_scm`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ documentation = "https://setuptools-scm.readthedocs.io/"
 repository = "https://github.com/pypa/setuptools_scm/"
 [project.entry-points."distutils.setup_keywords"]
 use_scm_version = "setuptools_scm._integration.setuptools:version_keyword"
+[project.entry-points."pipx.run"]
+setuptools_scm = "setuptools_scm._cli:main"
 [project.entry-points."setuptools.file_finders"]
 setuptools_scm = "setuptools_scm._file_finders:find_files"
 [project.entry-points."setuptools.finalize_distribution_options"]
@@ -103,9 +105,6 @@ PKG-INFO = "setuptools_scm.fallbacks:parse_pkginfo"
 "post-release" = "setuptools_scm.version:postrelease_version"
 "python-simplified-semver" = "setuptools_scm.version:simplified_semver_version"
 "release-branch-semver" = "setuptools_scm.version:release_branch_semver_version"
-[project.entry-points."pipx.run"]
-# support `pipx run setuptools_scm`
-setuptools_scm = "setuptools_scm._cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ PKG-INFO = "setuptools_scm.fallbacks:parse_pkginfo"
 "post-release" = "setuptools_scm.version:postrelease_version"
 "python-simplified-semver" = "setuptools_scm.version:simplified_semver_version"
 "release-branch-semver" = "setuptools_scm.version:release_branch_semver_version"
+[project.entry-points."pipx.run"]
+# support `pipx run setuptools_scm`
+setuptools_scm = "setuptools_scm._cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
Support `pipx run setuptools_scm` by adding a `pipx.run` entry point.

This PR can be validated using
```sh
pipx run --spec git+https://github.com/njzjz/setuptools_scm@patch-1 setuptools_scm
```