### PR TITLE
pipx.run entry-points should be setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ repository = "https://github.com/pypa/setuptools-scm/"
 [project.entry-points."distutils.setup_keywords"]
 use_scm_version = "setuptools_scm._integration.setuptools:version_keyword"
 [project.entry-points."pipx.run"]
+setuptools-scm = "setuptools_scm._cli:main"
 setuptools_scm = "setuptools_scm._cli:main"
 [project.entry-points."setuptools.file_finders"]
 setuptools_scm = "setuptools_scm._file_finders:find_files"


### PR DESCRIPTION
The package is now called setuptools-scm.

`-` are more common than `_` for command names (at least on Linux).

I guess it make more sense to write `pipx run setuptools-scm`.

Note: currently (before next release), this works

```
pipx run --spec setuptools-scm@https://github.com/pypa/setuptools-scm/archive/refs/heads/main.zip setuptools_scm
```