### PR TITLE
chore: remove redundant call to require_command()

### DIFF
--- a/src/setuptools_scm/hg_git.py
+++ b/src/setuptools_scm/hg_git.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from . import _types as _t
 from ._run_cmd import CompletedProcess as _CompletedProcess
-from ._run_cmd import require_command
 from ._run_cmd import run as _run
 from .git import GitWorkdir
 from .hg import HgWorkdir
@@ -28,7 +27,6 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
 
     @classmethod
     def from_potential_worktree(cls, wd: _t.PathT) -> GitWorkdirHgClient | None:
-        require_command("hg")
         res = _run(["hg", "root"], cwd=wd).parse_success(parse=Path)
         if res is None:
             return None


### PR DESCRIPTION
In 560a1cb5ff3a3c052e3641034476a3b0554edb86, the call to require_command() was moved from HgWorkdir.from_potential_worktree() to the caller. That caller is the only caller of GitWorkdirHgClient.from_potential_worktree() as well, so it is redundant and can be removed.