### PR TITLE
respect GIT_CEILING_DIRECTORIES

### DIFF
--- a/src/setuptools_scm/_file_finders/git.py
+++ b/src/setuptools_scm/_file_finders/git.py
@@ -72,6 +72,7 @@ def _git_ls_files_and_dirs(toplevel: str) -> tuple[set[str], set[str]]:
     # export-ignore git attribute
 
     cmd = ["git", "archive", "--prefix", toplevel + os.path.sep, "HEAD"]
+    log.info("running %s" % " ".join(str(x) for x in cmd))
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, cwd=toplevel, stderr=subprocess.DEVNULL
     )

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -98,7 +98,8 @@ def no_git_env(env: Mapping[str, str]) -> dict[str, str]:
         k: v
         for k, v in env.items()
         if not k.startswith("GIT_")
-        or k in ("GIT_CEILING_DIRECTORIES", "GIT_EXEC_PATH", "GIT_SSH", "GIT_SSH_COMMAND")
+        or k
+        in ("GIT_CEILING_DIRECTORIES", "GIT_EXEC_PATH", "GIT_SSH", "GIT_SSH_COMMAND")
     }
 
 

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -98,7 +98,7 @@ def no_git_env(env: Mapping[str, str]) -> dict[str, str]:
         k: v
         for k, v in env.items()
         if not k.startswith("GIT_")
-        or k in ("GIT_EXEC_PATH", "GIT_SSH", "GIT_SSH_COMMAND")
+        or k in ("GIT_CEILING_DIRECTORIES", "GIT_EXEC_PATH", "GIT_SSH", "GIT_SSH_COMMAND")
     }
 
 


### PR DESCRIPTION
Fix for https://github.com/pypa/setuptools-scm/issues/1103

When searching for the root-directory of the git repository e.g. with git rev-parse --show-toplevel, git stops the search when reaching $GIT_CEILING_DIRECTORIES. By ignoring this variable, the function _git_toplevel can go above the real git repository (e.g. when packaging a tarball without .git repository), and then runs "git archive" on an unrelated git repository.