### PR TITLE
fix(file_finders): sanitize GIT env vars in git archive subprocess

### DIFF
--- a/src/setuptools_scm/_file_finders/git.py
+++ b/src/setuptools_scm/_file_finders/git.py
@@ -8,6 +8,7 @@ import tarfile
 from typing import IO
 
 from .. import _types as _t
+from .._run_cmd import no_git_env
 from .._run_cmd import run as _run
 from ..integration import data_from_mime
 from . import is_toplevel_acceptable
@@ -72,7 +73,11 @@ def _git_ls_files_and_dirs(toplevel: str) -> tuple[set[str], set[str]]:
     cmd = ["git", "archive", "--prefix", toplevel + os.path.sep, "HEAD"]
     log.info("running %s", " ".join(str(x) for x in cmd))
     proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, cwd=toplevel, stderr=subprocess.DEVNULL
+        cmd,
+        stdout=subprocess.PIPE,
+        cwd=toplevel,
+        stderr=subprocess.DEVNULL,
+        env=no_git_env(os.environ),
     )
     assert proc.stdout is not None
     try:

--- a/testing/test_file_finder.py
+++ b/testing/test_file_finder.py
@@ -275,3 +275,26 @@ def test_hg_command_from_env(
         m.setenv("PATH", str(hg_wd.cwd / "not-existing"))
         # No module reloading needed - runtime configuration works immediately
         assert set(find_files()) == {"file"}
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/381")
+def test_file_finder_ignores_git_dir_env(
+    inwd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that file finder ignores GIT_DIR env var.
+
+    Git sets GIT_DIR when running hooks in worktrees/submodules, which
+    causes git archive to query the wrong repository. The file finder
+    must sanitize these variables like _run_cmd.run() does.
+    """
+    # Get expected files before setting GIT_DIR
+    expected_files = set(find_files())
+    assert expected_files  # Sanity check: we should have files
+
+    # Set GIT_DIR to an unrelated path (simulates git hook in worktree)
+    # This would cause git archive to fail or return wrong results if
+    # the environment isn't sanitized
+    monkeypatch.setenv("GIT_DIR", __file__)
+
+    # File finding should still work correctly
+    assert set(find_files()) == expected_files


### PR DESCRIPTION
Sanitize GIT environment variables in file finder's `subprocess.Popen` 

Fixes #1253