### PR TITLE
ci: harden all GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -19,30 +22,38 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
 
       - name: Get latest release tag
         id: latest-tag
         run: |
           # Get the latest git tag (griffe needs a git ref)
-          LATEST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "v9.2.1")
-          echo "Latest release tag: $LATEST_TAG"
-          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          LATEST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No tags found on origin/main, skipping API check"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Latest release tag: $LATEST_TAG"
+            echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install dependencies
+        if: steps.latest-tag.outputs.skip != 'true'
         run: uv sync --all-packages --all-groups
 
       - name: Check API stability against latest release
+        if: steps.latest-tag.outputs.skip != 'true'
         run: |
           echo "Comparing current code against tag: ${{ steps.latest-tag.outputs.tag }}"
           # Use local check_api.py script which includes griffe-public-wildcard-imports extension

--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify releases and create sync PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const workflowRun = context.payload.workflow_run;
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create PR main → develop if needed
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const workflowRun = context.payload.workflow_run;

--- a/.github/workflows/create-release-tags.yml
+++ b/.github/workflows/create-release-tags.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create tags and releases
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 
@@ -26,6 +28,8 @@ jobs:
   package:
     name: Build & inspect ${{ matrix.package }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         package:
@@ -36,12 +40,12 @@ jobs:
       SETUPTOOLS_SCM_NO_LOCAL: "1"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Build ${{ matrix.package }}
-        uses: hynek/build-and-inspect-python-package@v2
+        uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
         with:
           path: ${{ matrix.package }}
           upload-name-suffix: -${{ matrix.package }}
@@ -49,6 +53,8 @@ jobs:
   test:
     needs: [package]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -63,19 +69,19 @@ jobs:
 
     name: ${{ matrix.os }} - Python ${{ matrix.python_version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         if: matrix.python_version != 'msys2'
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       - name: Setup MSYS2
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
         if: matrix.python_version == 'msys2'
         with:
           msystem: MINGW64
@@ -110,12 +116,12 @@ jobs:
         if: runner.os == 'Windows'
       - run: uv sync --all-packages --all-groups
       - name: Download vcs-versioning packages
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: Packages-vcs-versioning
           path: dist
       - name: Download setuptools-scm packages
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: Packages-setuptools-scm
           path: dist
@@ -147,12 +153,12 @@ jobs:
     needs: [test]
     steps:
     - name: Download setuptools-scm packages
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: Packages-setuptools-scm
         path: dist
     - name: Publish setuptools-scm to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
   dist_upload_vcs_versioning:
     runs-on: ubuntu-latest
@@ -165,12 +171,12 @@ jobs:
     needs: [test]
     steps:
     - name: Download vcs-versioning packages
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: Packages-vcs-versioning
         path: dist
     - name: Publish vcs-versioning to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
   upload-release-assets-setuptools-scm:
     runs-on: ubuntu-latest
@@ -182,12 +188,12 @@ jobs:
       contents: write
     steps:
     - name: Download setuptools-scm packages
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: Packages-setuptools-scm
         path: dist
     - name: Upload release assets
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
         files: dist/*
         fail_on_unmatched_files: true
@@ -202,12 +208,12 @@ jobs:
       contents: write
     steps:
     - name: Download vcs-versioning packages
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: Packages-vcs-versioning
         path: dist
     - name: Upload release assets
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
         files: dist/*
         fail_on_unmatched_files: true
@@ -220,17 +226,17 @@ jobs:
       id-token: write
     steps:
     - name: Download vcs-versioning packages
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: Packages-vcs-versioning
         path: dist
     - name: Download setuptools-scm packages
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: Packages-setuptools-scm
         path: dist
     - name: Publish package to PyPI
       continue-on-error: true
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -7,9 +7,7 @@ on:
       - develop
   pull_request:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   # Version determination + changelog build for each project (parallel)
@@ -30,6 +28,7 @@ jobs:
     needs: [setuptools-scm, vcs-versioning]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Release validation summary
         env:
@@ -61,8 +60,11 @@ jobs:
       (needs.setuptools-scm.outputs.has_fragments == 'true' ||
        needs.vcs-versioning.outputs.has_fragments == 'true')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -83,14 +85,14 @@ jobs:
 
       - name: Download setuptools-scm changelog
         if: needs.setuptools-scm.outputs.has_fragments == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: changelog-setuptools-scm
           path: setuptools-scm
 
       - name: Download vcs-versioning changelog
         if: needs.vcs-versioning.outputs.has_fragments == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: changelog-vcs-versioning
           path: vcs-versioning
@@ -140,7 +142,7 @@ jobs:
           git push origin "${{ steps.meta.outputs.release_branch }}" --force
 
       - name: Create or update PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           RELEASE_BRANCH: ${{ steps.meta.outputs.release_branch }}
           RELEASES: ${{ steps.meta.outputs.releases }}

--- a/.github/workflows/reusable-towncrier-release.yml
+++ b/.github/workflows/reusable-towncrier-release.yml
@@ -26,17 +26,17 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       has_fragments: ${{ steps.check.outputs.has_fragments }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
 
       - name: Install dependencies
         run: |
@@ -86,17 +86,17 @@ jobs:
     if: needs.determine-version.outputs.has_fragments == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
 
       - name: Install dependencies
         run: |
@@ -111,11 +111,10 @@ jobs:
           fi
 
       - name: Upload changelog artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: changelog-${{ inputs.project_name }}
           path: |
             ${{ inputs.project_directory }}/CHANGELOG.md
             ${{ inputs.project_directory }}/changelog.d/
           retention-days: 5
-


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to full commit SHAs across all 6 workflow files (10 distinct actions) to prevent supply chain attacks via tag rewriting
- Add least-privilege `permissions: {}` at workflow level and grant per-job permissions only where needed
- Upgrade `pypa/gh-action-pypi-publish` from `release/v1` (mutable branch ref) to `v1.13.0` — includes fix for [GHSA-vxmw-7h4f-hqxh](https://github.com/pypa/gh-action-pypi-publish/security/advisories/GHSA-vxmw-7h4f-hqxh)
- Upgrade `actions/download-artifact` v4→v7 and `actions/upload-artifact` v4→v6 (Node 24 support, version consistency)
- Fix `api-check.yml`: replace hardcoded stale fallback tag (`v9.2.1`) with graceful skip when no tags exist
- Group Dependabot GitHub Actions updates into single PRs to reduce noise from SHA pinning

## Test plan

- [ ] `python-tests` workflow runs successfully on this PR
- [ ] `api-check` workflow runs successfully on this PR
- [ ] `release-proposal` validation step shows expected output on this PR
- [ ] Verify no permission errors in workflow logs

Made with [Cursor](https://cursor.com)