### PR TITLE
Better cleanup PYTHONPATH for Mercurial calls (support for PDM)

### DIFF
--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -117,7 +117,7 @@ def avoid_pip_isolation(env: Mapping[str, str]) -> dict[str, str]:
         [
             path
             for path in new_env["PYTHONPATH"].split(os.pathsep)
-            if "pip-build-env-" not in path
+            if "-build-env-" not in path
         ]
     )
     return new_env


### PR DESCRIPTION
PDM uses the same strategy as pip for the build isolation except that the path of the temporary directory starts with "pdm-build-env-" and not "pip-build-env-".

Therefore, Mercurial (a Python application) installations can be broken and we need to clean up `PYTHONPATH` from such paths. 