### PR TITLE
Apply ruff/tryceratops rule TRY401

### DIFF
--- a/src/setuptools_scm/hg.py
+++ b/src/setuptools_scm/hg.py
@@ -101,8 +101,8 @@ class HgWorkdir(Workdir):
             else:
                 return meta(tag, config=config, node_date=node_date)
 
-        except ValueError as e:
-            log.exception("error %s", e)
+        except ValueError:
+            log.exception("error")
             pass  # unpacking failed, old hg
 
         return None


### PR DESCRIPTION
```
TRY401 Redundant exception object included in `logging.exception` call
```
This is not a style issue. Rather, [`logging.exception()`](https://docs.python.org/3/library/logging.html#logging.exception) is now called the way it was designed to be called, resulting in an error message that is not redundant. From the [`logging.Logger.debug`](https://docs.python.org/3/library/logging.html#logging.Logger.debug) documentation:
> If _exc_info_ does not evaluate as false, it causes exception information to be added to the logging message. If an exception tuple (in the format returned by [`sys.exc_info()`](https://docs.python.org/3/library/sys.html#sys.exc_info)) or an exception instance is provided, it is used; otherwise, [`sys.exc_info()`](https://docs.python.org/3/library/sys.html#sys.exc_info) is called to get the exception information.