### PR TITLE
Python 3.13 (more)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10' ]
+        python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10' ]
         os: [windows-latest, ubuntu-latest] #, macos-latest]
         include:
         - os: windows-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,6 @@ repos:
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]
     - id: ruff-format
 
-- repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v1.8.0
-  hooks:
-    - id: pyproject-fmt
-      exclude: docs/examples/
-
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0
     hooks:

--- a/nextgen/vcs-versioning/pyproject.toml
+++ b/nextgen/vcs-versioning/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = [
   "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Version Control",
   "Topic :: System :: Software Distribution",

--- a/src/setuptools_scm/_version_cls.py
+++ b/src/setuptools_scm/_version_cls.py
@@ -8,7 +8,7 @@ try:
     from packaging.version import InvalidVersion
     from packaging.version import Version as Version
 except ImportError:
-    from setuptools.extern.packaging.version import (  # type: ignore[import-untyped, no-redef]
+    from setuptools.extern.packaging.version import (  # type: ignore[import-not-found, no-redef]
         InvalidVersion,
     )
     from setuptools.extern.packaging.version import (  # type: ignore[no-redef]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{38,39,310,311,312},check_readme,check-dist
+envlist=py{38,39,310,311,312,313},check_readme,check-dist
 requires= tox>4
 
 [flake8]


### PR DESCRIPTION
~~It's unclear why pre-commit wants to discard Python 3.13 support. I cannot reproduce locally.~~

The problem is that the [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) hook version is outdated. Either you accept version 2 and its formatting issues, or you get rid of this hook.

Requires 448838e from #1113 to fix the CI error.