### PR TITLE
ci: Dependabot uv ecosystem with grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,11 @@ updates:
       github-actions:
         patterns:
           - "*"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      uv:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR updates Dependabot to use the `uv` package ecosystem (aligned with the repo’s `uv.lock`) and adds a single `groups.uv` entry with pattern `*` so weekly dependency bumps are combined into one pull request instead of many separate ones.

**Changes**
- Replace `package-ecosystem: pip` with `uv`.
- Add `groups.uv` with `patterns: ["*"]` (same grouping style as `github-actions`).