### PR TITLE
fix: restrict version helpers to own tag prefix 

### DIFF
--- a/docs/examples/version_scheme_code/setup.py
+++ b/docs/examples/version_scheme_code/setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from setuptools import setup
+
 from setuptools_scm import ScmVersion
 
 

--- a/docs/examples/version_scheme_code/setup.py
+++ b/docs/examples/version_scheme_code/setup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from setuptools import setup
-
 from setuptools_scm import ScmVersion
 
 

--- a/setuptools-scm/_own_version_helper.py
+++ b/setuptools-scm/_own_version_helper.py
@@ -27,17 +27,24 @@ def scm_version() -> str:
         else "node-and-date"
     )
 
-    # Note: tag_regex is currently NOT set to allow backward compatibility
-    # with existing tags. To migrate to 'setuptools-scm-' prefix, uncomment:
-    # tag_regex=r"^setuptools-scm-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
-
-    # Use relative_to parent to find git root (one level up from setuptools-scm/)
+    # Restrict to setuptools-scm-* tags so we ignore other tags on the same
+    # commit (e.g. vcs-versioning-1.0.0.dev). Must match pyproject.toml.
     import pathlib
 
     return get_version(
         root=pathlib.Path(__file__).parent.parent,
         version_scheme="guess-next-dev",
         local_scheme=local_scheme,
+        tag_regex=r"^setuptools-scm-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
+        git_describe_command=[
+            "git",
+            "describe",
+            "--dirty",
+            "--tags",
+            "--long",
+            "--match",
+            "setuptools-scm-*",
+        ],
     )
 
 

--- a/setuptools-scm/_own_version_helper.py
+++ b/setuptools-scm/_own_version_helper.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 import os
 
+from pathlib import Path
+
 from setuptools import build_meta as build_meta
+from vcs_versioning._backends._git import make_describe_command
 
 from setuptools_scm import get_version
 
@@ -29,22 +32,12 @@ def scm_version() -> str:
 
     # Restrict to setuptools-scm-* tags so we ignore other tags on the same
     # commit (e.g. vcs-versioning-1.0.0.dev). Must match pyproject.toml.
-    import pathlib
-
     return get_version(
-        root=pathlib.Path(__file__).parent.parent,
+        root=Path(__file__).parent.parent,
         version_scheme="guess-next-dev",
         local_scheme=local_scheme,
-        tag_regex=r"^setuptools-scm-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
-        git_describe_command=[
-            "git",
-            "describe",
-            "--dirty",
-            "--tags",
-            "--long",
-            "--match",
-            "setuptools-scm-*",
-        ],
+        tag_regex=r"^setuptools-scm-(?P<version>v?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
+        scm={"git": {"describe_command": make_describe_command("setuptools-scm-*")}},
     )
 
 

--- a/setuptools-scm/_own_version_helper.py
+++ b/setuptools-scm/_own_version_helper.py
@@ -5,9 +5,10 @@ This module allows setuptools-scm to use VCS metadata for its own version.
 It works only if the backend-path of the build-system section from
 pyproject.toml is respected.
 
-Tag prefix configuration:
-- Currently: No prefix (for backward compatibility with existing tags)
-- Future: Will migrate to 'setuptools-scm-' prefix
+Version tags must carry the ``setuptools-scm-`` prefix (e.g.
+``setuptools-scm-v10.0.0``).  The tag regex and git describe ``--match``
+pattern are both restricted to this prefix so that co-located
+``vcs-versioning-*`` tags on the same commit do not affect the result.
 """
 
 from __future__ import annotations

--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -4,7 +4,7 @@
 build-backend = "_own_version_helper:build_meta"
 requires = [
   "setuptools>=77.0.3",
-  "vcs-versioning>=0.1.1",
+  "vcs-versioning>=1.0.0.dev0",
   # https://github.com/pypa/setuptools-scm/issues/1222: was <=2.0.2 for #1090 (old pip+toml);
   # pip 21.2+ vendors tomli, so the workaround is no longer needed.
   'tomli>=1; python_version < "3.11"',
@@ -45,7 +45,7 @@ dynamic = [
 ]
 dependencies = [
   # Core VCS functionality - workspace dependency
-  "vcs-versioning",
+  "vcs-versioning>=1.0.0.dev0",
   "packaging>=20",
   # https://github.com/pypa/setuptools-scm/issues/1112 - re-pin in a breaking release
   "setuptools", # >= 61",

--- a/vcs-versioning/_own_version_of_vcs_versioning.py
+++ b/vcs-versioning/_own_version_of_vcs_versioning.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Callable
+from pathlib import Path
 
 from vcs_versioning import Configuration
 from vcs_versioning import _types as _t
@@ -60,23 +61,29 @@ def _get_version() -> str:
         else get_local_node_and_date
     )
 
-    # __file__ is nextgen/vcs-versioning/_own_version_helper.py
-    # pyproject.toml is in nextgen/vcs-versioning/pyproject.toml
-    pyproject_path = os.path.join(os.path.dirname(__file__), "pyproject.toml")
+    # Resolve repo root from this file's location so version detection works
+    # regardless of cwd (e.g. when uv build runs from workspace root).
+    _here = Path(__file__).resolve()
+    _repo_root = _here.parent.parent
+    _pyproject_path = _here.parent / "pyproject.toml"
 
-    # root is the git repo root (../..)
-    # fallback_root is the vcs-versioning package dir (.)
-    # relative_to anchors to pyproject.toml
-    # fallback_version is used when no vcs-versioning- tags exist yet
     return get_version(
-        root="../..",
-        fallback_root=".",
-        relative_to=pyproject_path,
+        root=str(_repo_root),
+        fallback_root=str(_here.parent),
+        relative_to=str(_pyproject_path),
         parse=parse,
         version_scheme=guess_next_dev_version,
         local_scheme=local_scheme,
         tag_regex=r"^vcs-versioning-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
-        git_describe_command="git describe --dirty --tags --long --match 'vcs-versioning-*'",
+        git_describe_command=[
+            "git",
+            "describe",
+            "--dirty",
+            "--tags",
+            "--long",
+            "--match",
+            "vcs-versioning-*",
+        ],
         fallback_version="0.1.1+pre.tag",
     )
 

--- a/vcs-versioning/_own_version_of_vcs_versioning.py
+++ b/vcs-versioning/_own_version_of_vcs_versioning.py
@@ -74,16 +74,10 @@ def _get_version() -> str:
         parse=parse,
         version_scheme=guess_next_dev_version,
         local_scheme=local_scheme,
-        tag_regex=r"^vcs-versioning-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
-        git_describe_command=[
-            "git",
-            "describe",
-            "--dirty",
-            "--tags",
-            "--long",
-            "--match",
-            "vcs-versioning-*",
-        ],
+        tag_regex=r"^vcs-versioning-(?P<version>v?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
+        scm={
+            "git": {"describe_command": git.make_describe_command("vcs-versioning-*")}
+        },
         fallback_version="0.1.1+pre.tag",
     )
 

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -31,19 +31,25 @@ log = logging.getLogger(__name__)
 REF_TAG_RE = re.compile(r"(?<=\btag: )([^,]+)\b")
 DESCRIBE_UNSUPPORTED = "%(describe"
 
+
 # If testing command in shell make sure to quote the match argument like
 # '*[0-9]*' as it will expand before being sent to git if there are any matching
 # files in current directory.
-DEFAULT_DESCRIBE = [
-    "git",
-    "describe",
-    "--dirty",
-    "--tags",
-    "--long",
-    "--abbrev=40",
-    "--match",
-    "*[0-9]*",
-]
+def make_describe_command(match: str) -> list[str]:
+    """Build a ``git describe`` command list restricted to tags matching *match*."""
+    return [
+        "git",
+        "describe",
+        "--dirty",
+        "--tags",
+        "--long",
+        "--abbrev=40",
+        "--match",
+        match,
+    ]
+
+
+DEFAULT_DESCRIBE = make_describe_command("*[0-9]*")
 
 
 class GitPreParse(Enum):


### PR DESCRIPTION

- setuptools-scm: add tag_regex and git_describe_command with --match setuptools-scm-* so its version is not overridden by vcs-versioning-* tags on the same commit.
- vcs-versioning: compute repo root from Path(__file__).resolve() and pass git_describe_command as list so version works regardless of cwd (e.g. uv build from workspace root) and match pattern is not broken by shell quoting.