### PR TITLE
Filter out blobs when we unshallow a Git repo

### DIFF
--- a/vcs-versioning/changelog.d/1303.feature.md
+++ b/vcs-versioning/changelog.d/1303.feature.md
@@ -1,0 +1,3 @@
+The "fetch_on_shallow" option for Git worktrees no longer fetches the contents of Git commits--
+only their tags and refs.
+It takes hardly any bandwidth as a result, and is quite fast.

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -12,6 +12,7 @@ from datetime import date, datetime, timezone
 from enum import Enum
 from os.path import samefile
 from pathlib import Path
+from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 from .. import _discover as discover
@@ -178,12 +179,15 @@ class GitWorkdir(Workdir):
         return self.path.joinpath(".git/shallow").is_file()
 
     def fetch_shallow(self) -> None:
-        run_git(
-            ["fetch", "--unshallow", "--filter=blob:none"],
-            self.path,
-            check=True,
-            timeout=240,
-        )
+        try:
+            run_git(
+                ["fetch", "--unshallow", "--filter=blob:none"],
+                self.path,
+                check=True,
+                timeout=240,
+            )
+        except CalledProcessError:
+            run_git(["fetch", "--unshallow"], self.path, check=True, timeout=240)
 
     def node(self) -> str | None:
         return run_git(

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -178,7 +178,12 @@ class GitWorkdir(Workdir):
         return self.path.joinpath(".git/shallow").is_file()
 
     def fetch_shallow(self) -> None:
-        run_git(["fetch", "--unshallow"], self.path, check=True, timeout=240)
+        run_git(
+            ["fetch", "--unshallow", "--filter=blob:none"],
+            self.path,
+            check=True,
+            timeout=240,
+        )
 
     def node(self) -> str | None:
         return run_git(


### PR DESCRIPTION
setuptools-scm only needs tags and parents; it doesn't need the actual content of any commit in a Git repository. This PR makes it only fetch the tags and parents, not the blobs, when `pre_parse = "fetch_on_shallow"`. This results in far less bandwidth usage, which can save lots of time -- potentially avoiding the timeout -- on repos with long histories, hosted cheaply.