### PR TITLE
refactor testing infra around configruation and assertions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ test = [
   "build",
   "pytest",
   "pytest-timeout",  # Timeout protection for CI/CD
+  "pytest-xdist",
   "rich",
   "ruff",
   "mypy~=1.13.0", # pinned to old for python 3.8

--- a/src/setuptools_scm/_cli.py
+++ b/src/setuptools_scm/_cli.py
@@ -11,10 +11,13 @@ from typing import Any
 from setuptools_scm import Configuration
 from setuptools_scm._file_finders import find_files
 from setuptools_scm._get_version_impl import _get_version
+from setuptools_scm._integration.pyproject_reading import PyProjectData
 from setuptools_scm.discover import walk_potential_roots
 
 
-def main(args: list[str] | None = None) -> int:
+def main(
+    args: list[str] | None = None, *, _given_pyproject_data: PyProjectData | None = None
+) -> int:
     opts = _get_cli_opts(args)
     inferred_root: str = opts.root or "."
 
@@ -24,6 +27,7 @@ def main(args: list[str] | None = None) -> int:
         config = Configuration.from_file(
             pyproject,
             root=(os.path.abspath(opts.root) if opts.root is not None else None),
+            pyproject_data=_given_pyproject_data,
         )
     except (LookupError, FileNotFoundError) as ex:
         # no pyproject.toml OR no [tool.setuptools_scm]

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -88,22 +88,6 @@ def debug_mode() -> Iterator[DebugMode]:
         yield debug_mode
 
 
-def setup_git_wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch | None = None) -> WorkDir:
-    """Set up a WorkDir with git initialized and configured for testing.
-
-    Note: This is a compatibility wrapper. Consider using wd.setup_git() directly.
-    """
-    return wd.setup_git(monkeypatch)
-
-
-def setup_hg_wd(wd: WorkDir) -> WorkDir:
-    """Set up a WorkDir with mercurial initialized and configured for testing.
-
-    Note: This is a compatibility wrapper. Consider using wd.setup_hg() directly.
-    """
-    return wd.setup_hg()
-
-
 @pytest.fixture
 def wd(tmp_path: Path) -> WorkDir:
     """Base WorkDir fixture that returns an unconfigured working directory.

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -5,6 +5,8 @@ import os
 import shutil
 import sys
 
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -21,10 +23,18 @@ else:
 
 from .wd_wrapper import WorkDir
 
+# Test time constants: 2009-02-13T23:31:30+00:00
+TEST_SOURCE_DATE = datetime(2009, 2, 13, 23, 31, 30, tzinfo=timezone.utc)
+TEST_SOURCE_DATE_EPOCH = int(TEST_SOURCE_DATE.timestamp())
+TEST_SOURCE_DATE_FORMATTED = "20090213"  # As used in node-and-date local scheme
+TEST_SOURCE_DATE_TIMESTAMP = (
+    "20090213233130"  # As used in node-and-timestamp local scheme
+)
+
 
 def pytest_configure(config: pytest.Config) -> None:
     # 2009-02-13T23:31:30+00:00
-    os.environ["SOURCE_DATE_EPOCH"] = "1234567890"
+    os.environ["SOURCE_DATE_EPOCH"] = str(TEST_SOURCE_DATE_EPOCH)
     os.environ["SETUPTOOLS_SCM_DEBUG"] = "1"
 
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -113,12 +113,7 @@ def repositories_hg_git(tmp_path: Path) -> tuple[WorkDir, WorkDir]:
     path_git = tmp_path / "repo_git"
     path_git.mkdir()
 
-    wd = WorkDir(path_git)
-    wd("git init")
-    wd("git config user.email test@example.com")
-    wd('git config user.name "a test"')
-    wd.add_command = "git add ."
-    wd.commit_command = "git commit -m test-{reason}"
+    wd = WorkDir(path_git).setup_git()
 
     path_hg = tmp_path / "repo_hg"
     run(["hg", "clone", path_git, path_hg, "--config", "extensions.hggit="], tmp_path)
@@ -128,7 +123,6 @@ def repositories_hg_git(tmp_path: Path) -> tuple[WorkDir, WorkDir]:
         file.write("[extensions]\nhggit =\n")
 
     wd_hg = WorkDir(path_hg)
-    wd_hg.add_command = "hg add ."
-    wd_hg.commit_command = 'hg commit -m test-{reason} -u test -d "0 0"'
+    wd_hg.configure_hg_commands()
 
     return wd_hg, wd

--- a/testing/test_better_root_errors.py
+++ b/testing/test_better_root_errors.py
@@ -16,32 +16,13 @@ from setuptools_scm._get_version_impl import _find_scm_in_parents
 from setuptools_scm._get_version_impl import _version_missing
 from testing.wd_wrapper import WorkDir
 
-
-def setup_git_repo(wd: WorkDir) -> WorkDir:
-    """Set up a git repository for testing."""
-    wd("git init")
-    wd("git config user.email test@example.com")
-    wd('git config user.name "a test"')
-    wd.add_command = "git add ."
-    wd.commit_command = "git commit -m test-{reason}"
-    return wd
-
-
-def setup_hg_repo(wd: WorkDir) -> WorkDir:
-    """Set up a mercurial repository for testing."""
-    try:
-        wd("hg init")
-        wd.add_command = "hg add ."
-        wd.commit_command = 'hg commit -m test-{reason} -u test -d "0 0"'
-        return wd
-    except Exception:
-        pytest.skip("hg not available")
+# No longer need to import setup functions - using WorkDir methods directly
 
 
 def test_find_scm_in_parents_finds_git(wd: WorkDir) -> None:
     """Test that _find_scm_in_parents correctly finds git repositories in parent directories."""
     # Set up git repo in root
-    setup_git_repo(wd)
+    wd.setup_git()
 
     # Create a subdirectory structure
     subdir = wd.cwd / "subproject" / "nested"
@@ -57,7 +38,7 @@ def test_find_scm_in_parents_finds_git(wd: WorkDir) -> None:
 def test_find_scm_in_parents_finds_hg(wd: WorkDir) -> None:
     """Test that _find_scm_in_parents correctly finds mercurial repositories in parent directories."""
     # Set up hg repo in root
-    setup_hg_repo(wd)
+    wd.setup_hg()
 
     # Create a subdirectory structure
     subdir = wd.cwd / "subproject" / "nested"
@@ -85,7 +66,7 @@ def test_find_scm_in_parents_returns_none(wd: WorkDir) -> None:
 def test_version_missing_with_scm_in_parent(wd: WorkDir) -> None:
     """Test that _version_missing provides helpful error message when SCM is found in parent."""
     # Set up git repo in root
-    setup_git_repo(wd)
+    wd.setup_git()
 
     # Create a subdirectory structure
     subdir = wd.cwd / "subproject" / "nested"
@@ -130,7 +111,7 @@ def test_version_missing_no_scm_found(wd: WorkDir) -> None:
 def test_version_missing_with_relative_to_set(wd: WorkDir) -> None:
     """Test that when relative_to is set, we don't search parents for error messages."""
     # Set up git repo in root
-    setup_git_repo(wd)
+    wd.setup_git()
 
     # Create a subdirectory structure
     subdir = wd.cwd / "subproject" / "nested"
@@ -161,7 +142,7 @@ def test_search_parent_directories_works_as_suggested(
 ) -> None:
     """Test that the suggested search_parent_directories=True solution actually works."""
     # Set up git repo
-    setup_git_repo(wd)
+    wd.setup_git()
     wd.commit_testfile()  # Make sure there's a commit for version detection
 
     # Create a subdirectory
@@ -182,7 +163,7 @@ def test_integration_better_error_from_nested_directory(
 ) -> None:
     """Integration test: get_version from nested directory should give helpful error."""
     # Set up git repo
-    setup_git_repo(wd)
+    wd.setup_git()
 
     # Create a subdirectory
     subdir = wd.cwd / "subproject"

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -7,19 +7,46 @@ from contextlib import redirect_stdout
 import pytest
 
 from setuptools_scm._cli import main
+from setuptools_scm._integration.pyproject_reading import PyProjectData
 
 from .conftest import DebugMode
-from .test_git import wd as wd_fixture  # noqa: F401 (evil fixture reuse)
 from .wd_wrapper import WorkDir
+
+
+@pytest.fixture
+def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch, debug_mode: DebugMode) -> WorkDir:
+    """Set up git for CLI tests."""
+    debug_mode.disable()
+    wd.setup_git(monkeypatch)
+    debug_mode.enable()
+    return wd
+
 
 PYPROJECT_TOML = "pyproject.toml"
 PYPROJECT_SIMPLE = "[tool.setuptools_scm]"
 PYPROJECT_ROOT = '[tool.setuptools_scm]\nroot=".."'
 
+# PyProjectData constants for testing
+PYPROJECT_DATA_SIMPLE = PyProjectData.for_testing(section_present=True)
+PYPROJECT_DATA_WITH_PROJECT = PyProjectData.for_testing(
+    section_present=True, project_present=True, project_name="test"
+)
 
-def get_output(args: list[str]) -> str:
+
+def _create_version_file_pyproject_data() -> PyProjectData:
+    """Create PyProjectData with version_file configuration for testing."""
+    data = PyProjectData.for_testing(
+        section_present=True, project_present=True, project_name="test"
+    )
+    data.section["version_file"] = "ver.py"
+    return data
+
+
+def get_output(
+    args: list[str], *, _given_pyproject_data: PyProjectData | None = None
+) -> str:
     with redirect_stdout(io.StringIO()) as out:
-        main(args)
+        main(args, _given_pyproject_data=_given_pyproject_data)
     return out.getvalue()
 
 
@@ -59,24 +86,20 @@ def test_cli_force_version_files(
 ) -> None:
     debug_mode.disable()
     wd.commit_testfile()
-    wd.write(
-        PYPROJECT_TOML,
-        """
-[project]
-name = "test"
-[tool.setuptools_scm]
-version_file = "ver.py"
-""",
-    )
     monkeypatch.chdir(wd.cwd)
 
     version_file = wd.cwd.joinpath("ver.py")
     assert not version_file.exists()
 
-    get_output([])
+    # Create pyproject data with version_file configuration
+    pyproject_data = _create_version_file_pyproject_data()
+
+    get_output([], _given_pyproject_data=pyproject_data)
     assert not version_file.exists()
 
-    output = get_output(["--force-write-version-files"])
+    output = get_output(
+        ["--force-write-version-files"], _given_pyproject_data=pyproject_data
+    )
     assert version_file.exists()
 
     assert output[:5] in version_file.read_text("utf-8")
@@ -87,13 +110,16 @@ def test_cli_create_archival_file_stable(
 ) -> None:
     """Test creating stable .git_archival.txt file."""
     wd.commit_testfile()
-    wd.write(PYPROJECT_TOML, PYPROJECT_SIMPLE)
     monkeypatch.chdir(wd.cwd)
 
     archival_file = wd.cwd / ".git_archival.txt"
     assert not archival_file.exists()
 
-    result = main(["create-archival-file", "--stable"])
+    # Use injected pyproject data instead of creating a file
+    pyproject_data = PYPROJECT_DATA_SIMPLE
+    result = main(
+        ["create-archival-file", "--stable"], _given_pyproject_data=pyproject_data
+    )
     assert result == 0
     assert archival_file.exists()
 
@@ -115,13 +141,16 @@ def test_cli_create_archival_file_full(
 ) -> None:
     """Test creating full .git_archival.txt file with branch information."""
     wd.commit_testfile()
-    wd.write(PYPROJECT_TOML, PYPROJECT_SIMPLE)
     monkeypatch.chdir(wd.cwd)
 
     archival_file = wd.cwd / ".git_archival.txt"
     assert not archival_file.exists()
 
-    result = main(["create-archival-file", "--full"])
+    # Use injected pyproject data instead of creating a file
+    pyproject_data = PYPROJECT_DATA_SIMPLE
+    result = main(
+        ["create-archival-file", "--full"], _given_pyproject_data=pyproject_data
+    )
     assert result == 0
     assert archival_file.exists()
 
@@ -144,15 +173,18 @@ def test_cli_create_archival_file_exists_no_force(
     wd: WorkDir, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test that existing .git_archival.txt file prevents creation without --force."""
+    wd.setup_git(monkeypatch)
     wd.commit_testfile()
-    wd.write(PYPROJECT_TOML, PYPROJECT_SIMPLE)
     monkeypatch.chdir(wd.cwd)
 
     archival_file = wd.cwd / ".git_archival.txt"
     archival_file.write_text("existing content", encoding="utf-8")
 
     # Should fail without --force
-    result = main(["create-archival-file", "--stable"])
+    pyproject_data = PYPROJECT_DATA_SIMPLE
+    result = main(
+        ["create-archival-file", "--stable"], _given_pyproject_data=pyproject_data
+    )
     assert result == 1
 
     # Content should be unchanged
@@ -163,15 +195,19 @@ def test_cli_create_archival_file_exists_with_force(
     wd: WorkDir, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test that --force overwrites existing .git_archival.txt file."""
+    wd.setup_git(monkeypatch)
     wd.commit_testfile()
-    wd.write(PYPROJECT_TOML, PYPROJECT_SIMPLE)
     monkeypatch.chdir(wd.cwd)
 
     archival_file = wd.cwd / ".git_archival.txt"
     archival_file.write_text("existing content", encoding="utf-8")
 
     # Should succeed with --force
-    result = main(["create-archival-file", "--stable", "--force"])
+    pyproject_data = PYPROJECT_DATA_SIMPLE
+    result = main(
+        ["create-archival-file", "--stable", "--force"],
+        _given_pyproject_data=pyproject_data,
+    )
     assert result == 0
 
     # Content should be updated
@@ -184,26 +220,31 @@ def test_cli_create_archival_file_requires_stable_or_full(
     wd: WorkDir, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test that create-archival-file requires either --stable or --full."""
+    wd.setup_git(monkeypatch)
     wd.commit_testfile()
-    wd.write(PYPROJECT_TOML, PYPROJECT_SIMPLE)
     monkeypatch.chdir(wd.cwd)
 
     # Should fail without --stable or --full
+    pyproject_data = PYPROJECT_DATA_SIMPLE
     with pytest.raises(SystemExit):
-        main(["create-archival-file"])
+        main(["create-archival-file"], _given_pyproject_data=pyproject_data)
 
 
 def test_cli_create_archival_file_mutually_exclusive(
     wd: WorkDir, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test that --stable and --full are mutually exclusive."""
+    wd.setup_git(monkeypatch)
     wd.commit_testfile()
-    wd.write(PYPROJECT_TOML, PYPROJECT_SIMPLE)
     monkeypatch.chdir(wd.cwd)
 
     # Should fail with both --stable and --full
+    pyproject_data = PYPROJECT_DATA_SIMPLE
     with pytest.raises(SystemExit):
-        main(["create-archival-file", "--stable", "--full"])
+        main(
+            ["create-archival-file", "--stable", "--full"],
+            _given_pyproject_data=pyproject_data,
+        )
 
 
 def test_cli_create_archival_file_existing_gitattributes(
@@ -211,14 +252,16 @@ def test_cli_create_archival_file_existing_gitattributes(
 ) -> None:
     """Test behavior when .gitattributes already has export-subst configuration."""
     wd.commit_testfile()
-    wd.write(PYPROJECT_TOML, PYPROJECT_SIMPLE)
     monkeypatch.chdir(wd.cwd)
 
     # Create .gitattributes with export-subst configuration
     gitattributes_file = wd.cwd / ".gitattributes"
     gitattributes_file.write_text(".git_archival.txt  export-subst\n", encoding="utf-8")
 
-    result = main(["create-archival-file", "--stable"])
+    pyproject_data = PYPROJECT_DATA_SIMPLE
+    result = main(
+        ["create-archival-file", "--stable"], _given_pyproject_data=pyproject_data
+    )
     assert result == 0
 
     archival_file = wd.cwd / ".git_archival.txt"
@@ -230,10 +273,12 @@ def test_cli_create_archival_file_no_gitattributes(
 ) -> None:
     """Test behavior when .gitattributes doesn't exist or lacks export-subst."""
     wd.commit_testfile()
-    wd.write(PYPROJECT_TOML, PYPROJECT_SIMPLE)
     monkeypatch.chdir(wd.cwd)
 
-    result = main(["create-archival-file", "--stable"])
+    pyproject_data = PYPROJECT_DATA_SIMPLE
+    result = main(
+        ["create-archival-file", "--stable"], _given_pyproject_data=pyproject_data
+    )
     assert result == 0
 
     archival_file = wd.cwd / ".git_archival.txt"

--- a/testing/test_expect_parse.py
+++ b/testing/test_expect_parse.py
@@ -1,0 +1,180 @@
+"""Test the expect_parse and matches functionality."""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+
+import pytest
+
+from setuptools_scm import Configuration
+from setuptools_scm.version import ScmVersion
+from setuptools_scm.version import meta
+from setuptools_scm.version import mismatches
+
+from .conftest import TEST_SOURCE_DATE
+from .wd_wrapper import WorkDir
+
+
+def test_scm_version_matches_basic() -> None:
+    """Test the ScmVersion.matches method with various combinations."""
+    c = Configuration()
+
+    # Create test version with all properties set
+    version = meta(
+        "1.2.3",
+        distance=5,
+        dirty=True,
+        node="abc123def456",
+        branch="main",
+        config=c,
+    )
+
+    # Test individual matches
+    assert version.matches(tag="1.2.3")
+    assert version.matches(distance=5)
+    assert version.matches(dirty=True)
+    assert version.matches(branch="main")
+    assert version.matches(exact=False)
+
+    # Test combined matches
+    assert version.matches(tag="1.2.3", distance=5, dirty=True, branch="main")
+
+    # Test node prefix matching
+    assert version.matches(node_prefix="a")
+    assert version.matches(node_prefix="abc")
+    assert version.matches(node_prefix="abc123")
+    assert version.matches(node_prefix="abc123def456")
+
+    # Test mismatches are falsy
+    assert not version.matches(tag="1.2.4")
+    assert not version.matches(node_prefix="xyz")
+    assert not version.matches(distance=10)
+    assert not version.matches(dirty=False)
+
+
+def test_scm_version_matches_exact() -> None:
+    """Test exact matching."""
+    c = Configuration()
+
+    # Exact version
+    exact_version = meta("2.0.0", distance=0, dirty=False, config=c)
+    assert exact_version.matches(exact=True)
+
+    # Non-exact due to distance
+    with_distance = meta("2.0.0", distance=1, dirty=False, config=c)
+    assert not with_distance.matches(exact=True)
+
+    # Non-exact due to dirty
+    dirty_version = meta("2.0.0", distance=0, dirty=True, config=c)
+    assert not dirty_version.matches(exact=True)
+
+
+def test_expect_parse_calls_matches(tmp_path: Path) -> None:
+    """Test that expect_parse correctly parses and calls matches."""
+    wd = WorkDir(tmp_path)
+
+    # Create a mock parse function that returns a predefined ScmVersion
+    c = Configuration()
+    mock_version = meta(
+        "3.0.0",
+        distance=2,
+        dirty=False,
+        node="fedcba987654",
+        branch="develop",
+        config=c,
+    )
+
+    def mock_parse(root: Path, config: Configuration) -> ScmVersion | None:
+        return mock_version
+
+    wd.parse = mock_parse
+
+    # Test successful match
+    wd.expect_parse(tag="3.0.0", distance=2, dirty=False)
+    wd.expect_parse(node_prefix="fed")
+    wd.expect_parse(branch="develop")
+
+    # Test that mismatches raise AssertionError
+    with pytest.raises(AssertionError, match="Version mismatch"):
+        wd.expect_parse(tag="3.0.1")
+
+    with pytest.raises(AssertionError, match="Version mismatch"):
+        wd.expect_parse(dirty=True)
+
+    with pytest.raises(AssertionError, match="Version mismatch"):
+        wd.expect_parse(node_prefix="abc")
+
+
+def test_expect_parse_without_parse_function(tmp_path: Path) -> None:
+    """Test that expect_parse raises error when parse is not configured."""
+    wd = WorkDir(tmp_path)
+
+    with pytest.raises(RuntimeError, match="No SCM configured"):
+        wd.expect_parse(tag="1.0.0")
+
+
+def test_expect_parse_with_none_result(tmp_path: Path) -> None:
+    """Test that expect_parse handles None result from parse."""
+    wd = WorkDir(tmp_path)
+
+    def mock_parse_none(root: Path, config: Configuration) -> ScmVersion | None:
+        return None
+
+    wd.parse = mock_parse_none
+
+    with pytest.raises(AssertionError, match="Failed to parse version"):
+        wd.expect_parse(tag="1.0.0")
+
+
+def test_missmatches_string_formatting() -> None:
+    """Test mismatches string representation for good error messages."""
+    mismatch_obj = mismatches(
+        expected={"tag": "1.0.0", "distance": 0, "dirty": False},
+        actual={"tag": "2.0.0", "distance": 5, "dirty": True},
+    )
+
+    # Test that mismatches is falsy
+    assert not mismatch_obj
+
+    # Test string representation
+    str_repr = str(mismatch_obj)
+    assert "tag: expected '1.0.0', got '2.0.0'" in str_repr
+    assert "distance: expected 0, got 5" in str_repr
+    assert "dirty: expected False, got True" in str_repr
+
+
+def test_missmatches_node_prefix_formatting() -> None:
+    """Test mismatches formatting for node prefix mismatches."""
+    mismatch_obj = mismatches(
+        expected={"node_prefix": "abc"},
+        actual={"node": "def123456"},
+    )
+
+    str_repr = str(mismatch_obj)
+    assert "node: expected prefix 'abc', got 'def123456'" in str_repr
+
+
+def test_scm_version_matches_datetime() -> None:
+    """Test that ScmVersion.matches works with datetime fields."""
+    c = Configuration()
+
+    # Create version with specific datetime
+    version = meta(
+        "1.0.0",
+        distance=0,
+        dirty=False,
+        node_date=date(2023, 6, 15),
+        time=TEST_SOURCE_DATE,
+        config=c,
+    )
+
+    # Test date matching
+    assert version.matches(node_date=date(2023, 6, 15))
+    assert not version.matches(node_date=date(2023, 6, 16))
+
+    # Test time matching
+    assert version.matches(time=TEST_SOURCE_DATE)
+    assert not version.matches(time=datetime(2023, 1, 1, tzinfo=timezone.utc))

--- a/testing/test_file_finder.py
+++ b/testing/test_file_finder.py
@@ -18,21 +18,9 @@ def inwd(
 ) -> WorkDir:
     param: str = request.param  # type: ignore[attr-defined]
     if param == "git":
-        try:
-            wd("git init")
-        except OSError:
-            pytest.skip("git executable not found")
-        wd("git config user.email test@example.com")
-        wd('git config user.name "a test"')
-        wd.add_command = "git add ."
-        wd.commit_command = "git commit -m test-{reason}"
+        wd.setup_git(monkeypatch)
     elif param == "hg":
-        try:
-            wd("hg init")
-        except OSError:
-            pytest.skip("hg executable not found")
-        wd.add_command = "hg add ."
-        wd.commit_command = 'hg commit -m test-{reason} -u test -d "0 0"'
+        wd.setup_hg()
     (wd.cwd / "file1").touch()
     adir = wd.cwd / "adir"
     adir.mkdir()
@@ -249,10 +237,7 @@ def test_archive(
 
 @pytest.fixture
 def hg_wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> WorkDir:
-    try:
-        wd("hg init")
-    except OSError:
-        pytest.skip("hg executable not found")
+    wd.setup_hg()
     (wd.cwd / "file").touch()
     wd("hg add file")
     monkeypatch.chdir(wd.cwd)

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -826,9 +826,7 @@ def test_git_no_commits_uses_fallback_version(wd: WorkDir) -> None:
     """Test that when git describe fails (no commits), fallback_version is used instead of 0.0."""
     # Reinitialize as empty repo to remove any existing commits
     wd("rm -rf .git")
-    wd("git init")
-    wd("git config user.email test@example.com")
-    wd('git config user.name "a test"')
+    wd.setup_git()
 
     # Test with fallback_version set - should use the fallback instead of "0.0"
     config = Configuration(fallback_version="1.2.3")

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -154,34 +154,34 @@ def test_not_owner(wd: WorkDir) -> None:
 
 
 def test_version_from_git(wd: WorkDir) -> None:
-    assert wd.get_version() == "0.1.dev0+d20090213"
+    # No commits yet - fallback version
+    wd.expect_parse(tag="0.0", distance=0, dirty=True)
 
     parsed = git.parse(str(wd.cwd), Configuration(), git.DEFAULT_DESCRIBE)
     assert parsed is not None
     assert parsed.branch in ("master", "main")
 
     wd.commit_testfile()
-    assert wd.get_version().startswith("0.1.dev1+g")
-    assert not wd.get_version().endswith("1-")
+    wd.expect_parse(tag="0.0", distance=1, dirty=False, node_prefix="g")
 
     wd("git tag v0.1")
-    assert wd.get_version() == "0.1"
+    wd.expect_parse(tag="0.1", distance=0, dirty=False, exact=True)
 
     wd.write("test.txt", "test2")
-    assert wd.get_version().startswith("0.2.dev0+g")
+    wd.expect_parse(tag="0.1", distance=0, dirty=True)
 
     wd.commit_testfile()
-    assert wd.get_version().startswith("0.2.dev1+g")
+    wd.expect_parse(tag="0.1", distance=1, dirty=False, node_prefix="g")
 
     wd("git tag version-0.2")
-    assert wd.get_version().startswith("0.2")
+    wd.expect_parse(tag="0.2", distance=0, dirty=False, exact=True)
 
     wd.commit_testfile()
     wd("git tag version-0.2.post210+gbe48adfpost3+g0cc25f2")
     with pytest.warns(
         UserWarning, match="tag '.*' will be stripped of its suffix '.*'"
     ):
-        assert wd.get_version().startswith("0.2")
+        wd.expect_parse(tag="0.2.post210", distance=0, dirty=False)
 
     wd.commit_testfile()
     wd("git tag 17.33.0-rc")
@@ -261,7 +261,6 @@ def test_git_version_unnormalized_setuptools(
     assert wd.cwd.joinpath("VERSION.txt").read_text(encoding="utf-8") == "17.33.0-rc1"
 
 
-@pytest.mark.issue(179)
 def test_unicode_version_scheme(wd: WorkDir) -> None:
     scheme = b"guess-next-dev".decode("ascii")
     assert wd.get_version(version_scheme=scheme)
@@ -272,10 +271,12 @@ def test_unicode_version_scheme(wd: WorkDir) -> None:
 def test_git_worktree(wd: WorkDir) -> None:
     wd.write("test.txt", "test2")
     # untracked files dont change the state
-    assert wd.get_version() == "0.1.dev0+d20090213"
+    # No commits yet, so it's dirty and tag is 0.0
+    wd.expect_parse(tag="0.0", distance=0, dirty=True)
 
     wd("git add test.txt")
-    assert wd.get_version().startswith("0.1.dev0+d")
+    # Still no commits, but now we have staged changes
+    wd.expect_parse(tag="0.0", distance=0, dirty=True)
 
 
 @pytest.mark.issue(86)
@@ -361,7 +362,8 @@ def test_parse_no_worktree(tmp_path: Path) -> None:
 def test_alphanumeric_tags_match(wd: WorkDir) -> None:
     wd.commit_testfile()
     wd("git tag newstyle-development-started")
-    assert wd.get_version().startswith("0.1.dev1+g")
+    # Non-version tag should not be recognized, so we're still at distance 1 from 0.0
+    wd.expect_parse(tag="0.0", distance=1, dirty=False, node_prefix="g")
 
 
 def test_git_archive_export_ignore(
@@ -445,13 +447,16 @@ def test_non_dotted_version(wd: WorkDir) -> None:
     wd.commit_testfile()
     wd("git tag apache-arrow-1")
     wd.commit_testfile()
-    assert wd.get_version().startswith("2")
+    # Tag is recognized as version 1, so next commit is distance 1 from it
+    wd.expect_parse(tag="1", distance=1, dirty=False, node_prefix="g")
 
 
 def test_non_dotted_version_with_updated_regex(wd: WorkDir) -> None:
     wd.commit_testfile()
     wd("git tag apache-arrow-1")
     wd.commit_testfile()
+    # With custom regex, tag is still recognized as version 1
+    # This test is really about the regex configuration, so keep using get_version
     assert wd.get_version(tag_regex=r"^apache-arrow-([\.0-9]+)$").startswith("2")
 
 
@@ -461,7 +466,8 @@ def test_non_dotted_tag_no_version_match(wd: WorkDir) -> None:
     wd.commit_testfile()
     wd("git tag apache-arrow")
     wd.commit_testfile()
-    assert wd.get_version().startswith("0.11.2.dev2")
+    # "apache-arrow" tag without version is not recognized, so we're at distance 2 from 0.11.1
+    wd.expect_parse(tag="0.11.1", distance=2, dirty=False, node_prefix="g")
 
 
 @pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/381")

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -35,8 +35,11 @@ from .wd_wrapper import WorkDir
 c = Configuration()
 
 
-# File-level marker for git tests
-pytestmark = pytest.mark.git
+# Module-level fixture for git SCM setup
+@pytest.fixture
+def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> WorkDir:
+    """Set up git for integration tests."""
+    return wd.setup_git(monkeypatch)
 
 
 def test_pyproject_support(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -35,14 +35,8 @@ from .wd_wrapper import WorkDir
 c = Configuration()
 
 
-@pytest.fixture
-def wd(wd: WorkDir) -> WorkDir:
-    wd("git init")
-    wd("git config user.email test@example.com")
-    wd('git config user.name "a test"')
-    wd.add_command = "git add ."
-    wd.commit_command = "git commit -m test-{reason}"
-    return wd
+# File-level marker for git tests
+pytestmark = pytest.mark.git
 
 
 def test_pyproject_support(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -22,11 +22,7 @@ def test_main() -> None:
 
 @pytest.fixture
 def repo(wd: WorkDir) -> WorkDir:
-    wd("git init")
-    wd("git config user.email user@host")
-    wd("git config user.name user")
-    wd.add_command = "git add ."
-    wd.commit_command = "git commit -m test-{reason}"
+    wd.setup_git()
 
     wd.write("README.rst", "My example")
     wd.add_and_commit()

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -10,23 +10,18 @@ import setuptools_scm._file_finders
 
 from setuptools_scm import Configuration
 from setuptools_scm._run_cmd import CommandNotFoundError
-from setuptools_scm._run_cmd import has_command
 from setuptools_scm.hg import archival_to_version
 from setuptools_scm.hg import parse
 from setuptools_scm.version import format_version
 from testing.wd_wrapper import WorkDir
 
-pytestmark = pytest.mark.skipif(
-    not has_command("hg", warn=False), reason="hg executable not found"
-)
+# Note: Mercurial availability is now checked in WorkDir.setup_hg() method
 
 
 @pytest.fixture
 def wd(wd: WorkDir) -> WorkDir:
-    wd("hg init")
-    wd.add_command = "hg add ."
-    wd.commit_command = 'hg commit -m test-{reason} -u test -d "0 0"'
-    return wd
+    """Set up mercurial for hg-specific tests."""
+    return wd.setup_hg()
 
 
 archival_mapping = {

--- a/testing/test_mercurial.py
+++ b/testing/test_mercurial.py
@@ -109,31 +109,32 @@ def test_find_files_stop_at_root_hg(
 
 # XXX: better tests for tag prefixes
 def test_version_from_hg_id(wd: WorkDir) -> None:
-    assert wd.get_version() == "0.0"
+    # Initial state with no commits
+    wd.expect_parse(tag="0.0", distance=0, dirty=False, exact=True)
 
     wd.commit_testfile()
-    assert wd.get_version().startswith("0.1.dev1+")
+    wd.expect_parse(tag="0.0", distance=1, dirty=False, node_prefix="h")
 
     # tagging commit is considered the tag
     wd('hg tag v0.1 -u test -d "0 0"')
-    assert wd.get_version() == "0.1"
+    wd.expect_parse(tag="0.1", distance=0, dirty=False, exact=True)
 
     wd.commit_testfile()
-    assert wd.get_version().startswith("0.2.dev2")
+    wd.expect_parse(tag="0.1", distance=2, dirty=False)
 
     wd("hg up v0.1")
-    assert wd.get_version() == "0.1"
+    wd.expect_parse(tag="0.1", distance=0, dirty=False, exact=True)
 
     # commit originating from the tagged revision
     # that is not an actual tag
     wd.commit_testfile()
-    assert wd.get_version().startswith("0.2.dev1+")
+    wd.expect_parse(tag="0.1", distance=1, dirty=False)
 
     # several tags
     wd("hg up")
     wd('hg tag v0.2 -u test -d "0 0"')
     wd('hg tag v0.3 -u test -d "0 0" -r v0.2')
-    assert wd.get_version() == "0.3"
+    wd.expect_parse(tag="0.3", distance=0, dirty=False, exact=True)
 
 
 def test_version_from_archival(wd: WorkDir) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -356,6 +356,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1566,6 +1575,41 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060, upload-time = "2024-04-28T19:29:54.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108, upload-time = "2024-04-28T19:29:52.813Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version >= '3.9'" },
+    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1855,6 +1899,8 @@ test = [
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "rich" },
     { name = "ruff" },
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -1889,6 +1935,7 @@ test = [
     { name = "pip" },
     { name = "pytest" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "rich" },
     { name = "ruff" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
- **update `WorkDir` class**: Unified abstraction for managing Git and Mercurial test repositories with methods for setup, commits, tags, and version assertions
- **`expect_parse()` helper**: Fluent assertion method for validating SCM version properties with clear error messages
- **Enhanced `ScmVersion.matches()`**: Flexible property matching for version assertions
- **CLI improvements**: Better testability by accepting `PyProjectData` parameter
- **Removed deprecated helpers**: Cleaned up old `setup_git_wd` and `setup_hg_wd` wrapper functions
- **Added `pytest-xdist`**: Enable parallel test execution