### PR TITLE
Enforce more ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,8 @@ version = { attr = "_own_version_helper.version"}
 [tool.setuptools_scm]
 
 [tool.ruff]
-lint.select = ["E", "F", "B", "UP", "YTT", "C", "DTZ", "PYI", "PT", "I", "FURB", "RUF"]
-lint.ignore = ["B028"]
+lint.extend-select = ["YTT", "B", "C4", "DTZ", "ISC", "LOG", "G", "PIE", "PYI", "PT", "FLY", "I", "C90", "PERF", "W", "PGH", "PLE", "UP", "FURB", "RUF"]
+lint.ignore = ["B028", "LOG015", "PERF203"]
 lint.preview = true
 
 [tool.ruff.lint.isort]

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -190,7 +190,7 @@ def has_command(
     try:
         p = run([name, *args], cwd=".")
         if p.returncode != 0:
-            log.error(f"Command '{name}' returned non-zero. This is stderr:")
+            log.error("Command '%s' returned non-zero. This is stderr:", name)
             log.error(p.stderr)
     except OSError as e:
         log.warning("command %s missing: %s", name, e)

--- a/src/setuptools_scm/_version_cls.py
+++ b/src/setuptools_scm/_version_cls.py
@@ -8,7 +8,7 @@ try:
     from packaging.version import InvalidVersion
     from packaging.version import Version as Version
 except ImportError:
-    from setuptools.extern.packaging.version import (  # type: ignore[import-untyped, no-redef]
+    from setuptools.extern.packaging.version import (  # type: ignore[import-not-found, no-redef]
         InvalidVersion,
     )
     from setuptools.extern.packaging.version import (  # type: ignore[no-redef]


### PR DESCRIPTION
Add these rules:
* [flake8-comprehensions (C4)](https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4)
* [flake8-implicit-str-concat (ISC)](https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc)
* [flake8-logging (LOG)](https://docs.astral.sh/ruff/rules/#flake8-logging-log)
* [flake8-logging-format (G)](https://docs.astral.sh/ruff/rules/#flake8-logging-format-g)
* [flake8-pie (PIE)](https://docs.astral.sh/ruff/rules/#flake8-pie-pie)
* [flynt (FLY)](https://docs.astral.sh/ruff/rules/#flynt-fly)
* [mccabe (C90)](https://docs.astral.sh/ruff/rules/#mccabe-c90)
* [Perflint (PERF)](https://docs.astral.sh/ruff/rules/#perflint-perf)
* [pycodestyle (W) ](https://docs.astral.sh/ruff/rules/#warning-w)
* [pygrep-hooks (PGH)](https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh)
* [Pylint (PLE)](https://docs.astral.sh/ruff/rules/#error-ple)

Reorder rules, same order as [ruff documentation](https://docs.astral.sh/ruff/rules/).