### PR TITLE
Add a lower bound pin on setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = [
 ]
 dependencies = [
   "packaging>=20",
-  "setuptools",
+  "setuptools>=61",
   'tomli>=1; python_version < "3.11"',
   'typing-extensions; python_version < "3.10"',
 ]


### PR DESCRIPTION
mitigates #921

The docs and the checks are still inconsistent (setuptools>=61 & setuptools>=64 are used depending on checks or doc).
This aligns the runtime dependency with the check.
