### PR TITLE
Mark recently yanked versions in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,6 @@
 - fix #1194: correctly handle version keyword when pyproject metadata is missing
 
 
-## v9.1.1
-
-### fixed
-
-- fix #1194: correctly handle version keyword when pyproject metadata is missing
-
-
 ## v9.1.0
 
 ### fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### changed
 
-- refine activation logic and add unittest for the relevant cases instead of trying to speedrun setuptools 
+- refine activation logic and add unittest for the relevant cases instead of trying to speedrun setuptools
 
 ## v9.1.1 (yanked)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,14 @@
 
 - refine activation logic and add unittest for the relevant cases instead of trying to speedrun setuptools 
 
-## v9.1.1
+## v9.1.1 (yanked)
 
 ### fixed
 
 - fix #1194: correctly handle version keyword when pyproject metadata is missing
 
 
-## v9.1.0
+## v9.1.0 (yanked)
 
 ### fixed
 


### PR DESCRIPTION
This PR removes a duplicate changelog entry for v9.1.1 and marks v9.1.1 and v9.1.0 as yanked.