### PR TITLE
fix: don't warn about tool.setuptools.dynamic.version when only using file finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 
+## v9.2.2
+
+### Fixed
+
+- fix #1231: don't warn about `tool.setuptools.dynamic.version` when only using file finder.
+  The warning about combining version guessing with setuptools dynamic versions should only
+  be issued when setuptools-scm is performing version inference, not when it's only being
+  used for its file finder functionality.
+
+
 ## v9.2.1
 
 ### Fixed

--- a/src/setuptools_scm/_integration/pyproject_reading.py
+++ b/src/setuptools_scm/_integration/pyproject_reading.py
@@ -237,7 +237,10 @@ def read_pyproject(
         .get("dynamic", {})
         .get("version", None)
     )
-    if setuptools_dynamic_version is not None:
+    # Only warn if setuptools-scm is being used for version inference
+    # (not just file finding). When only file finders are used, it's valid
+    # to use tool.setuptools.dynamic.version for versioning.
+    if setuptools_dynamic_version is not None and pyproject_data.should_infer():
         from .deprecation import warn_pyproject_setuptools_dynamic_version
 
         warn_pyproject_setuptools_dynamic_version(path)

--- a/testing/test_pyproject_reading.py
+++ b/testing/test_pyproject_reading.py
@@ -129,6 +129,7 @@ def test_read_pyproject_with_given_definition(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_read_pyproject_with_setuptools_dynamic_version_warns() -> None:
+    """Test that warning is issued when version inference is enabled."""
     with pytest.warns(
         UserWarning,
         match=r"pyproject\.toml: at \[tool\.setuptools\.dynamic\]",
@@ -145,3 +146,36 @@ def test_read_pyproject_with_setuptools_dynamic_version_warns() -> None:
             }
         )
     assert pyproject_data.project_version is None
+
+
+def test_read_pyproject_with_setuptools_dynamic_version_no_warn_when_file_finder_only() -> (
+    None
+):
+    """Test that no warning is issued when only file finder is used (no version inference)."""
+    # When setuptools-scm is used only for file finding (no [tool.setuptools_scm] section,
+    # no [simple] extra, version not in dynamic), it's valid to use tool.setuptools.dynamic.version
+    import warnings
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        pyproject_data = read_pyproject(
+            _given_definition={
+                "build-system": {"requires": ["setuptools-scm"]},
+                "project": {"name": "test-package", "version": "1.0.0"},
+                "tool": {
+                    "setuptools": {
+                        "dynamic": {"version": {"attr": "test_package.__version__"}}
+                    }
+                },
+            }
+        )
+
+    # Filter to check for the dynamic version warning specifically
+    relevant_warnings = [
+        w for w in warning_list if "tool.setuptools.dynamic" in str(w.message)
+    ]
+    assert len(relevant_warnings) == 0, (
+        "Should not warn about tool.setuptools.dynamic when only using file finder"
+    )
+    assert pyproject_data.project_version == "1.0.0"
+    assert not pyproject_data.should_infer()


### PR DESCRIPTION
When setuptools-scm is used only for its file finder functionality
(no version inference), it's valid to use tool.setuptools.dynamic.version
for versioning. The warning should only be issued when setuptools-scm
is actually performing version inference.

Changes:
- Modified pyproject_reading.py to only warn when should_infer() is True
- Added test for file-finder-only case (no warning expected)
- Updated existing test with clarifying documentation

Fixes #1231
