### PR TITLE
reiterate version inference logic

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,8 +18,10 @@ include CHANGELOG.md
 
 recursive-include testing *.bash
 prune nextgen
+prune .cursor
 
 recursive-include docs *.md
 include docs/examples/version_scheme_code/*.py
 include docs/examples/version_scheme_code/*.toml
 include mkdocs.yml
+include uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,8 @@ dependencies = [
   'typing-extensions; python_version < "3.10"',
 ]
 [project.optional-dependencies]
-rich = [
-  "rich",
-]
-toml = [
-]
+rich = ["rich"]
+toml = []
 
 [dependency-groups]
 docs = [

--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -291,24 +291,12 @@ class Configuration:
         - **kwargs: additional keyword arguments to pass to the Configuration constructor
         """
 
-        try:
-            if pyproject_data is None:
-                pyproject_data = _read_pyproject(
-                    Path(name), missing_section_ok=missing_section_ok
-                )
-        except FileNotFoundError:
-            if missing_file_ok:
-                log.warning("File %s not found, using empty configuration", name)
-                pyproject_data = PyProjectData(
-                    path=Path(name),
-                    tool_name="setuptools_scm",
-                    project={},
-                    section={},
-                    is_required=False,
-                    section_present=False,
-                )
-            else:
-                raise
+        if pyproject_data is None:
+            pyproject_data = _read_pyproject(
+                Path(name),
+                missing_section_ok=missing_section_ok,
+                missing_file_ok=missing_file_ok,
+            )
         args = _get_args_for_pyproject(pyproject_data, dist_name, kwargs)
 
         args.update(read_toml_overrides(args["dist_name"]))

--- a/src/setuptools_scm/_integration/pyproject_reading.py
+++ b/src/setuptools_scm/_integration/pyproject_reading.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Sequence
 
 from .. import _log
+from .._requirement_cls import extract_package_name
 from .toml import TOML_RESULT
 from .toml import read_toml_content
 
@@ -75,12 +76,7 @@ def has_build_package(
     requires: Sequence[str], build_package_names: Sequence[str]
 ) -> bool:
     for requirement in requires:
-        import re
-
-        # Remove extras like [toml] first
-        clean_req = re.sub(r"\[.*?\]", "", requirement)
-        # Split on version operators and take first part
-        package_name = re.split(r"[><=!~]", clean_req)[0].strip().lower()
+        package_name = extract_package_name(requirement).lower()
         if package_name in build_package_names:
             return True
     return False

--- a/src/setuptools_scm/_integration/pyproject_reading.py
+++ b/src/setuptools_scm/_integration/pyproject_reading.py
@@ -73,11 +73,11 @@ class PyProjectData:
 
 
 def has_build_package(
-    requires: Sequence[str], build_package_names: Sequence[str]
+    requires: Sequence[str], canonical_build_package_name: str
 ) -> bool:
     for requirement in requires:
-        package_name = extract_package_name(requirement).lower()
-        if package_name in build_package_names:
+        package_name = extract_package_name(requirement)
+        if package_name == canonical_build_package_name:
             return True
     return False
 
@@ -85,7 +85,7 @@ def has_build_package(
 def read_pyproject(
     path: Path = Path("pyproject.toml"),
     tool_name: str = "setuptools_scm",
-    build_package_names: Sequence[str] = ("setuptools_scm", "setuptools-scm"),
+    canonical_build_package_name: str = "setuptools-scm",
     missing_section_ok: bool = False,
     missing_file_ok: bool = False,
 ) -> PyProjectData:
@@ -107,7 +107,7 @@ def read_pyproject(
             raise
 
     requires: list[str] = defn.get("build-system", {}).get("requires", [])
-    is_required = has_build_package(requires, build_package_names)
+    is_required = has_build_package(requires, canonical_build_package_name)
 
     try:
         section = defn.get("tool", {})[tool_name]

--- a/src/setuptools_scm/_integration/setup_cfg.py
+++ b/src/setuptools_scm/_integration/setup_cfg.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+
+import setuptools
+
+
+def read_dist_name_from_setup_cfg(
+    input: str | os.PathLike[str] = "setup.cfg",
+) -> str | None:
+    # minimal effort to read dist_name off setup.cfg metadata
+    import configparser
+
+    parser = configparser.ConfigParser()
+    parser.read([input], encoding="utf-8")
+    dist_name = parser.get("metadata", "name", fallback=None)
+    return dist_name
+
+
+def _dist_name_from_legacy(dist: setuptools.Distribution) -> str | None:
+    return dist.metadata.name or read_dist_name_from_setup_cfg()

--- a/src/setuptools_scm/_integration/setuptools.py
+++ b/src/setuptools_scm/_integration/setuptools.py
@@ -39,25 +39,6 @@ Suggested workaround if applicable:
         )
 
 
-def _extract_package_name(requirement: str) -> str:
-    """Extract the package name from a requirement string.
-
-    Examples:
-        'setuptools_scm' -> 'setuptools_scm'
-        'setuptools-scm>=8' -> 'setuptools-scm'
-        'setuptools_scm[toml]>=7.0' -> 'setuptools_scm'
-    """
-    # Split on common requirement operators and take the first part
-    # This handles: >=, <=, ==, !=, >, <, ~=
-    import re
-
-    # Remove extras like [toml] first
-    requirement = re.sub(r"\[.*?\]", "", requirement)
-    # Split on version operators
-    package_name = re.split(r"[><=!~]", requirement)[0].strip()
-    return package_name
-
-
 def _assign_version(
     dist: setuptools.Distribution, config: _config.Configuration
 ) -> None:

--- a/src/setuptools_scm/_integration/setuptools.py
+++ b/src/setuptools_scm/_integration/setuptools.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import warnings
 
 from pathlib import Path
@@ -11,20 +10,14 @@ from typing import Callable
 import setuptools
 
 from .. import _config
+from .pyproject_reading import read_pyproject
+from .setup_cfg import _dist_name_from_legacy
+from .version_inference import VersionInferenceConfig
+from .version_inference import VersionInferenceError
+from .version_inference import VersionInferenceException
+from .version_inference import get_version_inference_config
 
 log = logging.getLogger(__name__)
-
-
-def read_dist_name_from_setup_cfg(
-    input: str | os.PathLike[str] = "setup.cfg",
-) -> str | None:
-    # minimal effort to read dist_name off setup.cfg metadata
-    import configparser
-
-    parser = configparser.ConfigParser()
-    parser.read([input], encoding="utf-8")
-    dist_name = parser.get("metadata", "name", fallback=None)
-    return dist_name
 
 
 def _warn_on_old_setuptools(_version: str = setuptools.__version__) -> None:
@@ -85,7 +78,7 @@ _warn_on_old_setuptools()
 
 
 def _log_hookstart(hook: str, dist: setuptools.Distribution) -> None:
-    log.debug("%s %r", hook, vars(dist.metadata))
+    log.debug("%s %s %s %r", hook, id(dist), id(dist.metadata), vars(dist.metadata))
 
 
 def version_keyword(
@@ -93,6 +86,7 @@ def version_keyword(
     keyword: str,
     value: bool | dict[str, Any] | Callable[[], dict[str, Any]],
 ) -> None:
+    # Parse overrides (integration point responsibility)
     overrides: dict[str, Any]
     if value is True:
         overrides = {}
@@ -105,73 +99,96 @@ def version_keyword(
     assert "dist_name" not in overrides, (
         "dist_name may not be specified in the setup keyword "
     )
-    dist_name: str | None = dist.metadata.name
+
+    dist_name: str | None = _dist_name_from_legacy(dist)
+
+    was_set_by_infer = getattr(dist, "_setuptools_scm_version_set_by_infer", False)
     _log_hookstart("version_keyword", dist)
 
-    if dist.metadata.version is not None:
-        # Check if version was set by infer_version
-        was_set_by_infer = getattr(dist, "_setuptools_scm_version_set_by_infer", False)
+    # Get pyproject data
+    try:
+        pyproject_data = read_pyproject(
+            Path("pyproject.toml"), missing_section_ok=True, missing_file_ok=True
+        )
+    except (LookupError, ValueError) as e:
+        log.debug("Configuration issue in pyproject.toml: %s", e)
+        return
 
+    # Get decision
+    result = get_version_inference_config(
+        dist_name=dist_name,
+        current_version=dist.metadata.version,
+        pyproject_data=pyproject_data,
+        overrides=overrides,
+        was_set_by_infer=was_set_by_infer,
+    )
+
+    # Handle result
+    if result is None:
+        return  # Don't infer
+    elif isinstance(result, VersionInferenceError):
+        if result.should_warn:
+            warnings.warn(result.message)
+        return
+    elif isinstance(result, VersionInferenceException):
+        raise result.exception
+    elif isinstance(result, VersionInferenceConfig):
+        # Clear version if it was set by infer_version
         if was_set_by_infer:
-            # Version was set by infer_version, check if we have overrides
-            if not overrides:
-                # No overrides, just use the infer_version result
-                return
-            # We have overrides, clear the marker and proceed to override the version
             dist._setuptools_scm_version_set_by_infer = False  # type: ignore[attr-defined]
             dist.metadata.version = None
-        else:
-            # Version was set by something else, warn and return
-            warnings.warn(f"version of {dist_name} already set")
-            return
 
-    if dist_name is None:
-        dist_name = read_dist_name_from_setup_cfg()
-
-    config = _config.Configuration.from_file(
-        dist_name=dist_name,
-        missing_file_ok=True,
-        missing_section_ok=True,
-        **overrides,
-    )
-    _assign_version(dist, config)
+        # Proceed with inference
+        config = _config.Configuration.from_file(
+            dist_name=result.dist_name,
+            pyproject_data=result.pyproject_data,
+            missing_file_ok=True,
+            missing_section_ok=True,
+            **overrides,
+        )
+        _assign_version(dist, config)
 
 
 def infer_version(dist: setuptools.Distribution) -> None:
     _log_hookstart("infer_version", dist)
-    log.debug("dist %s %s", id(dist), id(dist.metadata))
-    if dist.metadata.version is not None:
-        return  # metadata already added by hook
-    dist_name = dist.metadata.name
-    if dist_name is None:
-        dist_name = read_dist_name_from_setup_cfg()
-    if not os.path.isfile("pyproject.toml"):
-        return
-    if dist_name == "setuptools-scm":
-        return
 
-    # Check if setuptools-scm is configured before proceeding
+    dist_name = _dist_name_from_legacy(dist)
+
+    # Get pyproject data (integration point responsibility)
     try:
-        from .pyproject_reading import read_pyproject
-
         pyproject_data = read_pyproject(Path("pyproject.toml"), missing_section_ok=True)
-        # Only proceed if setuptools-scm is either in build_requires or has a tool section
-        if not pyproject_data.is_required and not pyproject_data.section_present:
-            return  # No setuptools-scm configuration, silently return
-    except (FileNotFoundError, LookupError):
-        return  # No pyproject.toml or other issues, silently return
-    except ValueError as e:
-        # Log the error as debug info instead of raising it
+    except FileNotFoundError:
+        log.debug("pyproject.toml not found")
+        return
+    except (LookupError, ValueError) as e:
         log.debug("Configuration issue in pyproject.toml: %s", e)
-        return  # Configuration issue, silently return
+        return
 
-    try:
-        config = _config.Configuration.from_file(
-            dist_name=dist_name, pyproject_data=pyproject_data
-        )
-    except LookupError as e:
-        log.info(e, exc_info=True)
-    else:
-        _assign_version(dist, config)
-        # Mark that this version was set by infer_version
-        dist._setuptools_scm_version_set_by_infer = True  # type: ignore[attr-defined]
+    # Get decision
+    result = get_version_inference_config(
+        dist_name=dist_name,
+        current_version=dist.metadata.version,
+        pyproject_data=pyproject_data,
+    )
+
+    # Handle result
+    if result is None:
+        return  # Don't infer
+    elif isinstance(result, VersionInferenceError):
+        if result.should_warn:
+            log.warning(result.message)
+        return
+    elif isinstance(result, VersionInferenceException):
+        raise result.exception
+    elif isinstance(result, VersionInferenceConfig):
+        # Proceed with inference
+        try:
+            config = _config.Configuration.from_file(
+                dist_name=result.dist_name, pyproject_data=result.pyproject_data
+            )
+        except LookupError as e:
+            log.info(e, exc_info=True)
+        else:
+            _assign_version(dist, config)
+            # Mark that this version was set by infer_version
+            dist._setuptools_scm_version_set_by_infer = True  # type: ignore[attr-defined]

--- a/src/setuptools_scm/_integration/version_inference.py
+++ b/src/setuptools_scm/_integration/version_inference.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Union
+
+from .. import _log
+
+if TYPE_CHECKING:
+    from .pyproject_reading import PyProjectData
+
+log = _log.log.getChild("version_inference")
+
+
+@dataclass
+class VersionInferenceConfig:
+    """Configuration for version inference."""
+
+    dist_name: str | None
+    pyproject_data: PyProjectData | None
+    overrides: dict[str, Any]
+
+
+@dataclass
+class VersionInferenceError:
+    """Error message for user."""
+
+    message: str
+    should_warn: bool = False
+
+
+@dataclass
+class VersionInferenceException:
+    """Exception that should be raised."""
+
+    exception: Exception
+
+
+VersionInferenceResult = Union[
+    VersionInferenceConfig,  # Proceed with inference
+    VersionInferenceError,  # Show error/warning
+    VersionInferenceException,  # Raise exception
+    None,  # Don't infer (silent)
+]
+
+
+def get_version_inference_config(
+    dist_name: str | None,
+    current_version: str | None,
+    pyproject_data: PyProjectData,
+    overrides: dict[str, Any] | None = None,
+    was_set_by_infer: bool = False,
+) -> VersionInferenceResult:
+    """
+    Determine whether and how to perform version inference.
+
+    Args:
+        dist_name: The distribution name
+        current_version: Current version if any
+        pyproject_data: PyProjectData from parser (None if file doesn't exist)
+        overrides: Override configuration (None for no overrides)
+        was_set_by_infer: Whether current version was set by infer_version
+
+    Returns:
+        VersionInferenceResult with the decision and configuration
+    """
+    if dist_name is None:
+        dist_name = pyproject_data.project_name
+
+    # Handle version already set
+    if current_version is not None:
+        if was_set_by_infer:
+            if overrides is not None:
+                # Clear version and proceed with overrides
+                return VersionInferenceConfig(
+                    dist_name=dist_name,
+                    pyproject_data=pyproject_data,
+                    overrides=overrides,
+                )
+            else:
+                # Keep existing version from infer_version
+                return None
+        else:
+            # Version set by something else
+            return VersionInferenceError(
+                f"version of {dist_name} already set", should_warn=True
+            )
+
+    # Handle setuptools-scm package
+    if dist_name == "setuptools-scm":
+        return None
+
+    # Handle missing configuration
+    if not pyproject_data.is_required and not pyproject_data.section_present:
+        # If there are overrides, proceed with inference (explicit use_scm_version)
+        if overrides is not None:
+            return VersionInferenceConfig(
+                dist_name=dist_name,
+                pyproject_data=pyproject_data,
+                overrides=overrides,
+            )
+        return None
+
+    # Handle missing project section when required
+    if (
+        pyproject_data.is_required
+        and not pyproject_data.section_present
+        and not pyproject_data.project_present
+    ):
+        return None
+
+    # All conditions met - proceed with inference
+    return VersionInferenceConfig(
+        dist_name=dist_name,
+        pyproject_data=pyproject_data,
+        overrides=overrides or {},
+    )

--- a/src/setuptools_scm/_integration/version_inference.py
+++ b/src/setuptools_scm/_integration/version_inference.py
@@ -19,7 +19,40 @@ class VersionInferenceConfig:
 
     dist_name: str | None
     pyproject_data: PyProjectData | None
-    overrides: dict[str, Any]
+    overrides: dict[str, Any] | None
+
+    def apply(self, dist: Any) -> None:
+        """Apply version inference to the distribution."""
+        from .. import _config as _config_module
+        from .._get_version_impl import _get_version
+        from .._get_version_impl import _version_missing
+
+        # Clear version if it was set by infer_version (overrides is None means infer_version context)
+        # OR if we have overrides (version_keyword context) and the version was set by infer_version
+        was_set_by_infer = getattr(dist, "_setuptools_scm_version_set_by_infer", False)
+        if was_set_by_infer and (self.overrides is None or self.overrides):
+            dist._setuptools_scm_version_set_by_infer = False
+            dist.metadata.version = None
+
+        config = _config_module.Configuration.from_file(
+            dist_name=self.dist_name,
+            pyproject_data=self.pyproject_data,
+            missing_file_ok=True,
+            missing_section_ok=True,
+            **(self.overrides or {}),
+        )
+
+        # Get and assign version
+        maybe_version = _get_version(config, force_write_version_files=True)
+        if maybe_version is None:
+            _version_missing(config)
+        else:
+            assert dist.metadata.version is None
+            dist.metadata.version = maybe_version
+
+        # Mark that this version was set by infer_version if overrides is None (infer_version context)
+        if self.overrides is None:
+            dist._setuptools_scm_version_set_by_infer = True
 
 
 @dataclass
@@ -29,6 +62,13 @@ class VersionInferenceError:
     message: str
     should_warn: bool = False
 
+    def apply(self, dist: Any) -> None:
+        """Apply error handling to the distribution."""
+        import warnings
+
+        if self.should_warn:
+            warnings.warn(self.message)
+
 
 @dataclass
 class VersionInferenceException:
@@ -36,12 +76,23 @@ class VersionInferenceException:
 
     exception: Exception
 
+    def apply(self, dist: Any) -> None:
+        """Apply exception handling to the distribution."""
+        raise self.exception
+
+
+class VersionInferenceNoOp:
+    """No operation result - silent skip."""
+
+    def apply(self, dist: Any) -> None:
+        """Apply no-op to the distribution."""
+
 
 VersionInferenceResult = Union[
     VersionInferenceConfig,  # Proceed with inference
     VersionInferenceError,  # Show error/warning
     VersionInferenceException,  # Raise exception
-    None,  # Don't infer (silent)
+    VersionInferenceNoOp,  # Don't infer (silent)
 ]
 
 
@@ -71,16 +122,26 @@ def get_version_inference_config(
     # Handle version already set
     if current_version is not None:
         if was_set_by_infer:
-            if overrides is not None:
-                # Clear version and proceed with overrides
+            if overrides is not None and overrides:
+                # Clear version and proceed with actual overrides (non-empty dict)
                 return VersionInferenceConfig(
                     dist_name=dist_name,
                     pyproject_data=pyproject_data,
                     overrides=overrides,
                 )
             else:
-                # Keep existing version from infer_version
-                return None
+                # Keep existing version from infer_version (no overrides or empty overrides)
+                # But allow re-inferring if this is another infer_version call
+                if overrides is None:
+                    # This is another infer_version call, allow it to proceed
+                    return VersionInferenceConfig(
+                        dist_name=dist_name,
+                        pyproject_data=pyproject_data,
+                        overrides=overrides,
+                    )
+                else:
+                    # This is version_keyword with empty overrides, keep existing version
+                    return VersionInferenceNoOp()
         else:
             # Version set by something else
             return VersionInferenceError(
@@ -89,7 +150,7 @@ def get_version_inference_config(
 
     # Handle setuptools-scm package
     if dist_name == "setuptools-scm":
-        return None
+        return VersionInferenceNoOp()
 
     # Handle missing configuration
     if not pyproject_data.is_required and not pyproject_data.section_present:
@@ -100,7 +161,7 @@ def get_version_inference_config(
                 pyproject_data=pyproject_data,
                 overrides=overrides,
             )
-        return None
+        return VersionInferenceNoOp()
 
     # Handle missing project section when required
     if (
@@ -108,11 +169,11 @@ def get_version_inference_config(
         and not pyproject_data.section_present
         and not pyproject_data.project_present
     ):
-        return None
+        return VersionInferenceNoOp()
 
     # All conditions met - proceed with inference
     return VersionInferenceConfig(
         dist_name=dist_name,
         pyproject_data=pyproject_data,
-        overrides=overrides or {},
+        overrides=overrides,
     )

--- a/src/setuptools_scm/_requirement_cls.py
+++ b/src/setuptools_scm/_requirement_cls.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+try:
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+except ImportError:
+    from setuptools.extern.packaging.requirements import (  # type: ignore[import-not-found,no-redef]
+        Requirement as Requirement,
+    )
+    from setuptools.extern.packaging.utils import (  # type: ignore[import-not-found,no-redef]
+        canonicalize_name as canonicalize_name,
+    )
+
+from . import _log
+
+log = _log.log.getChild("requirement_cls")
+
+
+def extract_package_name(requirement_string: str) -> str:
+    """Extract the canonical package name from a requirement string.
+
+    This function uses packaging.requirements.Requirement to properly parse
+    the requirement and extract the package name, handling all edge cases
+    that the custom regex-based approach might miss.
+
+    Args:
+        requirement_string: The requirement string to parse
+
+    Returns:
+        The package name as a string
+    """
+    return canonicalize_name(Requirement(requirement_string).name)

--- a/testing/test_basic_api.py
+++ b/testing/test_basic_api.py
@@ -106,7 +106,7 @@ setup(use_scm_version={"fallback_version": "12.34"})
 
 
 def test_empty_pretend_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
+    # monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION", "")
     p = tmp_path / "sub/package"
     p.mkdir(parents=True)

--- a/testing/test_better_root_errors.py
+++ b/testing/test_better_root_errors.py
@@ -138,7 +138,7 @@ def test_version_missing_with_relative_to_set(wd: WorkDir) -> None:
 
     # Create a dummy file to use as relative_to
     dummy_file = subdir / "setup.py"
-    dummy_file.write_text("# dummy file")
+    dummy_file.write_text("# dummy file", encoding="utf-8")
 
     # Test error message when relative_to IS set
     config = Configuration(root=str(subdir), relative_to=str(dummy_file))

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -666,7 +666,7 @@ def test_fail_on_missing_submodules_with_initialized_submodules(wd: WorkDir) -> 
 
     # Create a commit in the submodule
     test_file = submodule_dir / "test.txt"
-    test_file.write_text("test content")
+    test_file.write_text("test content", encoding="utf-8")
     wd(["git", "-C", str(submodule_dir), "add", "test.txt"])
     wd(["git", "-C", str(submodule_dir), "commit", "-m", "Initial commit"])
 
@@ -741,7 +741,7 @@ def test_nested_scm_git_config_from_toml(tmp_path: Path) -> None:
 [tool.setuptools_scm.scm.git]
 pre_parse = "fail_on_missing_submodules"
 """
-    pyproject_path.write_text(pyproject_content)
+    pyproject_path.write_text(pyproject_content, encoding="utf-8")
 
     # Parse the configuration from file
     config = Configuration.from_file(pyproject_path)

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -818,17 +818,15 @@ def test_pyproject_build_system_requires_priority_over_tool_section(
     assert res.endswith("0.1.dev0+d20090213")
 
 
-def test_extract_package_name() -> None:
+@pytest.mark.parametrize("base_name", ["setuptools_scm", "setuptools-scm"])
+@pytest.mark.parametrize(
+    "requirements",
+    ["", ">=8", "[toml]>=7", "~=9.0", "[rich,toml]>=8"],
+    ids=["empty", "version", "extras", "fuzzy", "multiple-extras"],
+)
+def test_extract_package_name(base_name: str, requirements: str) -> None:
     """Test the _extract_package_name helper function"""
-    assert _extract_package_name("setuptools_scm") == "setuptools_scm"
-    assert _extract_package_name("setuptools-scm") == "setuptools-scm"
-    assert _extract_package_name("setuptools_scm>=8") == "setuptools_scm"
-    assert _extract_package_name("setuptools-scm>=8") == "setuptools-scm"
-    assert _extract_package_name("setuptools_scm[toml]>=7.0") == "setuptools_scm"
-    assert _extract_package_name("setuptools-scm[toml]>=7.0") == "setuptools-scm"
-    assert _extract_package_name("setuptools_scm==8.0.0") == "setuptools_scm"
-    assert _extract_package_name("setuptools_scm~=8.0") == "setuptools_scm"
-    assert _extract_package_name("setuptools_scm[rich,toml]>=8") == "setuptools_scm"
+    assert _extract_package_name(f"{base_name}{requirements}") == base_name
 
 
 def test_build_requires_integration_with_config_reading(wd: WorkDir) -> None:

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -18,11 +18,12 @@ from packaging.version import Version
 
 import setuptools_scm._integration.setuptools
 
+from setuptools_scm._requirement_cls import extract_package_name
+
 if TYPE_CHECKING:
     import setuptools
 
 from setuptools_scm import Configuration
-from setuptools_scm._integration.setuptools import _extract_package_name
 from setuptools_scm._integration.setuptools import _warn_on_old_setuptools
 from setuptools_scm._overrides import PRETEND_KEY
 from setuptools_scm._overrides import PRETEND_KEY_NAMED
@@ -826,7 +827,7 @@ def test_pyproject_build_system_requires_priority_over_tool_section(
 )
 def test_extract_package_name(base_name: str, requirements: str) -> None:
     """Test the _extract_package_name helper function"""
-    assert _extract_package_name(f"{base_name}{requirements}") == base_name
+    assert extract_package_name(f"{base_name}{requirements}") == "setuptools-scm"
 
 
 def test_build_requires_integration_with_config_reading(wd: WorkDir) -> None:

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -339,7 +339,7 @@ num_commit = {scm_version.distance}
         write_to="src/version.py", write_to_template=version_file_content
     )
 
-    content = (wd.cwd / "src/version.py").read_text()
+    content = (wd.cwd / "src/version.py").read_text(encoding="utf-8")
     assert "commit_hash = 'g1337beef'" in content
     assert "num_commit = 4" in content
 
@@ -412,7 +412,7 @@ num_commit = {scm_version.distance}
         write_to="src/version.py", write_to_template=version_file_content
     )
 
-    content = (wd.cwd / "src/version.py").read_text()
+    content = (wd.cwd / "src/version.py").read_text(encoding="utf-8")
     assert "commit_hash = 'gcustom123'" in content
     assert "num_commit = 7" in content
 

--- a/testing/test_pyproject_reading.py
+++ b/testing/test_pyproject_reading.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from setuptools_scm._integration.pyproject_reading import read_pyproject
+
+
+class TestPyProjectReading:
+    """Test the pyproject reading functionality."""
+
+    def test_read_pyproject_missing_file_ok(self, tmp_path: Path) -> None:
+        """Test that read_pyproject handles missing files when missing_file_ok=True."""
+        # Test with missing_file_ok=True
+        result = read_pyproject(
+            path=tmp_path / "nonexistent.toml", missing_file_ok=True
+        )
+
+        assert result.path == tmp_path / "nonexistent.toml"
+        assert result.tool_name == "setuptools_scm"
+        assert result.project == {}
+        assert result.section == {}
+        assert result.is_required is False
+        assert result.section_present is False
+        assert result.project_present is False
+
+    def test_read_pyproject_missing_file_not_ok(self, tmp_path: Path) -> None:
+        """Test that read_pyproject raises FileNotFoundError when missing_file_ok=False."""
+        with pytest.raises(FileNotFoundError):
+            read_pyproject(path=tmp_path / "nonexistent.toml", missing_file_ok=False)
+
+    def test_read_pyproject_existing_file(self, tmp_path: Path) -> None:
+        """Test that read_pyproject reads existing files correctly."""
+        # Create a simple pyproject.toml
+        pyproject_content = """
+[build-system]
+requires = ["setuptools>=80", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-package"
+dynamic = ["version"]
+
+[tool.setuptools_scm]
+"""
+        pyproject_file = tmp_path / "pyproject.toml"
+        pyproject_file.write_text(pyproject_content)
+
+        result = read_pyproject(path=pyproject_file)
+
+        assert result.path == pyproject_file
+        assert result.tool_name == "setuptools_scm"
+        assert result.is_required is True
+        assert result.section_present is True
+        assert result.project_present is True
+        assert result.project.get("name") == "test-package"

--- a/testing/test_pyproject_reading.py
+++ b/testing/test_pyproject_reading.py
@@ -45,7 +45,7 @@ dynamic = ["version"]
 [tool.setuptools_scm]
 """
         pyproject_file = tmp_path / "pyproject.toml"
-        pyproject_file.write_text(pyproject_content)
+        pyproject_file.write_text(pyproject_content, encoding="utf-8")
 
         result = read_pyproject(path=pyproject_file)
 

--- a/testing/test_regressions.py
+++ b/testing/test_regressions.py
@@ -114,7 +114,8 @@ def test_case_mismatch_nested_dir_windows_git(tmp_path: Path) -> None:
     nested_dir.mkdir()
 
     # Create a pyproject.toml in the nested directory
-    (nested_dir / "pyproject.toml").write_text("""
+    (nested_dir / "pyproject.toml").write_text(
+        """
 [build-system]
 requires = ["setuptools>=64", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
@@ -124,7 +125,9 @@ name = "test-project"
 dynamic = ["version"]
 
 [tool.setuptools_scm]
-""")
+""",
+        encoding="utf-8",
+    )
 
     # Add and commit the file
     run("git add .", repo_path)
@@ -159,7 +162,7 @@ def test_case_mismatch_force_assertion_failure(tmp_path: Path) -> None:
     nested_dir.mkdir()
 
     # Add and commit something to make it a valid repo
-    (nested_dir / "test.txt").write_text("test")
+    (nested_dir / "test.txt").write_text("test", encoding="utf-8")
     run("git add .", repo_path)
     run("git commit -m 'Initial commit'", repo_path)
 

--- a/testing/test_version_inference.py
+++ b/testing/test_version_inference.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from setuptools_scm._integration.pyproject_reading import PyProjectData
+from setuptools_scm._integration.version_inference import VersionInferenceConfig
+from setuptools_scm._integration.version_inference import VersionInferenceError
+from setuptools_scm._integration.version_inference import VersionInferenceException
+from setuptools_scm._integration.version_inference import get_version_inference_config
+
+
+class TestVersionInferenceDecision:
+    """Test the version inference decision logic."""
+
+    def test_version_already_set_by_infer_with_overrides(self) -> None:
+        """Test that we proceed when version was set by infer_version but overrides provided."""
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version="1.0.0",
+            pyproject_data=PyProjectData.for_testing(True, True, True),
+            overrides={"key": "value"},
+            was_set_by_infer=True,
+        )
+
+        assert isinstance(result, VersionInferenceConfig)
+        assert result.dist_name == "test_package"
+        assert result.overrides == {"key": "value"}
+
+    def test_version_already_set_by_infer_no_overrides(self) -> None:
+        """Test that we don't proceed when version was set by infer_version with no overrides."""
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version="1.0.0",
+            pyproject_data=PyProjectData.for_testing(True, True, True),
+            overrides=None,
+            was_set_by_infer=True,
+        )
+
+        assert result is None
+
+    def test_version_already_set_by_something_else(self) -> None:
+        """Test that we return error when version was set by something else."""
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version="1.0.0",
+            pyproject_data=PyProjectData.for_testing(True, True, True),
+            overrides=None,
+            was_set_by_infer=False,
+        )
+
+        assert isinstance(result, VersionInferenceError)
+        assert result.message == "version of test_package already set"
+        assert result.should_warn is True
+
+    def test_setuptools_scm_package(self) -> None:
+        """Test that we don't infer for setuptools-scm package itself."""
+        result = get_version_inference_config(
+            dist_name="setuptools-scm",
+            current_version=None,
+            pyproject_data=PyProjectData.for_testing(True, True, True),
+        )
+
+        assert result is None
+
+    def test_no_pyproject_toml(self) -> None:
+        """Test that we don't infer when no pyproject.toml exists."""
+        # When no pyproject.toml exists, the integration points should return early
+        # and not call get_version_inference_config at all.
+        # This test is no longer needed as pyproject_data is always required.
+
+    def test_no_setuptools_scm_config(self) -> None:
+        """Test that we don't infer when setuptools-scm is not configured."""
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version=None,
+            pyproject_data=PyProjectData.for_testing(False, False, True),
+        )
+
+        assert result is None
+
+    def test_setuptools_scm_required_no_project_section(self) -> None:
+        """Test that we don't infer when setuptools-scm is required but no project section."""
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version=None,
+            pyproject_data=PyProjectData.for_testing(True, False, False),
+        )
+
+        assert result is None
+
+    def test_setuptools_scm_required_with_project_section(self) -> None:
+        """Test that we infer when setuptools-scm is required and project section exists."""
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version=None,
+            pyproject_data=PyProjectData.for_testing(True, False, True),
+        )
+
+        assert isinstance(result, VersionInferenceConfig)
+        assert result.dist_name == "test_package"
+
+    def test_tool_section_present(self) -> None:
+        """Test that we infer when tool section is present."""
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version=None,
+            pyproject_data=PyProjectData.for_testing(False, True, False),
+        )
+
+        assert isinstance(result, VersionInferenceConfig)
+        assert result.dist_name == "test_package"
+
+    def test_both_required_and_tool_section(self) -> None:
+        """Test that we infer when both required and tool section are present."""
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version=None,
+            pyproject_data=PyProjectData.for_testing(True, True, True),
+        )
+
+        assert isinstance(result, VersionInferenceConfig)
+        assert result.dist_name == "test_package"
+
+    def test_none_dist_name(self) -> None:
+        """Test that we handle None dist_name correctly."""
+        result = get_version_inference_config(
+            dist_name=None,
+            current_version=None,
+            pyproject_data=PyProjectData.for_testing(True, True, True),
+        )
+
+        assert isinstance(result, VersionInferenceConfig)
+        assert result.dist_name is None
+
+    def test_version_already_set_none_dist_name(self) -> None:
+        """Test that we handle None dist_name in error case."""
+        result = get_version_inference_config(
+            dist_name=None,
+            current_version="1.0.0",
+            pyproject_data=PyProjectData.for_testing(True, True, True),
+            overrides=None,
+            was_set_by_infer=False,
+        )
+
+        assert isinstance(result, VersionInferenceError)
+        assert result.message == "version of None already set"
+
+    def test_overrides_passed_through(self) -> None:
+        """Test that overrides are passed through to the config."""
+        overrides = {"version_scheme": "calver"}
+        result = get_version_inference_config(
+            dist_name="test_package",
+            current_version=None,
+            pyproject_data=PyProjectData.for_testing(True, True, True),
+            overrides=overrides,
+        )
+
+        assert isinstance(result, VersionInferenceConfig)
+        assert result.overrides == overrides
+
+
+class TestPyProjectData:
+    """Test the PyProjectData dataclass."""
+
+    def test_pyproject_data_creation(self) -> None:
+        """Test creating PyProjectData instances."""
+        data = PyProjectData.for_testing(True, False, True)
+        assert data.is_required is True
+        assert data.section_present is False
+        assert data.project_present is True
+
+    def test_pyproject_data_equality(self) -> None:
+        """Test PyProjectData equality."""
+        data1 = PyProjectData.for_testing(True, False, True)
+        data2 = PyProjectData.for_testing(True, False, True)
+        data3 = PyProjectData.for_testing(False, False, True)
+
+        assert data1 == data2
+        assert data1 != data3
+
+
+class TestVersionInferenceConfig:
+    """Test the VersionInferenceConfig dataclass."""
+
+    def test_config_creation(self) -> None:
+        """Test creating VersionInferenceConfig instances."""
+        pyproject_data = PyProjectData.for_testing(True, True, True)
+        config = VersionInferenceConfig(
+            dist_name="test_package",
+            pyproject_data=pyproject_data,
+            overrides={"key": "value"},
+        )
+
+        assert config.dist_name == "test_package"
+        assert config.pyproject_data == pyproject_data
+        assert config.overrides == {"key": "value"}
+
+
+class TestVersionInferenceError:
+    """Test the VersionInferenceError dataclass."""
+
+    def test_error_creation(self) -> None:
+        """Test creating VersionInferenceError instances."""
+        error = VersionInferenceError("test message", should_warn=True)
+        assert error.message == "test message"
+        assert error.should_warn is True
+
+    def test_error_default_warn(self) -> None:
+        """Test VersionInferenceError default should_warn value."""
+        error = VersionInferenceError("test message")
+        assert error.should_warn is False
+
+
+class TestVersionInferenceException:
+    """Test the VersionInferenceException dataclass."""
+
+    def test_exception_creation(self) -> None:
+        """Test creating VersionInferenceException instances."""
+        original_exception = ValueError("test error")
+        wrapper = VersionInferenceException(original_exception)
+        assert wrapper.exception == original_exception

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,12 @@ ignore=E203,W503
 
 [testenv]
 usedevelop=True
-extras=test
+dependency_groups = test
+deps =
+    pytest
+    pytest-cov
+    pytest-timeout
+    pytest-xdist
 commands=
     python -X warn_default_encoding -m pytest {posargs}
 


### PR DESCRIPTION
- **refactor step for version inference - intorduce intermediate types and fix/simplify the tests**
- **simplify pyproject**
- **use parametrize in test_extract_package_name**
- **use the canonical parsers from packaging for getting the package name**
- **finish migrating to using canonical package nmes for  match setuptools_scm in bild deps**
- **correct encoding and manifest oversights**
- **split out normalizing version keywork normalization**
- **turn the version inference config into a protocol and simplify the setuptools integration points**
- **simplify integration invocations in the integration tests**
