### PR TITLE
ci(windows): update gnupg path for 64-bit builds

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -91,9 +91,9 @@ jobs:
           $env:PATH = "C:\Program Files\Git\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\Chocolatey\bin"
           [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
           choco install gnupg hg -y --no-progress
-          echo "C:\Program Files (x86)\gnupg\bin" >> $env:GITHUB_PATH
+          echo "C:\Program Files\gnupg\bin" >> $env:GITHUB_PATH
           echo "C:\Program Files\Mercurial\" >> $env:GITHUB_PATH
-          git config --system gpg.program "C:\Program Files (x86)\gnupg\bin\gpg.exe"
+          git config --system gpg.program "C:\Program Files\gnupg\bin\gpg.exe"
         if: runner.os == 'Windows'
       - run: uv sync --group test --group docs --extra rich
       - uses: actions/download-artifact@v7


### PR DESCRIPTION
The Chocolatey gnupg package updated to 2.5.16 on Dec 30, 2025 and changed its install location. The hardcoded path to gpg.exe no longer exists, breaking all Windows CI jobs.

Updates the gpg path for for 64-bit builds after installation.

Fixes #1255 