### PR TITLE
fix: preserve changelog.d scaffolding during release proposal

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -66,17 +66,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Remove directories that will be replaced by towncrier artifacts
+      # Remove only fragment files and CHANGELOG.md; preserve .gitkeep, template.md, README.md
       - name: Prepare for artifact overlay
         env:
           SCM_FRAGMENTS: ${{ needs.setuptools-scm.outputs.has_fragments }}
           VCS_FRAGMENTS: ${{ needs.vcs-versioning.outputs.has_fragments }}
         run: |
           if [ "$SCM_FRAGMENTS" == "true" ]; then
-            rm -rf setuptools-scm/changelog.d setuptools-scm/CHANGELOG.md
+            find setuptools-scm/changelog.d -name "*.*.md" ! -name "template.md" ! -name "README.md" -delete 2>/dev/null || true
+            rm -f setuptools-scm/CHANGELOG.md
           fi
           if [ "$VCS_FRAGMENTS" == "true" ]; then
-            rm -rf vcs-versioning/changelog.d vcs-versioning/CHANGELOG.md
+            find vcs-versioning/changelog.d -name "*.*.md" ! -name "template.md" ! -name "README.md" -delete 2>/dev/null || true
+            rm -f vcs-versioning/CHANGELOG.md
           fi
 
       - name: Download setuptools-scm changelog


### PR DESCRIPTION
## Summary

- The release workflow was doing `rm -rf changelog.d` which deleted `.gitkeep`, `template.md`, and `README.md` along with the fragment files
- Now only removes processed fragment files (`*.*.md` excluding `template.md` and `README.md`) and `CHANGELOG.md`, keeping the directory structure intact

## Context

Discovered after merging #1273 — the release proposal pipeline nukes the entire `changelog.d/` directory before overlaying the towncrier artifact, but the artifact may not restore dot files like `.gitkeep`, leaving the directory absent from git.

## Test plan

- [ ] Verify release proposal workflow preserves `.gitkeep`, `template.md`, `README.md` in `changelog.d/`
- [ ] Verify fragment files are still correctly removed after towncrier processing


Made with [Cursor](https://cursor.com)