### PR TITLE
Remove redundant licence definition

### DIFF
--- a/nextgen/vcs-versioning/pyproject.toml
+++ b/nextgen/vcs-versioning/pyproject.toml
@@ -10,13 +10,13 @@ description = "the blessed package to manage your versions by vcs metadata"
 readme = "README.md"
 keywords = [
 ]
-license = "MIT"
 authors = [
   { name = "Ronny Pfannschmidt", email = "opensource@ronnypfannschmidt.de" },
 ]
 requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 1 - Planning",
+  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Drop the licence key, keep the licence classifier.

From the [Python Packaging User Guide](https://packaging.python.org/):
> ### `license`
> 
> This can take two forms. You can put your license in a file, typically `LICENSE` or `LICENSE.txt`, and link that file here:
> ```toml
> [project]
> license = {file = "LICENSE"}
> ```
> or you can write the name of the license:
> ```toml
> [project]
> license = {text = "MIT License"}
> ```
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with `License ::`.