### PR TITLE
fix: drop tomli<=2.0.2 pin in build-system requires (fixes #1222)

### DIFF
--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "_own_version_helper:build_meta"
 requires = [
   "setuptools>=77.0.3",
   "vcs-versioning>=0.1.1",
-  'tomli<=2.0.2; python_version < "3.11"',
+  'tomli>=1; python_version < "3.11"',
   'typing-extensions; python_version < "3.11"',
 ]
 backend-path = [

--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -5,6 +5,8 @@ build-backend = "_own_version_helper:build_meta"
 requires = [
   "setuptools>=77.0.3",
   "vcs-versioning>=0.1.1",
+  # https://github.com/pypa/setuptools-scm/issues/1222: was <=2.0.2 for #1090 (old pip+toml);
+  # pip 21.2+ vendors tomli, so the workaround is no longer needed.
   'tomli>=1; python_version < "3.11"',
   'typing-extensions; python_version < "3.11"',
 ]


### PR DESCRIPTION
## Summary

Drops the `tomli<=2.0.2` upper bound from `[build-system]` requires and aligns it with project dependencies (`tomli>=1`).

## Background

- The pin was added in #1090 as a workaround: **pip** (using the old `toml` library) failed to parse **tomli's** own `pyproject.toml` when resolving build deps — the failure was in pip's parser, not in setuptools-scm or tomli's API.
- Issue #1222 asked to re-evaluate the pin. jhgit and others reported using setuptools-scm with tomli 2.2.1 on Python 3.9/3.10 without issues.
- Our code only uses `tomli.loads`; no version-specific behavior.

## Change

- **Before:** `'tomli<=2.0.2; python_version < "3.11"'` in build-system requires
- **After:** `'tomli>=1; python_version < "3.11"'` (matches `[project]` dependencies)

Minimal one-line change; no lockfile or other files modified.