### PR TITLE
Better linking Git Archive docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@
 
 ## about
 
-[setuptools-scm] extracts Python package versions from `git` or
-`hg` metadata instead of declaring them as the version argument
-or in an SCM managed file.
+[setuptools-scm] extracts Python package versions from `git` or `hg` metadata
+instead of declaring them as the version argument
+or in a Source Code Managed (SCM) managed file.
 
-Additionally, [setuptools-scm] provides setuptools
-with a list of files that are managed by the SCM <br/>
-(i.e. it automatically adds **all of** the SCM-managed files to the sdist).<br/>
-Unwanted files must be excluded via `MANIFEST.in`.
-
+Additionally [setuptools-scm] provides `setuptools` with a list of
+files that are managed by the SCM
+<br/>
+(i.e. it automatically adds all the SCM-managed files to the sdist).
+<br/>
+Unwanted files must be excluded via `MANIFEST.in`
+or [configuring Git archive][git-archive-docs].
 
 ## `pyproject.toml` usage
 
@@ -71,6 +73,7 @@ For further configuration see the [documentation].
 
 [setuptools-scm]: https://github.com/pypa/setuptools_scm
 [documentation]: https://setuptools-scm.readthedocs.io/
+[git-archive-docs]: https://setuptools-scm.readthedocs.io/en/stable/usage/#builtin-mechanisms-for-obtaining-version-numbers
 
 
 ## Interaction with Enterprise Distributions

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,16 @@
 # About
 
-
 `setuptools_scm` extracts Python package versions from `git` or `hg` metadata
-instead of declaring them as the version argument or in a SCM managed file.
+instead of declaring them as the version argument
+or in a Source Code Managed (SCM) managed file.
 
-Additionally `setuptools_scm` provides setuptools with a list of
-files that are managed by the SCM (i.e. it automatically adds all
-the SCM-managed files to the sdist). Unwanted files must be excluded
-via `MANIFEST.in`.
+Additionally `setuptools_scm` provides `setuptools` with a list of
+files that are managed by the SCM
+(i.e. it automatically adds all the SCM-managed files to the sdist).
+Unwanted files must be excluded via `MANIFEST.in`
+or [configuring Git archive][git-archive-docs].
+
+[git-archive-docs]: usage.md#builtin-mechanisms-for-obtaining-version-numbers
 
 ## basic usage
 


### PR DESCRIPTION
- Better links `git archive` docs, closing https://github.com/pypa/setuptools_scm/issues/1058
- Documents what SCM stands for