### PR TITLE
Merge main into develop (Jan 2026)

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,7 +27,7 @@ jobs:
       SETUPTOOLS_SCM_NO_LOCAL: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
 
     name: ${{ matrix.os }} - Python ${{ matrix.python_version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup python

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -96,7 +96,7 @@ jobs:
           git config --system gpg.program "C:\Program Files (x86)\gnupg\bin\gpg.exe"
         if: runner.os == 'Windows'
       - run: uv sync --group test --group docs --extra rich
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v7
         with:
           name: Packages
           path: dist
@@ -118,7 +118,7 @@ jobs:
       id-token: write
     needs: [test]
     steps:
-    - uses: actions/download-artifact@v5
+    - uses: actions/download-artifact@v7
       with:
         name: Packages
         path: dist
@@ -132,7 +132,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/download-artifact@v5
+    - uses: actions/download-artifact@v7
       with:
         name: Packages
         path: dist
@@ -149,7 +149,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/download-artifact@v5
+    - uses: actions/download-artifact@v7
       with:
         name: Packages
         path: dist

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -91,9 +91,9 @@ jobs:
           $env:PATH = "C:\Program Files\Git\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\Chocolatey\bin"
           [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
           choco install gnupg hg -y --no-progress
-          echo "C:\Program Files (x86)\gnupg\bin" >> $env:GITHUB_PATH
+          echo "C:\Program Files\gnupg\bin" >> $env:GITHUB_PATH
           echo "C:\Program Files\Mercurial\" >> $env:GITHUB_PATH
-          git config --system gpg.program "C:\Program Files (x86)\gnupg\bin\gpg.exe"
+          git config --system gpg.program "C:\Program Files\gnupg\bin\gpg.exe"
         if: runner.os == 'Windows'
       - run: uv sync --group test --group docs --extra rich
       - uses: actions/download-artifact@v7

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For further configuration see the [documentation].
 Some enterprise distributions like RHEL7
 ship rather old setuptools versions.
 
-In those cases its typically possible to build by using an sdist against `setuptools-scm<2.0`.
+In those cases it's typically possible to build by using an sdist against `setuptools-scm<2.0`.
 As those old setuptools versions lack sensible types for versions,
 modern [setuptools-scm] is unable to support them sensibly.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,11 +21,12 @@ This automatically enables version inference with default settings.
 ### Explicit Configuration (Full Control)
 
 Use the `[tool.setuptools_scm]` section when you need to:
-  - Write version files (`version_file`)
-  - Customize version schemes (`version_scheme`, `local_scheme`)
-  - Set custom tag patterns (`tag_regex`)
-  - Configure fallback behavior (`fallback_version`)
-  - Or any other non-default behavior
+
+- Write version files (`version_file`)
+- Customize version schemes (`version_scheme`, `local_scheme`)
+- Set custom tag patterns (`tag_regex`)
+- Configure fallback behavior (`fallback_version`)
+- Or any other non-default behavior
 
 ## configuration parameters
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -231,12 +231,14 @@ Callables or other Python objects have to be passed in `setup.py` (via the `use_
 3. Works for `include_package_data = True` in package building
 
 **Entry point registration:**
+
 ```toml
 [project.entry-points."setuptools.file_finders"]
 setuptools_scm = "setuptools_scm._file_finders:find_files"
 ```
 
 **Files included by default:**
+
 - All files tracked by Git (`git ls-files`)
 - All files tracked by Mercurial (`hg files`)
 - Includes: source code, documentation, tests, config files, etc.
@@ -290,6 +292,7 @@ tar -tzf dist/package-*.tar.gz
 
 
 ### the configuration class
+
 ::: setuptools_scm.Configuration
     options:
       heading_level: 4

--- a/docs/examples/version_scheme_code/setup.py
+++ b/docs/examples/version_scheme_code/setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from setuptools import setup
+
 from setuptools_scm import ScmVersion
 
 

--- a/docs/examples/version_scheme_code/setup.py
+++ b/docs/examples/version_scheme_code/setup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from setuptools import setup
-
 from setuptools_scm import ScmVersion
 
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -44,6 +44,7 @@
 
 
 ### `setuptools_scm.version_scheme`
+
 Configures how the version number is constructed given a
 [ScmVersion][setuptools_scm.version.ScmVersion] instance and should return a string
 representing the version.
@@ -58,6 +59,7 @@ representing the version.
     and custom `.devN` versions will trigger an error.
 
     **Examples:**
+
     - Tag `v1.0.0` → version `1.0.1.dev0` (if dirty or distance > 0)
     - Tag `v1.0.0` → version `1.0.0` (if exact match)
 
@@ -69,6 +71,7 @@ representing the version.
     for release branches.
 
     **Examples:**
+
     - Tag `v23.01.15.0` on same day → version `23.01.15.1.devN`
     - Tag `v23.01.15.0` on different day (e.g., 2023-01-16) → version `23.01.16.0.devN`
     - Tag `v2023.01.15.0` → uses 4-digit year format for new versions
@@ -78,6 +81,7 @@ representing the version.
     This is the recommended replacement for the deprecated `post-release` scheme.
 
     **Examples:**
+
     - Tag `v1.0.0` → version `1.0.0.post1.devN` (if distance > 0)
     - Tag `v1.0.0` → version `1.0.0` (if exact match)
 
@@ -87,6 +91,7 @@ representing the version.
     !!! warning "This means version is no longer pseudo unique per commit"
 
     **Examples:**
+
     - Tag `v1.0.0` → version `1.0.0` (always, regardless of distance or dirty state)
 
 `post-release (deprecated)`
@@ -97,6 +102,7 @@ representing the version.
     !!! warning "the recommended replacement is `no-guess-dev`"
 
     **Examples:**
+
     - Tag `1.0.0` → version `1.0.0.postN` (where N is the distance)
 
 `python-simplified-semver`
@@ -109,6 +115,7 @@ representing the version.
     This scheme is not compatible with pre-releases.
 
     **Examples:**
+
     - Tag `1.0.0` on non-feature branch → version `1.0.1.devN`
     - Tag `1.0.0` on feature branch → version `1.1.0.devN`
 
@@ -123,12 +130,15 @@ representing the version.
     Namespaces are unix pathname separated parts of a branch/tag name.
 
     **Examples:**
+
     - Tag `1.0.0` on release branch `release-1.0` → version `1.0.1.devN`
 
     - Tag `1.0.0` on release branch `release/v1.0` → version `1.0.1.devN`
+
     - Tag `1.0.0` on development branch → version `1.1.0.devN`
 
 ### `setuptools_scm.local_scheme`
+
 Configures how the local part of a version is rendered given a
 [ScmVersion][setuptools_scm.version.ScmVersion] instance and should return a string
 representing the local version.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -292,7 +292,7 @@ publish-release:
 The environment variable `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}` must be set where:
 
 1. **`${DIST_NAME}`** is your package name normalized according to PEP 503:
-   
+
    - Convert to uppercase
    - Replace hyphens and dots with underscores
    - Examples: `my-package` → `MY_PACKAGE`, `my.package` → `MY_PACKAGE`

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -60,6 +60,7 @@ setuptools-scm provides the `no-local-version` local scheme and environment vari
 #### The Problem
 
 By default, setuptools-scm generates version numbers like:
+
 - `1.2.3.dev4+g1a2b3c4d5` (development version with git hash)
 - `1.2.3+dirty` (dirty working directory)
 
@@ -72,6 +73,7 @@ Use the `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}` environment variable to over
 ### GitHub Actions Example
 
 Here's a complete GitHub Actions workflow that:
+
 - Runs tests on all branches
 - Uploads development versions to test-PyPI from feature branches
 - Uploads development versions to PyPI from the main branch (with no-local-version)
@@ -290,6 +292,7 @@ publish-release:
 The environment variable `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}` must be set where:
 
 1. **`${DIST_NAME}`** is your package name normalized according to PEP 503:
+   
    - Convert to uppercase
    - Replace hyphens and dots with underscores
    - Examples: `my-package` → `MY_PACKAGE`, `my.package` → `MY_PACKAGE`
@@ -316,10 +319,12 @@ However, the environment variable approach is preferred for CI/CD as it allows d
 #### Version Examples
 
 **Development versions from main branch** (with `local_scheme = "no-local-version"`):
+
 - Development commit: `1.2.3.dev4+g1a2b3c4d5` → `1.2.3.dev4` ✅ (uploadable to PyPI)
 - Dirty working directory: `1.2.3+dirty` → `1.2.3` ✅ (uploadable to PyPI)
 
 **Tagged releases** (without overrides, using default local scheme):
+
 - Tagged commit: `1.2.3` → `1.2.3` ✅ (uploadable to PyPI)
 - Tagged release on dirty workdir: `1.2.3+dirty` → `1.2.3+dirty` ❌ (should not happen in CI)
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -293,9 +293,9 @@ The environment variable `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}` must be set
 
 1. **`${DIST_NAME}`** is your package name normalized according to PEP 503:
 
-   - Convert to uppercase
-   - Replace hyphens and dots with underscores
-   - Examples: `my-package` → `MY_PACKAGE`, `my.package` → `MY_PACKAGE`
+    - Convert to uppercase
+    - Replace hyphens and dots with underscores
+    - Examples: `my-package` → `MY_PACKAGE`, `my.package` → `MY_PACKAGE`
 
 2. **Value** must be a valid TOML inline table format:
    ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -622,6 +622,9 @@ would be required when not using `setuptools-scm`.
 - ✅ **Check**: Is setuptools-scm installed in your build environment?
 - ✅ **Check**: Are you in a valid SCM repository?
 
+**Problem: Error about dubious ownership**
+- CVE-2022-24765 identified security issues with git trusting repositories owned by another user.  If the file-finder detects that git is unable to list files because it is operating in a git directory owned by another user, it will raise an error.  Since this was not the default behaviour of `setuptools_scm` previously, you can override this by setting `SETUPTOOLS_SCM_IGNORE_DUBIOUS_OWNER`, but be warned git will not be listing files correctly with this flag set.
+
 ### Timestamps for Local Development Versions
 
 !!! info "Improved Timestamp Behavior"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,12 +26,14 @@ dynamic = ["version"]
 ```
 
 This streamlined approach automatically enables version inference when:
+
 - `setuptools-scm[simple]` is listed in `build-system.requires`
 - `version` is included in `project.dynamic`
 
 !!! tip "When to use simplified activation"
 
     Use simplified activation when you:
+
     - Want basic SCM version inference with default settings
     - Don't need custom version schemes or file writing
     - Prefer minimal configuration
@@ -90,6 +92,7 @@ Version files can be created with the ``version_file`` directive.
 [tool.setuptools_scm]
 version_file = "pkg/_version.py"
 ```
+
 Where ``pkg`` is the name of your package.
 
 Unless the small overhead of introspecting the version at runtime via
@@ -253,6 +256,7 @@ without copying the entire `.git` folder into the container image.
 RUN --mount=source=.git,target=.git,type=bind \
     pip install --no-cache-dir -e .
 ```
+
 However, this build step introduces a dependency to the state of your local
 `.git` folder the build cache and triggers the long-running pip install process on every build.
 To optimize build caching, one can use an environment variable to pretend a pseudo
@@ -332,6 +336,7 @@ setuptools-scm's default tag regex supports:
 - **Build metadata**: Anything after `+` is ignored
 
 **Examples of valid tags:**
+
 ```bash
 # Recommended formats (with v prefix)
 v1.0.0
@@ -390,6 +395,7 @@ The prefixes are automatically added by setuptools-scm and should be included wh
 specifying node IDs in environment variables like `SETUPTOOLS_SCM_PRETEND_METADATA`.
 
 **Examples:**
+
 ```bash
 # Git node ID
 1.0.0.dev5+g1a2b3c4d5
@@ -480,6 +486,7 @@ tagging style.
 ```
 
 Finally, commit both files:
+
 ```commandline
 $ git add .git_archival.txt .gitattributes && git commit -m "add git archive support"
 ```
@@ -542,14 +549,17 @@ exclude .gitattributes
 #### Troubleshooting
 
 **Problem: "unprocessed git archival found" warnings**
+
 - ✅ **Solution**: Add `exclude .git_archival.txt` to `MANIFEST.in` for development builds
 - ✅ **Alternative**: Build from actual git archives for releases
 
 **Problem: "git archive did not support describe output" warnings**
+
 - ℹ️ **Information**: This is expected when `.git_archival.txt` contains unexpanded templates
 - ✅ **Solution**: Same as above - exclude file or build from git archives
 
 **Problem: Version detection fails in git archives**
+
 - ✅ **Check**: Is `.gitattributes` configured with `export-subst`?
 - ✅ **Check**: Are you building from a properly created git archive?
 - ✅ **Check**: Does your git hosting provider support archive template expansion?
@@ -611,14 +621,17 @@ would be required when not using `setuptools-scm`.
 #### Troubleshooting
 
 **Problem: Unwanted files in my package**
+
 - ✅ **Solution**: Add exclusions to `MANIFEST.in`
 - ✅ **Alternative**: Use Git/Mercurial archive configuration
 
 **Problem: Missing files in package**
+
 - ✅ **Check**: Are the files tracked in your SCM?
 - ✅ **Solution**: `git add` missing files or override with `MANIFEST.in`
 
 **Problem: File finder not working**
+
 - ✅ **Check**: Is setuptools-scm installed in your build environment?
 - ✅ **Check**: Are you in a valid SCM repository?
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -454,14 +454,16 @@ $ python -m setuptools_scm create-archival-file --full
 Alternatively, you can create the file manually:
 
 **Stable version (recommended):**
-```{ .text file=".git_archival.txt"}
+
+```{ .text title=".git_archival.txt"}
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ```
 
 **Full version (with branch information - can cause instability):**
-```{ .text file=".git_archival.txt"}
+
+```{ .text title=".git_archival.txt"}
 # WARNING: Including ref-names can make archive checksums unstable
 # after commits are added post-release. Use only if describe-name is insufficient.
 node: $Format:%H$
@@ -481,7 +483,7 @@ tagging style.
     post-release. See [this issue][git-archive-issue] for more details.
 
 
-``` {.text file=".gitattributes"}
+``` {.text title=".gitattributes"}
 .git_archival.txt  export-subst
 ```
 
@@ -510,7 +512,7 @@ This typically happens when:
 **For development builds:**
 Exclude `.git_archival.txt` from your package to avoid warnings:
 
-```{ .text file="MANIFEST.in"}
+```{ .text title="MANIFEST.in"}
 # Exclude archival file from development builds
 exclude .git_archival.txt
 ```
@@ -533,14 +535,15 @@ Many CI systems and package repositories (like GitHub Actions) automatically han
 #### Integration with package managers
 
 **MANIFEST.in exclusions:**
-```{ .text file="MANIFEST.in"}
+
+```{ .text title="MANIFEST.in"}
 # Exclude development files from packages
 exclude .git_archival.txt
 exclude .gitattributes
 ```
 
 
-```{ .text file=".gitattributes"}
+```{ .text title=".gitattributes"}
 # Archive configuration
 .git_archival.txt  export-subst
 .gitignore         export-ignore

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -497,7 +497,7 @@ $ git add .git_archival.txt .gitattributes && git commit -m "add git archive sup
 
 If you see warnings like these when building your package:
 
-```
+```text
 UserWarning: git archive did not support describe output
 UserWarning: unprocessed git archival found (no export subst applied)
 ```
@@ -574,7 +574,8 @@ exclude .gitattributes
 !!! note "Version Files"
 
     If you are creating a `_version.py` file, it should not be kept in version control. Add it to `.gitignore`:
-    ```
+
+    ```{.ini title=".gitignore"}
     # Generated version file
     src/mypackage/_version.py
     ```
@@ -607,17 +608,19 @@ would be required when not using `setuptools-scm`.
 **To exclude unwanted files:**
 
 1. **Use `MANIFEST.in`** to exclude specific files/patterns:
-   ```
-   exclude development.txt
-   recursive-exclude tests *.pyc
-   ```
+
+    ```{.text title="MANIFEST.in"}
+    exclude development.txt
+    recursive-exclude tests *.pyc
+    ```
 
 2. **Configure Git archive** (for Git repositories):
-   ```bash
-   # Add to .gitattributes
-   tests/ export-ignore
-   *.md export-ignore
-   ```
+
+    ```{.bash title=".gitattributes"}
+    # Add to .gitattributes
+    tests/ export-ignore
+    *.md export-ignore
+    ```
 
 3. **Use `.hgignore`** or **Mercurial archive configuration** (for Mercurial repositories)
 

--- a/src/setuptools_scm/_config.py
+++ b/src/setuptools_scm/_config.py
@@ -134,7 +134,7 @@ def _check_absolute_root(root: _t.PathT, relative_to: _t.PathT | None) -> str:
         if os.path.isdir(relative_to):
             warnings.warn(
                 "relative_to is expected to be a file,"
-                f" its the directory {relative_to}\n"
+                f" it's the directory {relative_to}\n"
                 "assuming the parent directory was passed"
             )
             log.debug("dir %s", relative_to)

--- a/src/setuptools_scm/_file_finders/git.py
+++ b/src/setuptools_scm/_file_finders/git.py
@@ -8,6 +8,7 @@ import tarfile
 from typing import IO
 
 from .. import _types as _t
+from .._run_cmd import no_git_env
 from .._run_cmd import run as _run
 from ..integration import data_from_mime
 from . import is_toplevel_acceptable
@@ -72,7 +73,11 @@ def _git_ls_files_and_dirs(toplevel: str) -> tuple[set[str], set[str]]:
     cmd = ["git", "archive", "--prefix", toplevel + os.path.sep, "HEAD"]
     log.info("running %s", " ".join(str(x) for x in cmd))
     proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, cwd=toplevel, stderr=subprocess.DEVNULL
+        cmd,
+        stdout=subprocess.PIPE,
+        cwd=toplevel,
+        stderr=subprocess.DEVNULL,
+        env=no_git_env(os.environ),
     )
     assert proc.stdout is not None
     try:

--- a/src/setuptools_scm/_file_finders/git.py
+++ b/src/setuptools_scm/_file_finders/git.py
@@ -22,6 +22,18 @@ def _git_toplevel(path: str) -> str | None:
         cwd = os.path.abspath(path or ".")
         res = _run(["git", "rev-parse", "HEAD"], cwd=cwd)
         if res.returncode:
+            # This catches you being in a git directory, but the
+            # permissions being incorrect.  With modern contanizered
+            # CI environments you can easily end up in a cloned repo
+            # with incorrect permissions and we don't want to silently
+            # ignore files.
+            if "--add safe.directory" in res.stderr and not os.environ.get(
+                "SETUPTOOLS_SCM_IGNORE_DUBIOUS_OWNER"
+            ):
+                log.error(res.stderr)
+                raise SystemExit(
+                    "git introspection failed: {}".format(res.stderr.split("\n")[0])
+                )
             # BAIL if there is no commit
             log.error("listing git files failed - pretending there aren't any")
             return None

--- a/src/setuptools_scm/_integration/pyproject_reading.py
+++ b/src/setuptools_scm/_integration/pyproject_reading.py
@@ -261,7 +261,7 @@ def get_args_for_pyproject(
         warnings.warn(
             f"{pyproject.path}: at [tool.{pyproject.tool_name}]\n"
             f"ignoring value relative_to={relative!r}"
-            " as its always relative to the config file"
+            " as it's always relative to the config file"
         )
     if "dist_name" in section:
         if dist_name is None:

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -72,7 +72,7 @@ def test_config_from_file_protects_relative_to(tmp_path: Path) -> None:
         UserWarning,
         match=".*pyproject.toml: at \\[tool.setuptools_scm\\]\n"
         "ignoring value relative_to='dont_use_me'"
-        " as its always relative to the config file",
+        " as it's always relative to the config file",
     ):
         assert Configuration.from_file(str(fn))
 

--- a/testing/test_file_finder.py
+++ b/testing/test_file_finder.py
@@ -275,3 +275,26 @@ def test_hg_command_from_env(
         m.setenv("PATH", str(hg_wd.cwd / "not-existing"))
         # No module reloading needed - runtime configuration works immediately
         assert set(find_files()) == {"file"}
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/381")
+def test_file_finder_ignores_git_dir_env(
+    inwd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that file finder ignores GIT_DIR env var.
+
+    Git sets GIT_DIR when running hooks in worktrees/submodules, which
+    causes git archive to query the wrong repository. The file finder
+    must sanitize these variables like _run_cmd.run() does.
+    """
+    # Get expected files before setting GIT_DIR
+    expected_files = set(find_files())
+    assert expected_files  # Sanity check: we should have files
+
+    # Set GIT_DIR to an unrelated path (simulates git hook in worktree)
+    # This would cause git archive to fail or return wrong results if
+    # the environment isn't sanitized
+    monkeypatch.setenv("GIT_DIR", __file__)
+
+    # File finding should still work correctly
+    assert set(find_files()) == expected_files

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import sys
+import textwrap
 
 from datetime import date
 from datetime import datetime
@@ -19,6 +20,7 @@ from unittest.mock import patch
 import pytest
 
 import setuptools_scm._file_finders
+import setuptools_scm._file_finders.git
 
 from setuptools_scm import Configuration
 from setuptools_scm import NonNormalizedVersion
@@ -861,3 +863,35 @@ def test_git_no_commits_uses_fallback_version(wd: WorkDir) -> None:
     assert str(version_no_fallback.tag) == "0.0"
     assert version_no_fallback.distance == 0
     assert version_no_fallback.dirty is True
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/784")
+def test_dubious_dir(
+    wd: WorkDir, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that we exit clearly if we are in a unsafe directory"""
+    wd.commit_testfile()
+    git_wd = git.GitWorkdir(wd.cwd)
+
+    def _run(*args, **kwargs) -> CompletedProcess:  # type: ignore[no-untyped-def]
+        """Fake "git rev-parse HEAD" to fail as if you do not own the git repo"""
+        stderr = textwrap.dedent(f"""
+        fatal: detected dubious ownership in repository at '{git_wd}'
+        To add an exception for this directory, call:
+
+            git config --global --add safe.directory /this/is/a/fake/path
+        """)
+        orig_run = run
+        if args[0] == ["git", "rev-parse", "HEAD"]:
+            return CompletedProcess(
+                args=[], stdout="%cI", stderr=stderr, returncode=128
+            )
+        return orig_run(*args, **kwargs)
+
+    monkeypatch.setattr(setuptools_scm._file_finders.git, "_run", _run)
+    with pytest.raises(SystemExit):
+        git_find_files(str(wd.cwd))
+
+    assert "fatal: detected dubious ownership in repository" in " ".join(
+        caplog.messages
+    )


### PR DESCRIPTION
Sync develop branch with main, bringing in recent fixes:

- #1257: Docs formatting fixes
- #1254: File finder GIT env var sanitization
- #1256: CI windows gnupg path fix
- #1251: Bump actions/download-artifact to v7
- #1250: Fix list markup in docs
- #1248: Typo fixes
- #1237: Bump actions/checkout to v6
- #1235: Clear exit for dubious git directories