### PR TITLE
ci: reiterate release tag creation and release proposal process after failure

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -1,221 +1,91 @@
 name: Branch Synchronization
 
-# Synchronize branches after successful releases:
-# - Triggers after upload jobs complete
-# - Verifies all expected releases for the commit succeeded
-# - Creates sync PRs between branches
+# After a release completes on main, sync main back to develop
+# so develop stays up to date with release commits (changelog, tags, etc.)
 
 on:
-  workflow_run:
-    workflows: ["python tests+artifacts+release"]
-    types: [completed]
+  pull_request:
+    types: [closed]
+    branches:
+      - main
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  # Verify all releases completed and sync branches
-  sync-after-release:
-    # Only run for tag-dispatched release runs (not PR or push runs)
+  sync-main-to-develop:
+    # Only run when a release PR is merged to main
     if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'workflow_dispatch' &&
-      (startsWith(github.event.workflow_run.head_branch, 'setuptools-scm-v') ||
-       startsWith(github.event.workflow_run.head_branch, 'vcs-versioning-v'))
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
-      - name: Verify releases and create sync PR
+      - name: Create PR main → develop
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const workflowRun = context.payload.workflow_run;
-            const headSha = workflowRun.head_sha;
-            const headBranch = workflowRun.head_branch;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
-            console.log(`Workflow completed for: ${headBranch} at ${headSha}`);
-
-            // Get all tags pointing to this commit
-            const { data: tagsResponse } = await github.rest.repos.listTags({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              per_page: 100
-            });
-
-            const commitTags = tagsResponse.filter(tag => tag.commit.sha === headSha);
-            console.log(`Tags at commit ${headSha}: ${commitTags.map(t => t.name).join(', ') || 'none'}`);
-
-            if (commitTags.length === 0) {
-              console.log('No tags found at this commit, nothing to sync');
-              return;
-            }
-
-            // Check which packages have tags at this commit
-            const setupToolsTag = commitTags.find(t => t.name.startsWith('setuptools-scm-v'));
-            const vcsVersioningTag = commitTags.find(t => t.name.startsWith('vcs-versioning-v'));
-
-            console.log(`setuptools-scm tag: ${setupToolsTag?.name || 'none'}`);
-            console.log(`vcs-versioning tag: ${vcsVersioningTag?.name || 'none'}`);
-
-            // Verify all expected releases have GitHub releases (created after successful upload)
-            const releasesToVerify = [];
-            if (setupToolsTag) releasesToVerify.push(setupToolsTag.name);
-            if (vcsVersioningTag) releasesToVerify.push(vcsVersioningTag.name);
-
-            for (const tagName of releasesToVerify) {
-              try {
-                const { data: release } = await github.rest.repos.getReleaseByTag({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  tag: tagName
-                });
-                console.log(`✓ Release exists for ${tagName}: ${release.html_url}`);
-              } catch (error) {
-                if (error.status === 404) {
-                  console.log(`✗ Release not found for ${tagName}, waiting for all releases to complete`);
-                  return;
-                }
-                throw error;
-              }
-            }
-
-            console.log('All expected releases verified successfully');
-
-            // Determine which branch this commit is on
-            // Check if this commit is on develop (for develop→main sync)
-            let isDevelopRelease = false;
+            // Check if develop branch exists
             try {
-              const { data: developBranch } = await github.rest.repos.getBranch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                branch: 'develop'
-              });
-
-              // Check if this commit is an ancestor of develop
-              const { data: comparison } = await github.rest.repos.compareCommits({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                base: headSha,
-                head: 'develop'
-              });
-
-              // If develop is at or ahead of this commit, it's a develop release
-              isDevelopRelease = comparison.status === 'identical' || comparison.status === 'ahead';
-              console.log(`Commit is on develop: ${isDevelopRelease}`);
+              await github.rest.repos.getBranch({ owner, repo, branch: 'develop' });
             } catch (error) {
               if (error.status === 404) {
-                console.log('develop branch does not exist');
-              } else {
-                throw error;
+                console.log('develop branch does not exist, skipping');
+                return;
               }
+              throw error;
             }
 
-            if (!isDevelopRelease) {
-              console.log('This is a main branch release, no sync needed (main→develop sync happens on PR merge)');
-              return;
-            }
-
-            // For develop releases, create sync PR to main
-            console.log('Creating sync PR from develop release to main');
-
-            // Use short commit SHA for branch name (simple and unique)
-            const tempBranchName = `sync/develop-to-main-${headSha.substring(0, 8)}`;
-
-            console.log(`Creating temporary branch ${tempBranchName} from commit ${headSha}`);
-
-            // Check if the commit has changes compared to main
-            const mainComparison = await github.rest.repos.compareCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              base: 'main',
-              head: headSha
+            // Check if main has commits that develop doesn't
+            const { data: comparison } = await github.rest.repos.compareCommits({
+              owner, repo, base: 'develop', head: 'main'
             });
 
-            if (mainComparison.data.ahead_by === 0) {
-              console.log('Commit has no new changes for main, skipping');
+            if (comparison.ahead_by === 0) {
+              console.log('main has no new commits for develop, skipping');
               return;
             }
 
-            console.log(`Commit has ${mainComparison.data.ahead_by} commits not on main`);
+            console.log(`main has ${comparison.ahead_by} commits not on develop`);
 
             // Check for existing sync PR
-            const existingPRs = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${context.repo.owner}:${tempBranchName}`,
-              base: 'main'
+            const { data: existingPRs } = await github.rest.pulls.list({
+              owner, repo, state: 'open',
+              head: `${owner}:main`, base: 'develop'
             });
 
-            if (existingPRs.data.length > 0) {
-              console.log(`Sync PR already exists: #${existingPRs.data[0].number}`);
+            if (existingPRs.length > 0) {
+              console.log(`Sync PR already exists: #${existingPRs[0].number}`);
               return;
             }
 
-            // Create temporary branch from the exact commit SHA
-            try {
-              await github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `refs/heads/${tempBranchName}`,
-                sha: headSha
-              });
-              console.log(`Created temporary branch ${tempBranchName}`);
-            } catch (error) {
-              if (error.status === 422) {
-                console.log(`Branch ${tempBranchName} already exists`);
-              } else {
-                throw error;
-              }
-            }
-
-            // Build release info for PR body
-            const releaseInfo = releasesToVerify.map(tag => `- \`${tag}\``).join('\n');
-
-            // Build PR body
+            const pr = context.payload.pull_request;
             const body = [
               '## Branch Synchronization',
               '',
-              'This PR syncs the release from `develop` to `main`.',
-              '',
-              '**Released tags:**',
-              releaseInfo,
-              '',
-              `**Commit:** ${headSha}`,
-              `**Temporary branch:** \`${tempBranchName}\``,
-              '',
-              'This PR uses a temporary branch created from the exact release commit',
-              'to ensure only the release changes are included (no extra commits).',
-              '',
-              'All PyPI uploads have been verified successful before creating this PR.',
+              `Syncs release changes from \`main\` back to \`develop\` after merging ${pr.title}.`,
               '',
               'This is an automated PR created by the branch-sync workflow.',
-              'If there are no conflicts, this PR will be auto-merged.',
-              '',
-              'The temporary branch will be deleted when this PR is merged or closed.'
+              'Review and merge to keep `develop` up to date with `main`.'
             ].join('\n');
 
-            // Build title with tag names
-            const title = `Sync: develop → main (${releasesToVerify.join(', ')})`;
-
-            // Create new sync PR from the temporary branch
-            const { data: pr } = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: title,
+            const { data: syncPR } = await github.rest.pulls.create({
+              owner, repo,
+              title: `Sync: main → develop`,
               body: body,
-              head: tempBranchName,
-              base: 'main'
+              head: 'main',
+              base: 'develop'
             });
 
-            console.log(`Created sync PR #${pr.number}`);
+            console.log(`Created sync PR #${syncPR.number}`);
 
-            // Add labels
             await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              labels: ['sync', 'auto-merge']
+              owner, repo,
+              issue_number: syncPR.number,
+              labels: ['sync']
             });
 
             // Try to enable auto-merge
@@ -230,133 +100,8 @@ jobs:
                     }
                   }
                 }
-              `, {
-                pullRequestId: pr.node_id
-              });
+              `, { pullRequestId: syncPR.node_id });
               console.log('Auto-merge enabled');
             } catch (error) {
-              console.log('Could not enable auto-merge (may require branch protection rules):', error.message);
+              console.log('Could not enable auto-merge:', error.message);
             }
-
-  # Forward-port: main → develop
-  # When a release PR is merged to main, create PR to keep develop in sync
-  sync-main-to-develop:
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'workflow_dispatch' &&
-      (startsWith(github.event.workflow_run.head_branch, 'setuptools-scm-v') ||
-       startsWith(github.event.workflow_run.head_branch, 'vcs-versioning-v'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create PR main → develop if needed
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const workflowRun = context.payload.workflow_run;
-            const headSha = workflowRun.head_sha;
-
-            // Check if develop branch exists
-            let developExists = true;
-            try {
-              await github.rest.repos.getBranch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                branch: 'develop'
-              });
-            } catch (error) {
-              if (error.status === 404) {
-                console.log('develop branch does not exist, skipping');
-                developExists = false;
-              } else {
-                throw error;
-              }
-            }
-
-            if (!developExists) return;
-
-            // Check if this commit is on main but not on develop
-            const { data: mainBranch } = await github.rest.repos.getBranch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'main'
-            });
-
-            // Check if commit is an ancestor of main
-            let isMainRelease = false;
-            try {
-              const { data: comparison } = await github.rest.repos.compareCommits({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                base: headSha,
-                head: 'main'
-              });
-              isMainRelease = comparison.status === 'identical' || comparison.status === 'ahead';
-            } catch {
-              isMainRelease = false;
-            }
-
-            if (!isMainRelease) {
-              console.log('This is not a main branch release, skipping main→develop sync');
-              return;
-            }
-
-            // Check if main has commits that develop doesn't have
-            const comparison = await github.rest.repos.compareCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              base: 'develop',
-              head: 'main'
-            });
-
-            if (comparison.data.ahead_by === 0) {
-              console.log('main has no new commits for develop, skipping');
-              return;
-            }
-
-            console.log(`main has ${comparison.data.ahead_by} commits not on develop`);
-
-            // Check for existing sync PR
-            const existingPRs = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${context.repo.owner}:main`,
-              base: 'develop'
-            });
-
-            if (existingPRs.data.length > 0) {
-              console.log(`Sync PR already exists: #${existingPRs.data[0].number}`);
-              return;
-            }
-
-            // Build PR body
-            const body = [
-              '## Branch Synchronization',
-              '',
-              'This PR syncs the release from `main` to `develop`.',
-              '',
-              `**Commit:** ${headSha}`,
-              '',
-              'This is an automated PR created by the branch-sync workflow.',
-              'Review and merge to keep `develop` up to date with `main`.'
-            ].join('\n');
-
-            // Create new sync PR
-            const { data: pr } = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Sync: main → develop`,
-              body: body,
-              head: 'main',
-              base: 'develop'
-            });
-
-            console.log(`Created sync PR #${pr.number}`);
-
-            // Add label
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              labels: ['sync']
-            });

--- a/.github/workflows/create-release-tags.yml
+++ b/.github/workflows/create-release-tags.yml
@@ -5,7 +5,6 @@ on:
     types: [closed]
     branches:
       - main
-      - develop
 
 permissions:
   contents: write

--- a/.github/workflows/create-release-tags.yml
+++ b/.github/workflows/create-release-tags.yml
@@ -86,7 +86,10 @@ jobs:
               }
             }
 
-            // Helper to create tag and release
+            // Helper to create tag and release via a single API call.
+            // createRelease with target_commitish automatically creates a
+            // lightweight tag if it doesn't already exist, avoiding the
+            // dangling tag object problem from separate createTag+createRef calls.
             async function createTagAndRelease(packageName, packageDir, tagPrefix) {
               const version = extractVersion(prTitle, packageName);
               if (!version) {
@@ -94,49 +97,24 @@ jobs:
               }
 
               const tagName = `${tagPrefix}-v${version}`;
-              console.log(`Creating tag: ${tagName} at ${mergeCommitSha}`);
-
-              // Create annotated tag via API
-              const { data: tagObject } = await github.rest.git.createTag({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag: tagName,
-                message: `Release ${packageName} v${version}`,
-                object: mergeCommitSha,
-                type: 'commit',
-                tagger: {
-                  name: 'github-actions[bot]',
-                  email: 'github-actions[bot]@users.noreply.github.com',
-                  date: new Date().toISOString()
-                }
-              });
-
-              // Create ref for the tag
-              await github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `refs/tags/${tagName}`,
-                sha: tagObject.sha
-              });
-
-              console.log(`Tag ${tagName} created`);
-              tagsCreated.push(tagName);
-
-              // Extract changelog
               const changelog = await extractChangelog(packageDir, version);
 
-              // Create GitHub release
+              console.log(`Creating release ${tagName} at ${mergeCommitSha}`);
+
               const { data: release } = await github.rest.repos.createRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 tag_name: tagName,
+                target_commitish: mergeCommitSha,
                 name: `${packageName} v${version}`,
                 body: changelog,
                 draft: false,
-                prerelease: false
+                prerelease: false,
+                make_latest: 'legacy'
               });
 
               console.log(`Release created: ${release.html_url}`);
+              tagsCreated.push(tagName);
               return { tagName, version };
             }
 

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -109,7 +109,7 @@ jobs:
           SCM_VERSION: ${{ needs.setuptools-scm.outputs.version }}
           VCS_FRAGMENTS: ${{ needs.vcs-versioning.outputs.has_fragments }}
           VCS_VERSION: ${{ needs.vcs-versioning.outputs.version }}
-          BRANCH: ${{ github.ref_name }}
+          SOURCE_BRANCH: ${{ github.ref_name }}
         run: |
           RELEASES=""
           LABELS=""
@@ -132,7 +132,7 @@ jobs:
 
           echo "releases=$RELEASES" >> "$GITHUB_OUTPUT"
           echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
-          echo "release_branch=release/${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "release_branch=release/${SOURCE_BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Create release branch and push
         run: |
@@ -147,13 +147,14 @@ jobs:
           RELEASE_BRANCH: ${{ steps.meta.outputs.release_branch }}
           RELEASES: ${{ steps.meta.outputs.releases }}
           LABELS: ${{ steps.meta.outputs.labels }}
-          BRANCH: ${{ github.ref_name }}
+          SOURCE_BRANCH: ${{ github.ref_name }}
         with:
           script: |
-            const branch = process.env.BRANCH;
+            const baseBranch = 'main';
             const releaseBranch = process.env.RELEASE_BRANCH;
             const releases = process.env.RELEASES;
             const labels = process.env.LABELS.split(',').filter(l => l);
+            const sourceBranch = process.env.SOURCE_BRANCH;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
@@ -164,7 +165,7 @@ jobs:
               'This PR prepares the following releases:',
               releases,
               '',
-              `**Source branch:** ${branch}`,
+              `**Source branch:** ${sourceBranch}`,
               '',
               '### Changes',
               '- Updated CHANGELOG.md with towncrier fragments',
@@ -175,12 +176,13 @@ jobs:
               '- [ ] Version numbers are correct',
               '- [ ] All tests pass',
               '',
-              '**Merging this PR will automatically create tags and trigger PyPI uploads.**'
+              '**Merging this PR will automatically create tags and trigger PyPI uploads.**',
+              '**After release, main will be synced back to develop.**'
             ].join('\n');
 
             // Check for existing release PR
             const { data: pulls } = await github.rest.pulls.list({
-              owner, repo, state: 'open', base: branch,
+              owner, repo, state: 'open', base: baseBranch,
               head: `${owner}:${releaseBranch}`
             });
 
@@ -189,7 +191,7 @@ jobs:
               console.log(`Updating existing PR #${prNumber}`);
               await github.rest.pulls.update({
                 owner, repo, pull_number: prNumber,
-                title: prTitle, body: prBody, base: branch
+                title: prTitle, body: prBody, base: baseBranch
               });
               if (labels.length > 0) {
                 await github.rest.issues.addLabels({
@@ -197,10 +199,10 @@ jobs:
                 });
               }
             } else {
-              console.log(`Creating new PR targeting ${branch}`);
+              console.log(`Creating new PR targeting ${baseBranch}`);
               const { data: pr } = await github.rest.pulls.create({
                 owner, repo, title: prTitle, body: prBody,
-                head: releaseBranch, base: branch
+                head: releaseBranch, base: baseBranch
               });
               console.log(`Created PR #${pr.number}`);
               if (labels.length > 0) {

--- a/setuptools-scm/changelog.d/release-pipeline.misc.md
+++ b/setuptools-scm/changelog.d/release-pipeline.misc.md
@@ -1,0 +1,1 @@
+Simplify release tag creation to use a single ``createRelease`` API call instead of separate ``createTag``/``createRef``/``createRelease`` calls, avoiding dangling tag objects on partial failures.

--- a/vcs-versioning/changelog.d/release-pipeline.misc.md
+++ b/vcs-versioning/changelog.d/release-pipeline.misc.md
@@ -1,0 +1,1 @@
+Simplify release tag creation to use a single ``createRelease`` API call instead of separate ``createTag``/``createRef``/``createRelease`` calls, avoiding dangling tag objects on partial failures.


### PR DESCRIPTION
## Summary

- Replace the 3-step tag+release creation (`createTag` → `createRef` → `createRelease`) with a single `createRelease` API call that atomically creates both the lightweight tag and the GitHub release
- This fixes the dangling tag object problem where `createTag` succeeds but `createRef` fails — as happened with `vcs-versioning-v1.0.0` due to the `v*` tag protection ruleset matching it
- Uses `make_latest: 'legacy'` so GitHub determines the "latest" release based on semantic versioning rather than creation order
- Adds changelog fragments for both packages to trigger a patch release

## Context

The v10.0.0 / v1.0.0 release pipeline failed at the `vcs-versioning-v1.0.0` tag creation step:
- `git.createTag()` succeeded (created annotated tag object `cd34263...`)
- `git.createRef()` failed with 422 "Reference update failed"
- Root cause: the repo's tag protection ruleset pattern `refs/tags/v*` matched `vcs-versioning-v1.0.0` (starts with `v`), and `GITHUB_TOKEN` was not a bypass actor

The tag protection ruleset has since been updated to add Write role bypass. This PR simplifies the workflow to avoid the multi-step failure mode entirely.

## Test plan

- [ ] Merge this PR to `main` — release-proposal workflow should detect the changelog fragments and create a release PR
- [ ] Merge the release PR — `create-release-tags` workflow should create both releases via single `createRelease` calls
- [ ] Verify both tags and releases are created on GitHub
- [ ] Verify `workflow_dispatch` triggers PyPI uploads for both packages

Made with [Cursor](https://cursor.com)