### PR TITLE
fix 1184 infer version indirect should ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v9.0.3
+
+### fixed
+
+- fix 1184: verify version is dynamic if the dependency is used as indicator for enabling
+
 ## v9.0.2
 
 ### Fixed

--- a/src/setuptools_scm/_integration/setuptools.py
+++ b/src/setuptools_scm/_integration/setuptools.py
@@ -160,6 +160,10 @@ def infer_version(dist: setuptools.Distribution) -> None:
             return  # No setuptools-scm configuration, silently return
     except (FileNotFoundError, LookupError):
         return  # No pyproject.toml or other issues, silently return
+    except ValueError as e:
+        # Log the error as debug info instead of raising it
+        log.debug("Configuration issue in pyproject.toml: %s", e)
+        return  # Configuration issue, silently return
 
     try:
         config = _config.Configuration.from_file(


### PR DESCRIPTION
verify dynamic version is requested when we use build-requirement as act indication

closes #1184 