### PR TITLE
Add missing code block end.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,6 +79,7 @@ To explore other options, try
 
 ```commandline
 $ python -m setuptools_scm --help
+```
 
 ## At runtime
 


### PR DESCRIPTION
https://setuptools-scm.readthedocs.io/en/latest/usage/ had an issue with the code block:

![CleanShot 2025-02-13 at 11 47 42@2x](https://github.com/user-attachments/assets/b1fe15ce-1544-40cc-a3b6-e9b90f4f47ac)
