### PR TITLE
fix: integrate reusable workflow into release proposal pipeline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -68,9 +68,15 @@ showcontent = true
    - `changelog.d/template.md` (towncrier template)
    - `CHANGELOG.md` with the start marker
 
-4. **Add the version scheme entry point** (if using vcs-versioning):
+4. **Configure version scheme** in your `pyproject.toml`:
+
+```toml
+[tool.setuptools_scm]
+version_scheme = "towncrier-fragments"
+```
 
 The `towncrier-fragments` version scheme is provided by vcs-versioning 0.2.0+.
+The reusable workflow reads the scheme from the project's `pyproject.toml` via the CLI.
 
 ### Complete Example Workflow
 

--- a/.github/workflows/create-release-tags.yml
+++ b/.github/workflows/create-release-tags.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   create-tags:
@@ -151,8 +152,20 @@ jobs:
               await createTagAndRelease('vcs-versioning', 'vcs-versioning', 'vcs-versioning');
             }
 
-            // Write summary
-            const summary = `## Tags Created\n\n${tagsCreated.map(t => `- \`${t}\``).join('\n')}\n\nPyPI upload will be triggered automatically by tag push.`;
+            // Dispatch python-tests.yml for each tag to trigger PyPI upload.
+            // Tags created by GITHUB_TOKEN don't trigger push-based workflows,
+            // but workflow_dispatch events dispatched by GITHUB_TOKEN DO.
+            for (const tagName of tagsCreated) {
+              console.log(`Dispatching python-tests.yml for ${tagName}`);
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'python-tests.yml',
+                ref: tagName
+              });
+            }
+
+            const summary = `## Tags Created\n\n${tagsCreated.map(t => `- \`${t}\``).join('\n')}\n\nPyPI upload dispatched via workflow_dispatch for each tag.`;
             await core.summary.addRaw(summary).write();
 
             console.log(`\nDone! Created tags: ${tagsCreated.join(', ')}`);

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,9 @@ on:
     - "vcs-versioning-v*"
   release:
     types: [published]
+  # Tags created by GITHUB_TOKEN don't trigger push events for other workflows.
+  # create-release-tags.yml dispatches this workflow explicitly after tagging.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -135,7 +138,10 @@ jobs:
 
   dist_upload_setuptools_scm:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/setuptools-scm-v')) || (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'setuptools-scm-v'))
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/setuptools-scm-v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/setuptools-scm-v')) ||
+      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'setuptools-scm-v'))
     permissions:
       id-token: write
     needs: [test]
@@ -150,7 +156,10 @@ jobs:
 
   dist_upload_vcs_versioning:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/vcs-versioning-v')) || (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'vcs-versioning-v'))
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vcs-versioning-v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/vcs-versioning-v')) ||
+      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'vcs-versioning-v'))
     permissions:
       id-token: write
     needs: [test]
@@ -165,7 +174,9 @@ jobs:
 
   upload-release-assets-setuptools-scm:
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'setuptools-scm-v')
+    if: |
+      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'setuptools-scm-v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/setuptools-scm-v'))
     needs: [test]
     permissions:
       contents: write
@@ -183,7 +194,9 @@ jobs:
 
   upload-release-assets-vcs-versioning:
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'vcs-versioning-v')
+    if: |
+      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'vcs-versioning-v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/vcs-versioning-v'))
     needs: [test]
     permissions:
       contents: write

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -12,109 +12,199 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Version determination + changelog build for each project (parallel)
+  setuptools-scm:
+    uses: ./.github/workflows/reusable-towncrier-release.yml
+    with:
+      project_name: setuptools-scm
+      project_directory: setuptools-scm
+
+  vcs-versioning:
+    uses: ./.github/workflows/reusable-towncrier-release.yml
+    with:
+      project_name: vcs-versioning
+      project_directory: vcs-versioning
+
+  # On PRs: show what would be released
+  validate:
+    needs: [setuptools-scm, vcs-versioning]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release validation summary
+        env:
+          SCM_FRAGMENTS: ${{ needs.setuptools-scm.outputs.has_fragments }}
+          SCM_VERSION: ${{ needs.setuptools-scm.outputs.version }}
+          VCS_FRAGMENTS: ${{ needs.vcs-versioning.outputs.has_fragments }}
+          VCS_VERSION: ${{ needs.vcs-versioning.outputs.version }}
+        run: |
+          {
+            echo "## Release Proposal Validation"
+            echo ""
+            if [ "$SCM_FRAGMENTS" == "true" ]; then
+              echo "- **setuptools-scm**: v${SCM_VERSION}"
+            else
+              echo "- **setuptools-scm**: no fragments"
+            fi
+            if [ "$VCS_FRAGMENTS" == "true" ]; then
+              echo "- **vcs-versioning**: v${VCS_VERSION}"
+            else
+              echo "- **vcs-versioning**: no fragments"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # On push: download built changelogs, commit to release branch, create/update PR
   create-release-pr:
+    needs: [setuptools-scm, vcs-versioning]
+    if: |
+      github.event_name == 'push' &&
+      (needs.setuptools-scm.outputs.has_fragments == 'true' ||
+       needs.vcs-versioning.outputs.has_fragments == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install dependencies
+      # Remove directories that will be replaced by towncrier artifacts
+      - name: Prepare for artifact overlay
+        env:
+          SCM_FRAGMENTS: ${{ needs.setuptools-scm.outputs.has_fragments }}
+          VCS_FRAGMENTS: ${{ needs.vcs-versioning.outputs.has_fragments }}
         run: |
-          uv sync --all-packages --all-groups
+          if [ "$SCM_FRAGMENTS" == "true" ]; then
+            rm -rf setuptools-scm/changelog.d setuptools-scm/CHANGELOG.md
+          fi
+          if [ "$VCS_FRAGMENTS" == "true" ]; then
+            rm -rf vcs-versioning/changelog.d vcs-versioning/CHANGELOG.md
+          fi
+
+      - name: Download setuptools-scm changelog
+        if: needs.setuptools-scm.outputs.has_fragments == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-setuptools-scm
+
+      - name: Download vcs-versioning changelog
+        if: needs.vcs-versioning.outputs.has_fragments == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-vcs-versioning
 
       - name: Configure git
-        if: github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Run release proposal
-        id: release
-        run: |
-          uv run create-release-proposal \
-            --event "${{ github.event_name }}" \
-            --branch "${{ github.ref_name }}"
+      - name: Prepare release metadata
+        id: meta
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Create or update release branch
-        if: github.event_name == 'push'
+          SCM_FRAGMENTS: ${{ needs.setuptools-scm.outputs.has_fragments }}
+          SCM_VERSION: ${{ needs.setuptools-scm.outputs.version }}
+          VCS_FRAGMENTS: ${{ needs.vcs-versioning.outputs.has_fragments }}
+          VCS_VERSION: ${{ needs.vcs-versioning.outputs.version }}
+          BRANCH: ${{ github.ref_name }}
         run: |
-          # Get release branch from script output
-          RELEASE_BRANCH="${{ steps.release.outputs.release_branch }}"
-          RELEASES="${{ steps.release.outputs.releases }}"
+          RELEASES=""
+          LABELS=""
 
-          # Checkout release branch (force)
-          git checkout -B "$RELEASE_BRANCH"
+          if [ "$SCM_FRAGMENTS" == "true" ]; then
+            RELEASES="setuptools-scm v${SCM_VERSION}"
+            LABELS="release:setuptools-scm"
+          fi
 
-          # Commit towncrier changes
+          if [ "$VCS_FRAGMENTS" == "true" ]; then
+            VCS="vcs-versioning v${VCS_VERSION}"
+            if [ -n "$RELEASES" ]; then
+              RELEASES="${RELEASES}, ${VCS}"
+              LABELS="${LABELS},release:vcs-versioning"
+            else
+              RELEASES="$VCS"
+              LABELS="release:vcs-versioning"
+            fi
+          fi
+
+          echo "releases=$RELEASES" >> "$GITHUB_OUTPUT"
+          echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
+          echo "release_branch=release/${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branch and push
+        run: |
+          git checkout -B "${{ steps.meta.outputs.release_branch }}"
           git add -A
-          git commit -m "Prepare release: $RELEASES" || echo "No changes to commit"
-
-          # Force push
-          git push origin "$RELEASE_BRANCH" --force
+          git commit -m "Prepare release: ${{ steps.meta.outputs.releases }}" || echo "No changes to commit"
+          git push origin "${{ steps.meta.outputs.release_branch }}" --force
 
       - name: Create or update PR
-        if: github.event_name == 'push'
         uses: actions/github-script@v8
         env:
-          RELEASE_BRANCH: ${{ steps.release.outputs.release_branch }}
-          PR_BASE: ${{ steps.release.outputs.pr_base }}
-          PR_EXISTS: ${{ steps.release.outputs.pr_exists }}
-          PR_NUMBER: ${{ steps.release.outputs.pr_number }}
-          PR_TITLE: ${{ steps.release.outputs.pr_title }}
-          PR_BODY: ${{ steps.release.outputs.pr_body }}
-          LABELS: ${{ steps.release.outputs.labels }}
+          RELEASE_BRANCH: ${{ steps.meta.outputs.release_branch }}
+          RELEASES: ${{ steps.meta.outputs.releases }}
+          LABELS: ${{ steps.meta.outputs.labels }}
+          BRANCH: ${{ github.ref_name }}
         with:
           script: |
+            const branch = process.env.BRANCH;
             const releaseBranch = process.env.RELEASE_BRANCH;
-            const prBase = process.env.PR_BASE;
-            const prExists = process.env.PR_EXISTS === 'true';
-            const prNumber = process.env.PR_NUMBER;
-            const prTitle = process.env.PR_TITLE;
-            const prBody = process.env.PR_BODY;
+            const releases = process.env.RELEASES;
             const labels = process.env.LABELS.split(',').filter(l => l);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
-            if (prExists && prNumber) {
-              // Update existing PR (including base branch if it changed)
-              console.log(`Updating existing PR #${prNumber} to target ${prBase}`);
+            const prTitle = `Release: ${releases}`;
+            const prBody = [
+              '## Release Proposal',
+              '',
+              'This PR prepares the following releases:',
+              releases,
+              '',
+              `**Source branch:** ${branch}`,
+              '',
+              '### Changes',
+              '- Updated CHANGELOG.md with towncrier fragments',
+              '- Removed processed fragments from changelog.d/',
+              '',
+              '### Review Checklist',
+              '- [ ] Changelog entries are accurate',
+              '- [ ] Version numbers are correct',
+              '- [ ] All tests pass',
+              '',
+              '**Merging this PR will automatically create tags and trigger PyPI uploads.**'
+            ].join('\n');
+
+            // Check for existing release PR
+            const { data: pulls } = await github.rest.pulls.list({
+              owner, repo, state: 'open', base: branch,
+              head: `${owner}:${releaseBranch}`
+            });
+
+            if (pulls.length > 0) {
+              const prNumber = pulls[0].number;
+              console.log(`Updating existing PR #${prNumber}`);
               await github.rest.pulls.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: parseInt(prNumber),
-                title: prTitle,
-                body: prBody,
-                base: prBase
+                owner, repo, pull_number: prNumber,
+                title: prTitle, body: prBody, base: branch
               });
             } else {
-              // Create new PR - targets the same branch it came from
-              console.log(`Creating new PR targeting ${prBase}`);
+              console.log(`Creating new PR targeting ${branch}`);
               const { data: pr } = await github.rest.pulls.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: prTitle,
-                body: prBody,
-                head: releaseBranch,
-                base: prBase
+                owner, repo, title: prTitle, body: prBody,
+                head: releaseBranch, base: branch
               });
               console.log(`Created PR #${pr.number}`);
-
-              // Add labels
               if (labels.length > 0) {
                 await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  labels: labels
+                  owner, repo, issue_number: pr.number, labels
                 });
               }
             }
+
+      - name: Write summary
+        env:
+          RELEASES: ${{ steps.meta.outputs.releases }}
+        run: |
+          {
+            echo "## Release Proposal"
+            echo ""
+            echo "**Releases:** ${RELEASES}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -185,6 +185,11 @@ jobs:
                 owner, repo, pull_number: prNumber,
                 title: prTitle, body: prBody, base: branch
               });
+              if (labels.length > 0) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: prNumber, labels
+                });
+              }
             } else {
               console.log(`Creating new PR targeting ${branch}`);
               const { data: pr } = await github.rest.pulls.create({

--- a/.github/workflows/reusable-towncrier-release.yml
+++ b/.github/workflows/reusable-towncrier-release.yml
@@ -47,16 +47,17 @@ jobs:
         working-directory: ${{ inputs.project_directory }}
         run: |
           if [ ! -d "changelog.d" ]; then
-            echo "ERROR: changelog.d directory not found for ${{ inputs.project_name }}"
-            exit 1
+            echo "has_fragments=false" >> $GITHUB_OUTPUT
+            echo "No changelog.d directory for ${{ inputs.project_name }}, skipping"
+            exit 0
           fi
 
           FRAGMENT_COUNT=$(find changelog.d -type f -name "*.*.md" ! -name "template.md" ! -name "README.md" 2>/dev/null | wc -l)
 
           if [ "$FRAGMENT_COUNT" -eq 0 ]; then
-            echo "ERROR: No changelog fragments found for ${{ inputs.project_name }}"
-            echo "Cannot create release without changelog fragments"
-            exit 1
+            echo "has_fragments=false" >> $GITHUB_OUTPUT
+            echo "No changelog fragments for ${{ inputs.project_name }}, skipping"
+            exit 0
           fi
 
           echo "has_fragments=true" >> $GITHUB_OUTPUT
@@ -66,11 +67,10 @@ jobs:
         if: steps.check.outputs.has_fragments == 'true'
         id: version
         run: |
-          # Use vcs-versioning CLI to get the next version from the version scheme
-          NEXT_VERSION=$(uv run --directory ${{ inputs.project_directory }} python -m vcs_versioning \
-            --root . \
-            --version-scheme towncrier-fragments \
-            --local-scheme no-local-version 2>&1 | grep -oP '^\d+\.\d+\.\d+' || echo "")
+          # Version scheme is read from the project's pyproject.toml config
+          NEXT_VERSION=$(uv run python -m vcs_versioning \
+            -c ${{ inputs.project_directory }}/pyproject.toml \
+            --strip-dev 2>&1 | grep -oP '^\d+\.\d+\.\d+' || echo "")
 
           if [ -z "$NEXT_VERSION" ]; then
             echo "ERROR: Failed to determine version for ${{ inputs.project_name }}"


### PR DESCRIPTION
## Summary

- Rewrites the release-proposal workflow to call the reusable-towncrier-release workflow for each project in parallel, instead of relying on a monolithic Python script
- Fixes the broken CLI invocation in the reusable workflow (used nonexistent `--version-scheme`/`--local-scheme` flags)
- Makes fragment checking a soft output (`has_fragments=false`) rather than a hard failure, so monorepo callers can handle projects with no fragments gracefully

### Flow after this change

```
push to develop/main
  ├── setuptools-scm (reusable workflow) ─┐
  │   ├── determine-version               │  parallel
  │   └── build-changelog → artifact      │
  ├── vcs-versioning (reusable workflow) ──┘
  │   ├── determine-version
  │   └── build-changelog → artifact
  └── create-release-pr
      ├── downloads changelog artifacts
      ├── commits to release/<branch>
      └── creates/updates PR with labels
```

On PRs, a lightweight `validate` job shows planned releases in the step summary.

The `create_release_proposal.py` script is unchanged and continues to work for local development.

## Test plan

- [ ] CI passes on this PR (the reusable workflow runs as part of release-proposal)
- [ ] Validate step summary shows correct version info on this PR
- [ ] After merge: verify release-proposal workflow creates/updates the release PR on develop push

Made with [Cursor](https://cursor.com)