### PR TITLE
Improve the docs about `version_scheme` and `local_scheme`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,7 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
 `local_scheme : str | Callable[[ScmVersion], str]`
 : Configures how the local component of the version (the optional part after the `+`) is constructed;
   either an entrypoint name or a callable.
+  See [Version number construction](extending.md#setuptools_scmlocal_scheme) for predefined implementations.
 
 
 `version_file: Path | PathLike[str] | None = None`

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,7 +11,7 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
 : Relative path to the SCM root, defaults to `.` and is relative to the file path passed in `relative_to`
 
 `version_scheme : str | Callable[[ScmVersion], str]`
-: Configures how the local version number is constructed; either an entrypoint name or a callable.
+: Configures how the version number is constructed; either an entrypoint name or a callable.
   See [Version number construction](extending.md#setuptools_scmversion_scheme) for predefined implementations.
 
 `local_scheme : str | Callable[[ScmVersion], str]`

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,7 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
 
 `version_scheme : str | Callable[[ScmVersion], str]`
 : Configures how the local version number is constructed; either an entrypoint name or a callable.
+  See [Version number construction](extending.md#setuptools_scmversion_scheme) for predefined implementations.
 
 `local_scheme : str | Callable[[ScmVersion], str]`
 : Configures how the local component of the version is constructed

--- a/docs/config.md
+++ b/docs/config.md
@@ -15,7 +15,7 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
   See [Version number construction](extending.md#setuptools_scmversion_scheme) for predefined implementations.
 
 `local_scheme : str | Callable[[ScmVersion], str]`
-: Configures how the local component of the version is constructed
+: Configures how the local component of the version (the optional part after the `+`) is constructed;
   either an entrypoint name or a callable.
 
 


### PR DESCRIPTION
I added cross-references to the implementations. it was confusing to me before that the available options weren't listed in `config.md`. See comments in individual commits for more details.