### PR TITLE
fix: download release artifacts into correct project subdirectories

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -84,12 +84,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog-setuptools-scm
+          path: setuptools-scm
 
       - name: Download vcs-versioning changelog
         if: needs.vcs-versioning.outputs.has_fragments == 'true'
         uses: actions/download-artifact@v4
         with:
           name: changelog-vcs-versioning
+          path: vcs-versioning
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

- Fix release proposal pipeline bug where one project's changelog overwrites the other
- `upload-artifact@v4` strips the common root directory from paths, so both changelogs were extracted to the workspace root instead of their project subdirectories
- Add explicit `path:` to `download-artifact` steps so each artifact extracts into its correct project directory

Fixes the issue seen in #1246 where only the vcs-versioning changelog appeared.

## Test plan

- [ ] Verify the next release proposal PR includes changelogs for both setuptools-scm and vcs-versioning
- [ ] Confirm changelog fragments are correctly removed from both project directories

Made with [Cursor](https://cursor.com)