### PR TITLE
fix(docs): correct simplified configuration to require [simple] extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,20 @@ dynamic = ["version"]
 
 !!! note "Simplified Configuration"
 
-    Starting with setuptools-scm 8.1+, if `setuptools_scm` (or `setuptools-scm`) is
-    present in your `build-system.requires`, the `[tool.setuptools_scm]` section
-    becomes optional! You can now enable setuptools-scm with just:
+    For projects that don't need custom configuration, use the `simple` extra
+    to skip the `[tool.setuptools_scm]` section entirely:
 
     ```toml title="pyproject.toml"
     [build-system]
-    requires = ["setuptools>=80", "setuptools-scm>=8"]
+    requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
     build-backend = "setuptools.build_meta"
 
     [project]
     dynamic = ["version"]
     ```
 
-    The `[tool.setuptools_scm]` section is only needed if you want to customize
-    configuration options.
+    The `[simple]` extra explicitly enables version inference with default settings.
+    Add a `[tool.setuptools_scm]` section only if you need to customize options.
 
 Additionally, a version file can be written by specifying:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ dynamic = ["version"]
 
     ```toml title="pyproject.toml"
     [build-system]
-    requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
+    requires = ["setuptools>=80", "setuptools-scm[simple]>=9.2"]
     build-backend = "setuptools.build_meta"
 
     [project]

--- a/docs/config.md
+++ b/docs/config.md
@@ -16,7 +16,8 @@ requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
 dynamic = ["version"]
 ```
 
-This automatically enables version inference with default settings.
+The `[simple]` extra enables version inference with default settings.
+See the [usage guide](usage.md#simplified-activation-new) for details.
 
 ### Explicit Configuration (Full Control)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -10,7 +10,7 @@ For basic usage, use the `simple` extra with no configuration:
 
 ```toml title="pyproject.toml"
 [build-system]
-requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
+requires = ["setuptools>=80", "setuptools-scm[simple]>=9.2"]
 
 [project]
 dynamic = ["version"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Support for setuptools <80 is deprecated and will be removed in a future release
 
 ```toml title="pyproject.toml"
 [build-system]
-requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
+requires = ["setuptools>=80", "setuptools-scm[simple]>=9.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,7 @@ dynamic = ["version"]
 # No [tool.setuptools_scm] section needed for basic usage!
 ```
 
-This streamlined approach automatically enables version inference when:
+This streamlined approach automatically enables version inference when **both** conditions are met:
 
 - `setuptools-scm[simple]` is listed in `build-system.requires`
 - `version` is included in `project.dynamic`
@@ -72,16 +72,18 @@ must ensure build requirements are installed.
 Alternatively, enable `setuptools-scm` via the `use_scm_version` keyword in `setup.py`.
 This also counts as an explicit opt-in and does not require a tool section.
 
-!!! note "Legacy simplified activation"
+!!! note "Legacy simplified activation (removed)"
 
-    Previous versions had a "simplified" activation where listing `setuptools_scm`
-    in `build-system.requires` together with `project.dynamic = ["version"]` would
-    auto-enable version inference. This behavior was removed due to regressions and
-    ambiguous activation.
+    Previous versions (before 9.2) had a "simplified" activation where listing
+    plain `setuptools-scm` in `build-system.requires` together with
+    `project.dynamic = ["version"]` would auto-enable version inference.
+    This was removed because it caused ambiguous activation — projects using
+    setuptools-scm only for its file finder would unexpectedly trigger
+    version inference.
 
-    The new simplified activation using the `[simple]` extra provides the same
-    convenience but with explicit opt-in, making it clear when version inference
-    should be enabled.
+    The `[simple]` extra replaces this with explicit opt-in. If you previously
+    relied on the old behavior, either add the `[simple]` extra or add an
+    explicit `[tool.setuptools_scm]` section.
 
 ### Version files
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,7 @@ For basic usage without custom configuration, use the `simple` extra:
 
 ```toml title="pyproject.toml"
 [build-system]
-requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
+requires = ["setuptools>=80", "setuptools-scm[simple]>=9.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -74,7 +74,7 @@ This also counts as an explicit opt-in and does not require a tool section.
 
 !!! note "Legacy simplified activation (removed)"
 
-    Previous versions (before 9.2) had a "simplified" activation where listing
+    Previous versions (before 9.2.0) had a "simplified" activation where listing
     plain `setuptools-scm` in `build-system.requires` together with
     `project.dynamic = ["version"]` would auto-enable version inference.
     This was removed because it caused ambiguous activation — projects using


### PR DESCRIPTION
## Summary

- Fix README to show `setuptools-scm[simple]` instead of plain `setuptools-scm` in the simplified configuration example
- Clarify in `docs/usage.md` that **both** conditions (`[simple]` extra + `dynamic = ["version"]`) are required
- Improve legacy activation note with actionable migration guidance
- Add cross-reference from `docs/config.md` to usage guide

## Context

The README was written when simplified activation used plain `setuptools-scm` (commit 8b2e751), but that behavior was later changed to require the `[simple]` extra as a safeguard (commit 206742a / PR #1202). The `docs/usage.md` was updated at that time but the README was missed.

Users following the README (like the mpmath maintainer in #1266) get version `0.0.0` because `should_infer()` returns `False` without the `[simple]` extra.

Fixes #1266

Made with [Cursor](https://cursor.com)