### PR TITLE
fix #1112 - unpin minimum setuptools due to ubuntu lts bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - fix #1119: also include pre/post release details in version_tuple
+- fix #1112: unpin setuptools for own dependencies due to ubuntu lts bugs
 
 
 ## v8.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dynamic = [
 ]
 dependencies = [
   "packaging>=20",
-  "setuptools>=61",
+  # https://github.com/pypa/setuptools-scm/issues/1112 - re-pin in a breaking release
+  "setuptools", # >=61",
   'tomli>=1; python_version < "3.11"',
   'typing-extensions; python_version < "3.10"',
 ]


### PR DESCRIPTION
- **fixes #1119: consider all version parts for version tuple**
- **fix #1112: unpin setuptools for ubuntu lts - this re-adds pain**
