### PR TITLE
Fix issue #1022: version_keyword should override infer_version when config differs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - add `scm` parameter support to `get_version()` function for nested SCM configuration
 - fix #987: expand documentation on git archival files and add cli tools for good defaults
 - fix #311: document github/gitlab ci pipelines that enable auto-upload to test-pypi/pypi
+- fix #1022: allow `version_keyword` to override `infer_version` when configuration differs
 
 
 ### Changed


### PR DESCRIPTION
Fixes #1022

Allows version_keyword to properly override infer_version when user provides specific configuration like calver schemes, regardless of hook execution order.