### PR TITLE
Add console_scripts entry point to executable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@ repos:
     -   id: debug-statements
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.13
+  rev: v0.12.0
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]
     - id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v1.16.1
     hooks:
     -   id: mypy
         args: [--strict]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ rich = [
   "rich",
 ]
 test = [
+  "pip",
   "build",
   "pytest",
   "rich",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ toml = [
 documentation = "https://setuptools-scm.readthedocs.io/"
 repository = "https://github.com/pypa/setuptools-scm/"
 
+[project.entry-points.console_scripts]
+setuptools-scm = "setuptools_scm._cli:main"
+
 [project.entry-points."distutils.setup_keywords"]
 use_scm_version = "setuptools_scm._integration.setuptools:version_keyword"
 


### PR DESCRIPTION
Added [project.entry-points.console_scripts] section to expose the setuptools-scm CLI via uv and other modern tools.

Without this, uv does not recognize the CLI as an executable.
This resolves installability issues when using setuptools-scm as a tool dependency with uv.


ASIS

```shell
$ uv tool install setuptools-scm        
Resolved 3 packages in 2ms
Installed 3 packages in 8ms
 + packaging==25.0
 + setuptools==80.9.0
 + setuptools-scm==8.3.1
No executables are provided by `setuptools-scm`
```

TOBE
```shell
$ uv tool install setuptools-scm@git+https://github.com/Jeukoh/setuptools-scm.git@feature/make-it-excutable
    Updated https://github.com/Jeukoh/setuptools-scm.git (ab893770fa9dcd0f2caaa4aa8ecf9c01eee15acd)
Resolved 3 packages in 1.71s
      Built setuptools-scm @ git+https://github.com/Jeukoh/setuptools-scm.git@ab893770fa9dcd0f2caaa4aa8ecf9c01eee15acd
Prepared 1 package in 696ms
Installed 3 packages in 12ms
 + packaging==25.0
 + setuptools==80.9.0
 + setuptools-scm==0.1.dev1861+gab89377 (from git+https://github.com/Jeukoh/setuptools-scm.git@ab893770fa9dcd0f2caaa4aa8ecf9c01eee15acd)
Installed 1 executable: setuptools-scm

$ setuptools-scm
8.3.2.dev15+gab89377
```

for info
```shell
$ which setuptools-scm
/home/jeuk/.local/bin/setuptools-scm

$ cat /home/jeuk/.local/bin/setuptools-scm
#!/home/jeuk/.local/share/uv/tools/setuptools-scm/bin/python3
# -*- coding: utf-8 -*-
import sys
from setuptools_scm._cli import main
if __name__ == "__main__":
    if sys.argv[0].endswith("-script.pyw"):
        sys.argv[0] = sys.argv[0][:-11]
    elif sys.argv[0].endswith(".exe"):
        sys.argv[0] = sys.argv[0][:-4]
    sys.exit(main())

$ cd myproject
$ setuptools-scm
setuptools-scm
0.1.0
```