### PR TITLE
Apply assorted repo-review rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   rev: v0.3.4
   hooks:
     - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
+      args: [--fix, --exit-non-zero-on-fix, --show-fixes]
     - id: ruff-format
 
 - repo: https://github.com/tox-dev/pyproject-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ repos:
     - id: ruff-format
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: "1.7.0"
+  rev: 1.7.0
   hooks:
     - id: pyproject-fmt
       exclude: docs/examples/
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.9.0'
+    rev: v1.9.0
     hooks:
     -   id: mypy
         args: [--strict]
@@ -31,3 +31,8 @@ repos:
             - importlib_metadata
             - typing-extensions>=4.5
             - rich
+
+-   repo: https://github.com/scientific-python/cookie
+    rev: 2024.04.23
+    hooks:
+      - id: sp-repo-review

--- a/_own_version_helper.py
+++ b/_own_version_helper.py
@@ -13,6 +13,7 @@ import logging
 from typing import Callable
 
 from setuptools import build_meta as build_meta
+
 from setuptools_scm import Configuration
 from setuptools_scm import _types as _t
 from setuptools_scm import get_version

--- a/docs/examples/version_scheme_code/setup.py
+++ b/docs/examples/version_scheme_code/setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from setuptools import setup
+
 from setuptools_scm import ScmVersion
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,11 @@ from-first = false
 lines-between-types = 1
 order-by-type = true
 
+[tool.repo-review]
+ignore = ["PP305", "GH103", "GH212", "MY100", "PC111", "PC160", "PC170", "PC180", "PC901"]
+
 [tool.pytest.ini_options]
+minversion = "7"
 testpaths = ["testing"]
 filterwarnings = [
   "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ version = { attr = "_own_version_helper.version"}
 [tool.setuptools_scm]
 
 [tool.ruff]
+src = ["src"]
 fix = true
 lint.select = ["E", "F", "B", "U", "YTT", "C", "DTZ", "PYI", "PT", "I", "FURB", "RUF"]
 lint.ignore = ["B028"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ filterwarnings = [
 log_level = "debug"
 log_cli_level = "info"
 # disable unraisable until investigated
-addopts = ["-p", "no:unraisableexception"]
+addopts = ["-ra", "--strict-config", "--strict-markers", "-p", "no:unraisableexception"]
 markers = [
   "issue(id): reference to github issue",
   "skip_commit: allows to skip committing in the helpers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ version = { attr = "_own_version_helper.version"}
 [tool.ruff]
 src = ["src"]
 fix = true
-lint.select = ["E", "F", "B", "U", "YTT", "C", "DTZ", "PYI", "PT", "I", "FURB", "RUF"]
+lint.select = ["E", "F", "B", "UP", "YTT", "C", "DTZ", "PYI", "PT", "I", "FURB", "RUF"]
 lint.ignore = ["B028"]
 lint.preview = true
 

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -7,6 +7,7 @@ from datetime import date
 from pathlib import Path
 
 import pytest
+
 import setuptools_scm
 
 from setuptools_scm import Configuration
@@ -15,7 +16,6 @@ from setuptools_scm._run_cmd import run
 from setuptools_scm.integration import data_from_mime
 from setuptools_scm.version import ScmVersion
 from setuptools_scm.version import meta
-
 from testing.wd_wrapper import WorkDir
 
 c = Configuration()

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+
 import setuptools_scm._file_finders
 
 from setuptools_scm import Configuration

--- a/testing/test_hg_git.py
+++ b/testing/test_hg_git.py
@@ -4,7 +4,6 @@ import pytest
 
 from setuptools_scm._run_cmd import has_command
 from setuptools_scm._run_cmd import run
-
 from testing.wd_wrapper import WorkDir
 
 

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -9,6 +9,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
+
 import setuptools_scm._integration.setuptools
 
 from setuptools_scm import Configuration

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 import pytest
+
 import setuptools_scm._file_finders
 
 from setuptools_scm import Configuration
@@ -13,7 +14,6 @@ from setuptools_scm._run_cmd import has_command
 from setuptools_scm.hg import archival_to_version
 from setuptools_scm.hg import parse
 from setuptools_scm.version import format_version
-
 from testing.wd_wrapper import WorkDir
 
 pytestmark = pytest.mark.skipif(


### PR DESCRIPTION
https://learn.scientific-python.org/development/guides/repo-review/?repo=pypa%2Fsetuptools_scm&branch=main

Apply repo-review rules PP306, PP307, PP308
    
> [PP306](https://learn.scientific-python.org/development/guides/pytest#PP306): Specifies strict config
> `--strict-config` should be in `addopts = [...]`. This forces an error if a config setting is misspelled.
> 
> [PP307](https://learn.scientific-python.org/development/guides/pytest#PP307): Specifies strict markers
> `--strict-markers` should be in `addopts = [...]`. This forces all markers to be specified in config, avoiding misspellings.
> 
> [PP308](https://learn.scientific-python.org/development/guides/pytest#PP308): Specifies useful pytest summary
> An explicit summary flag like `-ra` should be in `addopts = [...]` (print summary of all fails/errors).

Apply repo-review rule PC191

> [PC191](https://learn.scientific-python.org/development/guides/style#PC191): Ruff show fixes if fixes enabled
> If `--fix` is present, `--show-fixes` must be too.

Apply repo-review rule RF003

> [RF003](https://learn.scientific-python.org/development/guides/style#RF003): src directory specified if used
> Must specify `src` directory if it exists.

Apply repo-review rule RF103

> [RF103](https://learn.scientific-python.org/development/guides/style#RF103): pyupgrade must be selected
> Must select the pyupgrade `UP` checks.