### PR TITLE
ci: fix release pipeline concurrency and branch-sync triggering

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Get latest release tag
         id: latest-tag
         run: |
-          # Get the latest git tag (griffe needs a git ref)
-          LATEST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
+          # Get the latest setuptools-scm tag (griffe needs a git ref)
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'setuptools-scm-v*' origin/main 2>/dev/null || echo "")
           if [ -z "$LATEST_TAG" ]; then
             echo "No tags found on origin/main, skipping API check"
             echo "skip=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -9,7 +9,6 @@ on:
   workflow_run:
     workflows: ["python tests+artifacts+release"]
     types: [completed]
-    branches: [main, develop]
 
 permissions:
   contents: write
@@ -18,9 +17,10 @@ permissions:
 jobs:
   # Verify all releases completed and sync branches
   sync-after-release:
-    # Only run if the triggering workflow succeeded and was triggered by a tag push
+    # Only run for tag-dispatched release runs (not PR or push runs)
     if: |
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
       (startsWith(github.event.workflow_run.head_branch, 'setuptools-scm-v') ||
        startsWith(github.event.workflow_run.head_branch, 'vcs-versioning-v'))
     runs-on: ubuntu-latest
@@ -243,6 +243,7 @@ jobs:
   sync-main-to-develop:
     if: |
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
       (startsWith(github.event.workflow_run.head_branch, 'setuptools-scm-v') ||
        startsWith(github.event.workflow_run.head_branch, 'vcs-versioning-v'))
     runs-on: ubuntu-latest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
## Summary

Three fixes for the release pipeline discovered during pre-release validation:

- **python-tests.yml**: Fix concurrency group using `github.sha` → `github.ref`. When both packages are released at the same commit, two tag-dispatched runs share the same SHA, causing `cancel-in-progress` to kill one PyPI upload. Using `github.ref` gives each tag its own concurrency group.
- **branch-sync.yml**: Remove the `branches: [main, develop]` filter. It only delivers `workflow_run` events when `head_branch` matches main/develop, but the job's `if:` condition requires `head_branch` to start with a tag prefix — these are mutually exclusive, so sync never triggers. The script already validates tags at the commit internally.
- **api-check.yml**: Scope `git describe` to `--match 'setuptools-scm-v*'` tags. Without it, a `vcs-versioning-v*` tag could be picked as the baseline, causing griffe to compare against the wrong release.

## Test plan

- [x] YAML validates (pre-commit `check yaml` passes)
- [ ] Verify concurrency: dual-package release dispatches don't cancel each other
- [ ] Verify branch-sync triggers after tag-dispatched workflow completes
- [ ] Verify api-check uses correct setuptools-scm tag as baseline

Made with [Cursor](https://cursor.com)