### PR TITLE
revise importing on python 3.9 + bugfixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@ repos:
     -   id: debug-statements
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.3
+  rev: v0.12.4
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]
     - id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.1
+    rev: v1.17.0
     hooks:
     -   id: mypy
         args: [--strict]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- add `setuptools-scm` console_scripts entry point to make the CLI directly executable
+- make Mercurial command configurable by environment variable `SETUPTOOLS_SCM_HG_COMMAND`
+
+### Changed
+
+- add `pip` to test optional dependencies for improved uv venv compatibility
+- migrate to selectable entrypoints for better extensibility
+- improve typing for entry_points
+
+### Fixed
+
+- reintroduce Python 3.9 entrypoints shim for compatibility
+- fix #1136: update customizing.md to fix missing import
+
 ## v8.3.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - fix #1145: ensure GitWorkdir.get_head_date returns consistent UTC dates regardless of local timezone
+- fix #687: ensure calendar versioning tests use consistent time context to prevent failures around midnight in non-UTC timezones
 - reintroduce Python 3.9 entrypoints shim for compatibility
 - fix #1136: update customizing.md to fix missing import
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- fix #1145: ensure GitWorkdir.get_head_date returns consistent UTC dates regardless of local timezone
 - reintroduce Python 3.9 entrypoints shim for compatibility
 - fix #1136: update customizing.md to fix missing import
 

--- a/changelog.d/20250612_144312_me_hg_command.md
+++ b/changelog.d/20250612_144312_me_hg_command.md
@@ -1,4 +1,0 @@
-### Added
-
-- make Mercurial command configurable by environment variable `SETUPTOOLS_SCM_HG_COMMAND`
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
   "setuptools", # >= 61",
   'tomli>=1; python_version < "3.11"',
   'typing-extensions; python_version < "3.10"',
-  'importlib-metadata>=4.6; python_version < "3.10"',
 ]
 [project.optional-dependencies]
 docs = [

--- a/src/setuptools_scm/_run_cmd.py
+++ b/src/setuptools_scm/_run_cmd.py
@@ -81,6 +81,16 @@ class CompletedProcess(BaseCompletedProcess):
             return parse(self.stdout)
 
 
+KEEP_GIT_ENV = (
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_EXEC_PATH",
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
+    "GIT_AUTHOR_DATE",
+    "GIT_COMMITTER_DATE",
+)
+
+
 def no_git_env(env: Mapping[str, str]) -> dict[str, str]:
     # adapted from pre-commit
     # Too many bugs dealing with environment variables and GIT:
@@ -95,11 +105,7 @@ def no_git_env(env: Mapping[str, str]) -> dict[str, str]:
         if k.startswith("GIT_"):
             log.debug("%s: %s", k, v)
     return {
-        k: v
-        for k, v in env.items()
-        if not k.startswith("GIT_")
-        or k
-        in ("GIT_CEILING_DIRECTORIES", "GIT_EXEC_PATH", "GIT_SSH", "GIT_SSH_COMMAND")
+        k: v for k, v in env.items() if not k.startswith("GIT_") or k in KEEP_GIT_ENV
     }
 
 

--- a/src/setuptools_scm/git.py
+++ b/src/setuptools_scm/git.py
@@ -123,7 +123,13 @@ class GitWorkdir(Workdir):
                 return None
             if sys.version_info < (3, 11) and timestamp_text.endswith("Z"):
                 timestamp_text = timestamp_text[:-1] + "+00:00"
-            return datetime.fromisoformat(timestamp_text).date()
+
+            # Convert to UTC to ensure consistent date regardless of local timezone
+            dt = datetime.fromisoformat(timestamp_text)
+            log.debug("dt: %s", dt)
+            dt_utc = dt.astimezone(timezone.utc).date()
+            log.debug("dt utc: %s", dt_utc)
+            return dt_utc
 
         res = run_git(
             [


### PR DESCRIPTION
reintroduces the shim in a simpler way

closes #1145 
addresses [python/importlib-metadata#515](https://github.com/python/importlib_metadata/issues/516)
closes #687 