### PR TITLE
Mention SETUPTOOLS_SCM_PRETEND_VERSION_FOR in error message

### DIFF
--- a/src/setuptools_scm/_get_version_impl.py
+++ b/src/setuptools_scm/_get_version_impl.py
@@ -122,7 +122,10 @@ def _version_missing(config: Configuration) -> NoReturn:
         "metadata and will not work.\n\n"
         "For example, if you're using pip, instead of "
         "https://github.com/user/proj/archive/master.zip "
-        "use git+https://github.com/user/proj.git#egg=proj"
+        "use git+https://github.com/user/proj.git#egg=proj\n\n"
+        "Alternatively, set the version with the environment variable "
+        "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME} as described "
+        "in https://setuptools-scm.readthedocs.io/en/latest/config."
     )
 
 


### PR DESCRIPTION
I think it would be useful to mention `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_...` in the error message.

This would be especially useful for using setuptools-scm for Mercurial development (merge request https://foss.heptapod.net/mercurial/mercurial-devel/-/merge_requests/1207).