### PR TITLE
Fix list rendering in docs/config.md

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -21,11 +21,12 @@ This automatically enables version inference with default settings.
 ### Explicit Configuration (Full Control)
 
 Use the `[tool.setuptools_scm]` section when you need to:
-  - Write version files (`version_file`)
-  - Customize version schemes (`version_scheme`, `local_scheme`)
-  - Set custom tag patterns (`tag_regex`)
-  - Configure fallback behavior (`fallback_version`)
-  - Or any other non-default behavior
+
+- Write version files (`version_file`)
+- Customize version schemes (`version_scheme`, `local_scheme`)
+- Set custom tag patterns (`tag_regex`)
+- Configure fallback behavior (`fallback_version`)
+- Or any other non-default behavior
 
 ## configuration parameters
 


### PR DESCRIPTION
Before (https://setuptools-scm.readthedocs.io/en/latest/config/):

<img width="728" height="111" alt="image" src="https://github.com/user-attachments/assets/4b3f3649-3db0-4971-8e77-19596ef0a2f8" />

After:

<img width="464" height="202" alt="image" src="https://github.com/user-attachments/assets/5edb98a8-21c1-4e70-bee9-e50e0de02dba" />
