### PR TITLE
Fix release proposal workflow and add post-release branch sync

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -1,0 +1,361 @@
+name: Branch Synchronization
+
+# Synchronize branches after successful releases:
+# - Triggers after upload jobs complete
+# - Verifies all expected releases for the commit succeeded
+# - Creates sync PRs between branches
+
+on:
+  workflow_run:
+    workflows: ["python tests+artifacts+release"]
+    types: [completed]
+    branches: [main, develop]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Verify all releases completed and sync branches
+  sync-after-release:
+    # Only run if the triggering workflow succeeded and was triggered by a tag push
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'setuptools-scm-v') ||
+      startsWith(github.event.workflow_run.head_branch, 'vcs-versioning-v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify releases and create sync PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflowRun = context.payload.workflow_run;
+            const headSha = workflowRun.head_sha;
+            const headBranch = workflowRun.head_branch;
+
+            console.log(`Workflow completed for: ${headBranch} at ${headSha}`);
+
+            // Get all tags pointing to this commit
+            const { data: tagsResponse } = await github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+
+            const commitTags = tagsResponse.filter(tag => tag.commit.sha === headSha);
+            console.log(`Tags at commit ${headSha}: ${commitTags.map(t => t.name).join(', ') || 'none'}`);
+
+            if (commitTags.length === 0) {
+              console.log('No tags found at this commit, nothing to sync');
+              return;
+            }
+
+            // Check which packages have tags at this commit
+            const setupToolsTag = commitTags.find(t => t.name.startsWith('setuptools-scm-v'));
+            const vcsVersioningTag = commitTags.find(t => t.name.startsWith('vcs-versioning-v'));
+
+            console.log(`setuptools-scm tag: ${setupToolsTag?.name || 'none'}`);
+            console.log(`vcs-versioning tag: ${vcsVersioningTag?.name || 'none'}`);
+
+            // Verify all expected releases have GitHub releases (created after successful upload)
+            const releasesToVerify = [];
+            if (setupToolsTag) releasesToVerify.push(setupToolsTag.name);
+            if (vcsVersioningTag) releasesToVerify.push(vcsVersioningTag.name);
+
+            for (const tagName of releasesToVerify) {
+              try {
+                const { data: release } = await github.rest.repos.getReleaseByTag({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag: tagName
+                });
+                console.log(`✓ Release exists for ${tagName}: ${release.html_url}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  console.log(`✗ Release not found for ${tagName}, waiting for all releases to complete`);
+                  return;
+                }
+                throw error;
+              }
+            }
+
+            console.log('All expected releases verified successfully');
+
+            // Determine which branch this commit is on
+            // Check if this commit is on develop (for develop→main sync)
+            let isDevelopRelease = false;
+            try {
+              const { data: developBranch } = await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: 'develop'
+              });
+
+              // Check if this commit is an ancestor of develop
+              const { data: comparison } = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: headSha,
+                head: 'develop'
+              });
+
+              // If develop is at or ahead of this commit, it's a develop release
+              isDevelopRelease = comparison.status === 'identical' || comparison.status === 'ahead';
+              console.log(`Commit is on develop: ${isDevelopRelease}`);
+            } catch (error) {
+              if (error.status === 404) {
+                console.log('develop branch does not exist');
+              } else {
+                throw error;
+              }
+            }
+
+            if (!isDevelopRelease) {
+              console.log('This is a main branch release, no sync needed (main→develop sync happens on PR merge)');
+              return;
+            }
+
+            // For develop releases, create sync PR to main
+            console.log('Creating sync PR from develop release to main');
+
+            // Use short commit SHA for branch name (simple and unique)
+            const tempBranchName = `sync/develop-to-main-${headSha.substring(0, 8)}`;
+
+            console.log(`Creating temporary branch ${tempBranchName} from commit ${headSha}`);
+
+            // Check if the commit has changes compared to main
+            const mainComparison = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'main',
+              head: headSha
+            });
+
+            if (mainComparison.data.ahead_by === 0) {
+              console.log('Commit has no new changes for main, skipping');
+              return;
+            }
+
+            console.log(`Commit has ${mainComparison.data.ahead_by} commits not on main`);
+
+            // Check for existing sync PR
+            const existingPRs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${tempBranchName}`,
+              base: 'main'
+            });
+
+            if (existingPRs.data.length > 0) {
+              console.log(`Sync PR already exists: #${existingPRs.data[0].number}`);
+              return;
+            }
+
+            // Create temporary branch from the exact commit SHA
+            try {
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/heads/${tempBranchName}`,
+                sha: headSha
+              });
+              console.log(`Created temporary branch ${tempBranchName}`);
+            } catch (error) {
+              if (error.status === 422) {
+                console.log(`Branch ${tempBranchName} already exists`);
+              } else {
+                throw error;
+              }
+            }
+
+            // Build release info for PR body
+            const releaseInfo = releasesToVerify.map(tag => `- \`${tag}\``).join('\n');
+
+            // Build PR body
+            const body = [
+              '## Branch Synchronization',
+              '',
+              'This PR syncs the release from `develop` to `main`.',
+              '',
+              '**Released tags:**',
+              releaseInfo,
+              '',
+              `**Commit:** ${headSha}`,
+              `**Temporary branch:** \`${tempBranchName}\``,
+              '',
+              'This PR uses a temporary branch created from the exact release commit',
+              'to ensure only the release changes are included (no extra commits).',
+              '',
+              'All PyPI uploads have been verified successful before creating this PR.',
+              '',
+              'This is an automated PR created by the branch-sync workflow.',
+              'If there are no conflicts, this PR will be auto-merged.',
+              '',
+              'The temporary branch will be deleted when this PR is merged or closed.'
+            ].join('\n');
+
+            // Build title with tag names
+            const title = `Sync: develop → main (${releasesToVerify.join(', ')})`;
+
+            // Create new sync PR from the temporary branch
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              head: tempBranchName,
+              base: 'main'
+            });
+
+            console.log(`Created sync PR #${pr.number}`);
+
+            // Add labels
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['sync', 'auto-merge']
+            });
+
+            // Try to enable auto-merge
+            try {
+              await github.graphql(`
+                mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: MERGE}) {
+                    pullRequest {
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }
+              `, {
+                pullRequestId: pr.node_id
+              });
+              console.log('Auto-merge enabled');
+            } catch (error) {
+              console.log('Could not enable auto-merge (may require branch protection rules):', error.message);
+            }
+
+  # Forward-port: main → develop
+  # When a release PR is merged to main, create PR to keep develop in sync
+  sync-main-to-develop:
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      (startsWith(github.event.workflow_run.head_branch, 'setuptools-scm-v') ||
+       startsWith(github.event.workflow_run.head_branch, 'vcs-versioning-v'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR main → develop if needed
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflowRun = context.payload.workflow_run;
+            const headSha = workflowRun.head_sha;
+
+            // Check if develop branch exists
+            let developExists = true;
+            try {
+              await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: 'develop'
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                console.log('develop branch does not exist, skipping');
+                developExists = false;
+              } else {
+                throw error;
+              }
+            }
+
+            if (!developExists) return;
+
+            // Check if this commit is on main but not on develop
+            const { data: mainBranch } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'main'
+            });
+
+            // Check if commit is an ancestor of main
+            let isMainRelease = false;
+            try {
+              const { data: comparison } = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: headSha,
+                head: 'main'
+              });
+              isMainRelease = comparison.status === 'identical' || comparison.status === 'ahead';
+            } catch {
+              isMainRelease = false;
+            }
+
+            if (!isMainRelease) {
+              console.log('This is not a main branch release, skipping main→develop sync');
+              return;
+            }
+
+            // Check if main has commits that develop doesn't have
+            const comparison = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'develop',
+              head: 'main'
+            });
+
+            if (comparison.data.ahead_by === 0) {
+              console.log('main has no new commits for develop, skipping');
+              return;
+            }
+
+            console.log(`main has ${comparison.data.ahead_by} commits not on develop`);
+
+            // Check for existing sync PR
+            const existingPRs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:main`,
+              base: 'develop'
+            });
+
+            if (existingPRs.data.length > 0) {
+              console.log(`Sync PR already exists: #${existingPRs.data[0].number}`);
+              return;
+            }
+
+            // Build PR body
+            const body = [
+              '## Branch Synchronization',
+              '',
+              'This PR syncs the release from `main` to `develop`.',
+              '',
+              `**Commit:** ${headSha}`,
+              '',
+              'This is an automated PR created by the branch-sync workflow.',
+              'Review and merge to keep `develop` up to date with `main`.'
+            ].join('\n');
+
+            // Create new sync PR
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Sync: main → develop`,
+              body: body,
+              head: 'main',
+              base: 'develop'
+            });
+
+            console.log(`Created sync PR #${pr.number}`);
+
+            // Add label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['sync']
+            });

--- a/.github/workflows/create-release-tags.yml
+++ b/.github/workflows/create-release-tags.yml
@@ -5,6 +5,7 @@ on:
     types: [closed]
     branches:
       - main
+      - develop
 
 permissions:
   contents: write
@@ -18,128 +19,140 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'release:vcs-versioning'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - name: Create tags and releases
+        uses: actions/github-script@v8
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          script: |
+            const pr = context.payload.pull_request;
+            const prTitle = pr.title;
+            const mergeCommitSha = pr.merge_commit_sha;
+            const labels = pr.labels.map(l => l.name);
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
+            console.log(`Processing PR #${pr.number}: ${prTitle}`);
+            console.log(`Merge commit: ${mergeCommitSha}`);
+            console.log(`Labels: ${labels.join(', ')}`);
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+            const tagsCreated = [];
 
-      - name: Create tags
-        id: create-tags
-        run: |
-          set -e
+            // Helper to extract version from PR title
+            function extractVersion(title, packageName) {
+              const regex = new RegExp(`${packageName} v(\\d+\\.\\d+\\.\\d+)`);
+              const match = title.match(regex);
+              return match ? match[1] : null;
+            }
 
-          TAGS_CREATED=""
-          PR_TITLE="${{ github.event.pull_request.title }}"
+            // Helper to extract changelog section for a version
+            async function extractChangelog(packageDir, version) {
+              try {
+                const { data: file } = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: `${packageDir}/CHANGELOG.md`,
+                  ref: mergeCommitSha
+                });
 
-          # Check if we should release setuptools-scm
-          if echo "${{ toJson(github.event.pull_request.labels.*.name) }}" | grep -q "release:setuptools-scm"; then
-            # Extract version from PR title: "Release: setuptools-scm v9.3.0, ..."
-            VERSION=$(echo "$PR_TITLE" | grep -oP 'setuptools-scm v\K[0-9]+\.[0-9]+\.[0-9]+')
+                const content = Buffer.from(file.content, 'base64').toString('utf-8');
+                const lines = content.split('\n');
 
-            if [ -z "$VERSION" ]; then
-              echo "ERROR: Failed to extract setuptools-scm version from PR title"
-              echo "PR title: $PR_TITLE"
-              echo "Expected format: 'Release: setuptools-scm vX.Y.Z'"
-              exit 1
-            fi
+                let inSection = false;
+                let changelog = [];
 
-            TAG="setuptools-scm-v$VERSION"
-            echo "Creating tag: $TAG"
+                for (const line of lines) {
+                  if (line.startsWith(`## ${version}`)) {
+                    inSection = true;
+                    continue; // Skip the header line
+                  }
+                  if (inSection && line.match(/^## \d/)) {
+                    break; // Next version section
+                  }
+                  if (inSection) {
+                    changelog.push(line);
+                  }
+                }
 
-            git tag -a "$TAG" -m "Release setuptools-scm v$VERSION"
-            git push origin "$TAG"
+                // Trim leading/trailing empty lines
+                while (changelog.length > 0 && changelog[0].trim() === '') {
+                  changelog.shift();
+                }
+                while (changelog.length > 0 && changelog[changelog.length - 1].trim() === '') {
+                  changelog.pop();
+                }
 
-            TAGS_CREATED="$TAGS_CREATED $TAG"
-            echo "setuptools_scm_tag=$TAG" >> $GITHUB_OUTPUT
-            echo "setuptools_scm_version=$VERSION" >> $GITHUB_OUTPUT
-          fi
+                return changelog.join('\n');
+              } catch (error) {
+                console.log(`Could not extract changelog: ${error.message}`);
+                return `Release ${version}`;
+              }
+            }
 
-          # Check if we should release vcs-versioning
-          if echo "${{ toJson(github.event.pull_request.labels.*.name) }}" | grep -q "release:vcs-versioning"; then
-            # Extract version from PR title: "Release: ..., vcs-versioning v0.2.0"
-            VERSION=$(echo "$PR_TITLE" | grep -oP 'vcs-versioning v\K[0-9]+\.[0-9]+\.[0-9]+')
+            // Helper to create tag and release
+            async function createTagAndRelease(packageName, packageDir, tagPrefix) {
+              const version = extractVersion(prTitle, packageName);
+              if (!version) {
+                throw new Error(`Failed to extract ${packageName} version from PR title: ${prTitle}`);
+              }
 
-            if [ -z "$VERSION" ]; then
-              echo "ERROR: Failed to extract vcs-versioning version from PR title"
-              echo "PR title: $PR_TITLE"
-              echo "Expected format: 'Release: vcs-versioning vX.Y.Z'"
-              exit 1
-            fi
+              const tagName = `${tagPrefix}-v${version}`;
+              console.log(`Creating tag: ${tagName} at ${mergeCommitSha}`);
 
-            TAG="vcs-versioning-v$VERSION"
-            echo "Creating tag: $TAG"
+              // Create annotated tag via API
+              const { data: tagObject } = await github.rest.git.createTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName,
+                message: `Release ${packageName} v${version}`,
+                object: mergeCommitSha,
+                type: 'commit',
+                tagger: {
+                  name: 'github-actions[bot]',
+                  email: 'github-actions[bot]@users.noreply.github.com',
+                  date: new Date().toISOString()
+                }
+              });
 
-            git tag -a "$TAG" -m "Release vcs-versioning v$VERSION"
-            git push origin "$TAG"
+              // Create ref for the tag
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/tags/${tagName}`,
+                sha: tagObject.sha
+              });
 
-            TAGS_CREATED="$TAGS_CREATED $TAG"
-            echo "vcs_versioning_tag=$TAG" >> $GITHUB_OUTPUT
-            echo "vcs_versioning_version=$VERSION" >> $GITHUB_OUTPUT
-          fi
+              console.log(`Tag ${tagName} created`);
+              tagsCreated.push(tagName);
 
-          echo "tags_created=$TAGS_CREATED" >> $GITHUB_OUTPUT
+              // Extract changelog
+              const changelog = await extractChangelog(packageDir, version);
 
-      - name: Extract changelog for setuptools-scm
-        if: steps.create-tags.outputs.setuptools_scm_version
-        id: changelog-setuptools-scm
-        run: |
-          VERSION="${{ steps.create-tags.outputs.setuptools_scm_version }}"
-          cd setuptools-scm
+              // Create GitHub release
+              const { data: release } = await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tagName,
+                name: `${packageName} v${version}`,
+                body: changelog,
+                draft: false,
+                prerelease: false
+              });
 
-          # Extract the changelog section for this version
-          # Read from version heading until next version heading or EOF
-          CHANGELOG=$(awk "/^## $VERSION/,/^## [0-9]/" CHANGELOG.md | sed '1d;$d')
+              console.log(`Release created: ${release.html_url}`);
+              return { tagName, version };
+            }
 
-          # Save to file for GitHub release
-          echo "$CHANGELOG" > /tmp/changelog-setuptools-scm.md
+            // Process setuptools-scm
+            if (labels.includes('release:setuptools-scm')) {
+              console.log('\n--- Processing setuptools-scm ---');
+              await createTagAndRelease('setuptools-scm', 'setuptools-scm', 'setuptools-scm');
+            }
 
-      - name: Extract changelog for vcs-versioning
-        if: steps.create-tags.outputs.vcs_versioning_version
-        id: changelog-vcs-versioning
-        run: |
-          VERSION="${{ steps.create-tags.outputs.vcs_versioning_version }}"
-          cd vcs-versioning
+            // Process vcs-versioning
+            if (labels.includes('release:vcs-versioning')) {
+              console.log('\n--- Processing vcs-versioning ---');
+              await createTagAndRelease('vcs-versioning', 'vcs-versioning', 'vcs-versioning');
+            }
 
-          # Extract the changelog section for this version
-          CHANGELOG=$(awk "/^## $VERSION/,/^## [0-9]/" CHANGELOG.md | sed '1d;$d')
+            // Write summary
+            const summary = `## Tags Created\n\n${tagsCreated.map(t => `- \`${t}\``).join('\n')}\n\nPyPI upload will be triggered automatically by tag push.`;
+            await core.summary.addRaw(summary).write();
 
-          # Save to file for GitHub release
-          echo "$CHANGELOG" > /tmp/changelog-vcs-versioning.md
-
-      - name: Create GitHub Release for setuptools-scm
-        if: steps.create-tags.outputs.setuptools_scm_tag
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.create-tags.outputs.setuptools_scm_tag }}
-          name: setuptools-scm v${{ steps.create-tags.outputs.setuptools_scm_version }}
-          body_path: /tmp/changelog-setuptools-scm.md
-          draft: false
-          prerelease: false
-
-      - name: Create GitHub Release for vcs-versioning
-        if: steps.create-tags.outputs.vcs_versioning_tag
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.create-tags.outputs.vcs_versioning_tag }}
-          name: vcs-versioning v${{ steps.create-tags.outputs.vcs_versioning_version }}
-          body_path: /tmp/changelog-vcs-versioning.md
-          draft: false
-          prerelease: false
-
-      - name: Summary
-        run: |
-          echo "## Tags Created" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.create-tags.outputs.tags_created }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "PyPI upload will be triggered automatically by tag push." >> $GITHUB_STEP_SUMMARY
-
+            console.log(`\nDone! Created tags: ${tagsCreated.join(', ')}`);

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,7 +6,8 @@ on:
     branches:
     - "*"
     tags:
-    - "v*"
+    - "setuptools-scm-v*"
+    - "vcs-versioning-v*"
   release:
     types: [published]
 

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/github-script@v8
         env:
           RELEASE_BRANCH: ${{ steps.release.outputs.release_branch }}
+          PR_BASE: ${{ steps.release.outputs.pr_base }}
           PR_EXISTS: ${{ steps.release.outputs.pr_exists }}
           PR_NUMBER: ${{ steps.release.outputs.pr_number }}
           PR_TITLE: ${{ steps.release.outputs.pr_title }}
@@ -76,6 +77,7 @@ jobs:
         with:
           script: |
             const releaseBranch = process.env.RELEASE_BRANCH;
+            const prBase = process.env.PR_BASE;
             const prExists = process.env.PR_EXISTS === 'true';
             const prNumber = process.env.PR_NUMBER;
             const prTitle = process.env.PR_TITLE;
@@ -83,25 +85,26 @@ jobs:
             const labels = process.env.LABELS.split(',').filter(l => l);
 
             if (prExists && prNumber) {
-              // Update existing PR
-              console.log(`Updating existing PR #${prNumber}`);
+              // Update existing PR (including base branch if it changed)
+              console.log(`Updating existing PR #${prNumber} to target ${prBase}`);
               await github.rest.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: parseInt(prNumber),
                 title: prTitle,
-                body: prBody
+                body: prBody,
+                base: prBase
               });
             } else {
-              // Create new PR
-              console.log('Creating new PR');
+              // Create new PR - targets the same branch it came from
+              console.log(`Creating new PR targeting ${prBase}`);
               const { data: pr } = await github.rest.pulls.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: prTitle,
                 body: prBody,
                 head: releaseBranch,
-                base: 'main'
+                base: prBase
               });
               console.log(`Created PR #${pr.number}`);
 


### PR DESCRIPTION
- Fix version extraction to use clean versions without .devN suffix
  by adding get_release_version() function to towncrier scheme
- Release PRs now target their source branch (main→main, develop→develop)
- Update existing PRs including base branch when source changes
- Fix tag patterns in python-tests.yml to match actual tag format
  (setuptools-scm-v*, vcs-versioning-v*)
- Rewrite create-release-tags.yml to use GitHub API instead of checkout
- Add branch-sync.yml workflow that triggers after successful uploads:
  - Verifies all releases at commit have GitHub releases
  - Creates sync PR from develop→main using temporary branch
  - Uses exact commit SHA to avoid including extra commits
  - Enables auto-merge for conflict-free syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
