### PR TITLE
Add Configuration.strip_dev and strip dev info if set

### DIFF
--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -103,6 +103,7 @@ class Configuration:
     dist_name: str | None = None
     version_cls: type[_VersionT] = _Version
     search_parent_directories: bool = False
+    strip_dev: bool = False
 
     parent: _t.PathT | None = None
 

--- a/src/setuptools_scm/_get_version_impl.py
+++ b/src/setuptools_scm/_get_version_impl.py
@@ -99,6 +99,9 @@ def _get_version(
     if parsed_version is None:
         return None
     version_string = _format_version(parsed_version)
+    if config.strip_dev:
+        version_string = version_string.partition(".dev")[0]
+
     if force_write_version_files is None:
         force_write_version_files = True
         warnings.warn(


### PR DESCRIPTION
There is no easy way to just do the equivalent of `python -m setuptools_scm --strip-dev` via pyproject.toml

This adds a field strip_dev:bool to the Configuration dataclass which maps to

```toml
[tool.setuptools_scm]
strip_dev = true
```

and when true makes any version computed a non-dev version. the same of `--strip-dev`.

It seems that any other way is to fiddle with python code.

Having python code in large projects means either having the code repeated for each repo, or having to have a single package from which all the build setups needs to depends. This would be ok, but is largely prerible adding a description line to pyproject and avoid the hassle.



