### PR TITLE
Avoid non-monotonic versions

### DIFF
--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -103,6 +103,7 @@ class Configuration:
     dist_name: str | None = None
     version_cls: type[_VersionT] = _Version
     search_parent_directories: bool = False
+    micro_version_factor: int = 1000
 
     parent: _t.PathT | None = None
 

--- a/src/setuptools_scm/version.py
+++ b/src/setuptools_scm/version.py
@@ -295,7 +295,11 @@ def release_branch_semver_version(version: ScmVersion) -> str:
             if branch_ver_up_to_minor == tag_ver_up_to_minor:
                 # We're in a release/maintenance branch, next is a patch/rc/beta bump:
                 return version.format_next_version(guess_next_version)
-    # We're in a development branch, next is a minor bump:
+
+    # We're in a development branch, next is a minor bump, but take
+    # the minor into consideration so that e.g. being five commits off
+    # 1.0.1 is greater than being 10 commits off 1.0.0.
+    version.distance += version.tag.micro * version.config.micro_version_factor
     return version.format_next_version(guess_next_simple_semver, retain=SEMVER_MINOR)
 
 

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -32,7 +32,12 @@ def wd(wd: WorkDir) -> WorkDir:
 archival_mapping = {
     "1.0": {"tag": "1.0"},
     "1.1.0.dev3+h000000000000": {
-        "latesttag": "1.0",
+        "latesttag": "1.0.0",
+        "latesttagdistance": "3",
+        "node": "0" * 20,
+    },
+    "1.1.0.dev103+h000000000000": {
+        "latesttag": "1.0.1",
         "latesttagdistance": "3",
         "node": "0" * 20,
     },
@@ -51,7 +56,9 @@ archival_mapping = {
 @pytest.mark.parametrize(("expected", "data"), sorted(archival_mapping.items()))
 def test_archival_to_version(expected: str, data: dict[str, str]) -> None:
     config = Configuration(
-        version_scheme="release-branch-semver", local_scheme="node-and-date"
+        version_scheme="release-branch-semver",
+        local_scheme="node-and-date",
+        micro_version_factor=100,
     )
     version = archival_to_version(data, config=config)
     assert format_version(version) == expected


### PR DESCRIPTION
Using the `release-branch-semver` scheme, a commit five nodes off e.g. `1.0.0` will get `1.1.0dev5`, but a commit four nodes off `1.0.1` will get `1.1.0dev4`, despite it being more commits from `1.0.0`. To fix this, we add a factor that we use for bumping the distance based on the micro release we're discarding. The default is `1000`; for most projects, that should be _plenty_ of commits per bug-fix release.

Fixes #1025.