### PR TITLE
Update minimum dependencies on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@
 [build-system]
 build-backend = "_own_version_helper:build_meta"
 requires = [
-  "setuptools>=61",
+  "setuptools>=64",
+  "setuptools>=67;python_version>='3.12'",
   'tomli<=2.0.2; python_version < "3.11"',
 ]
 backend-path = [
@@ -43,6 +44,8 @@ dynamic = [
 dependencies = [
   "packaging>=20",
   "setuptools>=61",
+  "setuptools>=63;python_version>='3.11'",
+  "setuptools>=67;python_version>='3.12'",
   'tomli>=1; python_version < "3.11"',
   'typing-extensions; python_version < "3.10"',
 ]


### PR DESCRIPTION
In another project that has an indirect dependency on setuptools-scm, I am trying to use a feature of uv for CI testing, where it will install the minimum support version of each dependency. This works surprisingly well, with a few minor exceptions.
I have tested the actual minimum versions of setuptools for setuptools-scm for python version 3.9 to 3.13 and added the information.
I would prefer to just up the minimum version for all python versions to 67, however I suspect that this package is sufficient popular that it will be used in linux distribution packages and getting updated setuptools versions are hard get. So for the PR, I created different pinnings for different python versions. But I am more than happy to change this to one version that works for all supported python versions.