### PR TITLE
chore: upgrade pre-commit hooks and Ruff 0.15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+  autofix_commit_msg: "style: pre-commit fixes"
+  autoupdate_schedule: monthly
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -7,14 +11,14 @@ repos:
     -   id: debug-statements
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.13.3
+  rev: v0.15.7
   hooks:
     - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]
     - id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: v1.19.1
     hooks:
     -   id: mypy
         args: [--strict]
@@ -29,12 +33,12 @@ repos:
             - towncrier>=23.11.0
 
 -   repo: https://github.com/scientific-python/cookie
-    rev: 2025.10.01
+    rev: 2026.03.02
     hooks:
       - id: sp-repo-review
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     -   id: codespell
         args: [-w, --ignore-words-list=hist,nd,te]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,35 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.7
   hooks:
+    # Explicit --config so hooks match `uv run ruff` (astral-sh/ruff#11924).
+    # Workspace = everything except setuptools-scm/ (src/, vcs-versioning/, docs/, …).
+    # Args order: --config first, then check-only flags (--fix …).
     - id: ruff-check
-      args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+      name: ruff check (workspace)
+      exclude: ^setuptools-scm/
+      args:
+        - --config=pyproject.toml
+        - --fix
+        - --exit-non-zero-on-fix
+        - --show-fixes
+    - id: ruff-check
+      name: ruff check (setuptools-scm)
+      files: ^setuptools-scm/
+      args:
+        - --config=setuptools-scm/pyproject.toml
+        - --fix
+        - --exit-non-zero-on-fix
+        - --show-fixes
     - id: ruff-format
+      name: ruff format (workspace)
+      exclude: ^setuptools-scm/
+      args:
+        - --config=pyproject.toml
+    - id: ruff-format
+      name: ruff format (setuptools-scm)
+      files: ^setuptools-scm/
+      args:
+        - --config=setuptools-scm/pyproject.toml
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1

--- a/docs/examples/version_scheme_code/setup.py
+++ b/docs/examples/version_scheme_code/setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from setuptools import setup
+
 from setuptools_scm import ScmVersion
 
 

--- a/docs/examples/version_scheme_code/setup.py
+++ b/docs/examples/version_scheme_code/setup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from setuptools import setup
-
 from setuptools_scm import ScmVersion
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
 create-release-proposal = "vcs_versioning_workspace.create_release_proposal:main"
 
 [dependency-groups]
+# PP006 / uv: aggregate groups for local development (members define their own test deps)
+dev = [{ include-group = "docs" }, { include-group = "typing" }, { include-group = "release" }]
 docs = [
   "mkdocs",
   "mkdocs-include-markdown-plugin",
@@ -95,4 +97,12 @@ ignore = [
     "PY005", # no tests folder for the workspace
     "PY003", # each subproject has one
 
-    "GH103", "GH212", "MY100", "PC111", "PC160", "PC170", "PC180", "PC901"]
+    "GH103",
+    "GH212",
+    "MY100",
+    "PC111",
+    "PC160",
+    "PC170",
+    "PC180",
+    "PC901",
+]

--- a/setuptools-scm/_own_version_helper.py
+++ b/setuptools-scm/_own_version_helper.py
@@ -19,9 +19,8 @@ import os
 from pathlib import Path
 
 from setuptools import build_meta as build_meta
-from vcs_versioning._backends._git import make_describe_command
-
 from setuptools_scm import get_version
+from vcs_versioning._backends._git import make_describe_command
 
 
 def scm_version() -> str:

--- a/setuptools-scm/changelog.d/1311.misc.md
+++ b/setuptools-scm/changelog.d/1311.misc.md
@@ -1,0 +1,1 @@
+Upgrade pre-commit hooks (Ruff, mypy, codespell), align locked Ruff with hooks, and add Ruff per-file configuration for setuptools_scm re-export modules.

--- a/setuptools-scm/check_api.py
+++ b/setuptools-scm/check_api.py
@@ -40,7 +40,7 @@ def main() -> int:
         *("--against", against),
     ]
 
-    result = subprocess.run(cmd, cwd=repo_root)
+    result = subprocess.run(cmd, cwd=repo_root, check=False)
 
     return result.returncode
 

--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -59,6 +59,7 @@ simple = []
 toml = []
 
 [dependency-groups]
+dev = [{ include-group = "test" }]
 docs = [
   "mkdocs",
   "mkdocs-entangled-plugin",
@@ -133,6 +134,23 @@ scm.git.describe_command = ["git", "describe", "--dirty", "--tags", "--long", "-
 lint.extend-select = ["YTT", "B", "C4", "DTZ", "ISC", "LOG", "G", "PIE", "PYI", "PT", "FLY", "I", "C90", "PERF", "W", "PGH", "PLE", "UP", "FURB", "RUF"]
 lint.ignore = ["B028", "LOG015", "PERF203"]
 lint.preview = true
+
+# setuptools_scm alias modules: explicit `from m import x as x` re-exports for API stability
+# (PLC0414 only skips __init__.py; see check_api.py / griffe-public-wildcard-imports).
+[tool.ruff.lint.per-file-ignores]
+"src/setuptools_scm/version.py" = ["PLC0414"]
+"src/setuptools_scm/git.py" = ["PLC0414"]
+"src/setuptools_scm/scm_workdir.py" = ["PLC0414"]
+"src/setuptools_scm/discover.py" = ["PLC0414"]
+"src/setuptools_scm/integration.py" = ["PLC0414"]
+"src/setuptools_scm/hg.py" = ["PLC0414"]
+"src/setuptools_scm/hg_git.py" = ["PLC0414"]
+"src/setuptools_scm/fallbacks.py" = ["PLC0414"]
+"_own_version_helper.py" = ["PLC0414"]
+"src/setuptools_scm/_integration/pyproject_reading.py" = ["BLE001", "S112"]
+"testing_scm/conftest.py" = ["BLE001", "S110"]
+"testing_scm/test_main.py" = ["S102"]
+"testing_scm/test_regressions.py" = ["BLE001"]
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -137,20 +137,22 @@ lint.preview = true
 
 # setuptools_scm alias modules: explicit `from m import x as x` re-exports for API stability
 # (PLC0414 only skips __init__.py; see check_api.py / griffe-public-wildcard-imports).
+# Globs: match paths both from package dir (`src/...`) and from monorepo root (`setuptools-scm/src/...`)
+# when using `--config=setuptools-scm/pyproject.toml` (pre-commit).
 [tool.ruff.lint.per-file-ignores]
-"src/setuptools_scm/version.py" = ["PLC0414"]
-"src/setuptools_scm/git.py" = ["PLC0414"]
-"src/setuptools_scm/scm_workdir.py" = ["PLC0414"]
-"src/setuptools_scm/discover.py" = ["PLC0414"]
-"src/setuptools_scm/integration.py" = ["PLC0414"]
-"src/setuptools_scm/hg.py" = ["PLC0414"]
-"src/setuptools_scm/hg_git.py" = ["PLC0414"]
-"src/setuptools_scm/fallbacks.py" = ["PLC0414"]
-"_own_version_helper.py" = ["PLC0414"]
-"src/setuptools_scm/_integration/pyproject_reading.py" = ["BLE001", "S112"]
-"testing_scm/conftest.py" = ["BLE001", "S110"]
-"testing_scm/test_main.py" = ["S102"]
-"testing_scm/test_regressions.py" = ["BLE001"]
+"**/src/setuptools_scm/version.py" = ["PLC0414"]
+"**/src/setuptools_scm/git.py" = ["PLC0414"]
+"**/src/setuptools_scm/scm_workdir.py" = ["PLC0414"]
+"**/src/setuptools_scm/discover.py" = ["PLC0414"]
+"**/src/setuptools_scm/integration.py" = ["PLC0414"]
+"**/src/setuptools_scm/hg.py" = ["PLC0414"]
+"**/src/setuptools_scm/hg_git.py" = ["PLC0414"]
+"**/src/setuptools_scm/fallbacks.py" = ["PLC0414"]
+"**/_own_version_helper.py" = ["PLC0414"]
+"**/src/setuptools_scm/_integration/pyproject_reading.py" = ["BLE001", "S112"]
+"**/testing_scm/conftest.py" = ["BLE001", "S110"]
+"**/testing_scm/test_main.py" = ["S102"]
+"**/testing_scm/test_regressions.py" = ["BLE001"]
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/setuptools-scm/src/setuptools_scm/_integration/pyproject_reading.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/pyproject_reading.py
@@ -49,11 +49,10 @@ def should_infer(pyproject_data: PyProjectData) -> bool:
     # New behavior: simple extra + dynamic version
     if pyproject_data.project_present:
         dynamic_fields = pyproject_data.project.get("dynamic", [])
-        if "version" in dynamic_fields:
-            if has_build_package_with_extra(
-                pyproject_data.build_requires, "setuptools-scm", "simple"
-            ):
-                return True
+        if "version" in dynamic_fields and has_build_package_with_extra(
+            pyproject_data.build_requires, "setuptools-scm", "simple"
+        ):
+            return True
 
     return False
 
@@ -75,9 +74,11 @@ def has_build_package_with_extra(
         try:
             requirement = Requirement(requirement_string)
             package_name = extract_package_name(requirement_string)
-            if package_name == canonical_build_package_name:
-                if extra_name in requirement.extras:
-                    return True
+            if (
+                package_name == canonical_build_package_name
+                and extra_name in requirement.extras
+            ):
+                return True
         except Exception:
             # If parsing fails, continue to next requirement
             continue

--- a/setuptools-scm/src/setuptools_scm/_integration/version_inference.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/version_inference.py
@@ -30,9 +30,7 @@ def _should_write_to_source() -> bool:
     is explicitly set to a falsy value ("0", "false", "no").
     """
     value = os.environ.get(WRITE_TO_SOURCE_ENV_VAR, "").lower()
-    if value in ("0", "false", "no"):
-        return False
-    return True
+    return value not in ("0", "false", "no")
 
 
 def infer_version_with_config(

--- a/setuptools-scm/testing_scm/test_basic_api.py
+++ b/setuptools-scm/testing_scm/test_basic_api.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 import pytest
 
+from setuptools_scm.integration import data_from_mime
+from setuptools_scm.version import ScmVersion
+from setuptools_scm.version import meta
 from vcs_versioning._overrides import PRETEND_KEY
 from vcs_versioning._run_cmd import run
 from vcs_versioning.test_api import WorkDir
@@ -16,9 +19,6 @@ import setuptools_scm
 
 from setuptools_scm import Configuration
 from setuptools_scm import dump_version
-from setuptools_scm.integration import data_from_mime
-from setuptools_scm.version import ScmVersion
-from setuptools_scm.version import meta
 
 c = Configuration()
 

--- a/setuptools-scm/testing_scm/test_basic_api.py
+++ b/setuptools-scm/testing_scm/test_basic_api.py
@@ -7,18 +7,16 @@ from datetime import date
 from pathlib import Path
 
 import pytest
+import setuptools_scm
 
+from setuptools_scm import Configuration
+from setuptools_scm import dump_version
 from setuptools_scm.integration import data_from_mime
 from setuptools_scm.version import ScmVersion
 from setuptools_scm.version import meta
 from vcs_versioning._overrides import PRETEND_KEY
 from vcs_versioning._run_cmd import run
 from vcs_versioning.test_api import WorkDir
-
-import setuptools_scm
-
-from setuptools_scm import Configuration
-from setuptools_scm import dump_version
 
 c = Configuration()
 

--- a/setuptools-scm/testing_scm/test_cli.py
+++ b/setuptools-scm/testing_scm/test_cli.py
@@ -6,10 +6,9 @@ from contextlib import redirect_stdout
 
 import pytest
 
+from setuptools_scm._integration.pyproject_reading import PyProjectData
 from vcs_versioning._cli import main
 from vcs_versioning.test_api import WorkDir
-
-from setuptools_scm._integration.pyproject_reading import PyProjectData
 
 from .conftest import DebugMode
 

--- a/setuptools-scm/testing_scm/test_functions.py
+++ b/setuptools-scm/testing_scm/test_functions.py
@@ -14,12 +14,12 @@ from pathlib import Path
 
 import pytest
 
+from setuptools_scm.version import meta
 from vcs_versioning._overrides import PRETEND_KEY
 
 from setuptools_scm import Configuration
 from setuptools_scm import dump_version
 from setuptools_scm import get_version
-from setuptools_scm.version import meta
 
 c = Configuration()
 

--- a/setuptools-scm/testing_scm/test_functions.py
+++ b/setuptools-scm/testing_scm/test_functions.py
@@ -14,12 +14,11 @@ from pathlib import Path
 
 import pytest
 
-from setuptools_scm.version import meta
-from vcs_versioning._overrides import PRETEND_KEY
-
 from setuptools_scm import Configuration
 from setuptools_scm import dump_version
 from setuptools_scm import get_version
+from setuptools_scm.version import meta
+from vcs_versioning._overrides import PRETEND_KEY
 
 c = Configuration()
 

--- a/setuptools-scm/testing_scm/test_integration.py
+++ b/setuptools-scm/testing_scm/test_integration.py
@@ -15,23 +15,23 @@ from typing import Any
 import pytest
 
 from packaging.version import Version
-from vcs_versioning._requirement_cls import extract_package_name
-
-from setuptools_scm._integration import setuptools as setuptools_integration
 from setuptools_scm._integration.pyproject_reading import PyProjectData
 from setuptools_scm._integration.setup_cfg import SetuptoolsBasicData
 from setuptools_scm._integration.setup_cfg import read_setup_cfg
+from vcs_versioning._requirement_cls import extract_package_name
+
+from setuptools_scm._integration import setuptools as setuptools_integration
 
 if TYPE_CHECKING:
     import setuptools
 
+from setuptools_scm._integration.setuptools import _warn_on_old_setuptools
 from vcs_versioning._overrides import PRETEND_KEY
 from vcs_versioning._overrides import PRETEND_KEY_NAMED
 from vcs_versioning._run_cmd import run
 from vcs_versioning.test_api import WorkDir
 
 from setuptools_scm import Configuration
-from setuptools_scm._integration.setuptools import _warn_on_old_setuptools
 
 c = Configuration()
 
@@ -505,9 +505,10 @@ def test_setup_cfg_version_prevents_inference_version_keyword(
     dist = create_clean_distribution("legacy-proj")
 
     # Using keyword should detect an existing version via legacy data and avoid inferring
-    from setuptools_scm._integration import setuptools as setuptools_integration
     from setuptools_scm._integration.pyproject_reading import PyProjectData
     from setuptools_scm._integration.setup_cfg import SetuptoolsBasicData
+
+    from setuptools_scm._integration import setuptools as setuptools_integration
 
     # Construct PyProjectData directly without requiring build backend inference
     pyproject_data = PyProjectData.for_testing(

--- a/setuptools-scm/testing_scm/test_integration.py
+++ b/setuptools-scm/testing_scm/test_integration.py
@@ -47,6 +47,7 @@ def _run_setuptools_setup(cwd: Path) -> subprocess.CompletedProcess[str]:
         cwd=cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert result.returncode != 0, "setup() with no commands should exit non-zero"
     return result
@@ -594,7 +595,7 @@ def create_clean_distribution(name: str) -> setuptools.Distribution:
     # Clean all setuptools_scm effects
     dist.metadata.version = None
     if hasattr(dist, "_setuptools_scm_version_set_by_infer"):
-        delattr(dist, "_setuptools_scm_version_set_by_infer")
+        del dist._setuptools_scm_version_set_by_infer
 
     return dist
 
@@ -782,6 +783,7 @@ def test_version_file_written_to_build_directory(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     # Build should succeed
@@ -854,6 +856,7 @@ def test_version_file_src_layout_path_transformation(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     assert build_result.returncode == 0, (
@@ -938,6 +941,7 @@ def test_editable_install_version_file(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     assert build_result.returncode == 0, (
@@ -1012,6 +1016,7 @@ def test_editable_strict_includes_version_file(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     assert build_result.returncode == 0, (
@@ -1108,6 +1113,7 @@ def test_readonly_source_directory_build(
             cwd=wd.cwd,
             capture_output=True,
             text=True,
+            check=False,
             env={**os.environ, "SETUPTOOLS_SCM_WRITE_TO_SOURCE": "0"},
         )
 
@@ -1198,6 +1204,7 @@ def test_legacy_write_to_build_directory(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     assert build_result.returncode == 0, (
@@ -1270,6 +1277,7 @@ def test_version_file_template_in_build(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     assert build_result.returncode == 0, (
@@ -1354,6 +1362,7 @@ def test_custom_build_py_still_writes_version_file(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     assert build_result.returncode == 0, (
@@ -1425,6 +1434,7 @@ def test_version_file_contains_commit_node_in_wheel(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     assert build_result.returncode == 0, (
@@ -1510,6 +1520,7 @@ def test_version_file_contains_commit_node_in_editable_strict(
         cwd=wd.cwd,
         capture_output=True,
         text=True,
+        check=False,
     )
 
     assert build_result.returncode == 0, (

--- a/setuptools-scm/testing_scm/test_integration.py
+++ b/setuptools-scm/testing_scm/test_integration.py
@@ -15,23 +15,21 @@ from typing import Any
 import pytest
 
 from packaging.version import Version
+from setuptools_scm._integration import setuptools as setuptools_integration
 from setuptools_scm._integration.pyproject_reading import PyProjectData
 from setuptools_scm._integration.setup_cfg import SetuptoolsBasicData
 from setuptools_scm._integration.setup_cfg import read_setup_cfg
 from vcs_versioning._requirement_cls import extract_package_name
 
-from setuptools_scm._integration import setuptools as setuptools_integration
-
 if TYPE_CHECKING:
     import setuptools
 
+from setuptools_scm import Configuration
 from setuptools_scm._integration.setuptools import _warn_on_old_setuptools
 from vcs_versioning._overrides import PRETEND_KEY
 from vcs_versioning._overrides import PRETEND_KEY_NAMED
 from vcs_versioning._run_cmd import run
 from vcs_versioning.test_api import WorkDir
-
-from setuptools_scm import Configuration
 
 c = Configuration()
 
@@ -505,10 +503,9 @@ def test_setup_cfg_version_prevents_inference_version_keyword(
     dist = create_clean_distribution("legacy-proj")
 
     # Using keyword should detect an existing version via legacy data and avoid inferring
+    from setuptools_scm._integration import setuptools as setuptools_integration
     from setuptools_scm._integration.pyproject_reading import PyProjectData
     from setuptools_scm._integration.setup_cfg import SetuptoolsBasicData
-
-    from setuptools_scm._integration import setuptools as setuptools_integration
 
     # Construct PyProjectData directly without requiring build backend inference
     pyproject_data = PyProjectData.for_testing(

--- a/setuptools-scm/testing_scm/test_regressions.py
+++ b/setuptools-scm/testing_scm/test_regressions.py
@@ -15,10 +15,9 @@ from pathlib import Path
 
 import pytest
 
+from setuptools_scm.integration import data_from_mime
 from vcs_versioning._run_cmd import run
 from vcs_versioning.test_api import WorkDir
-
-from setuptools_scm.integration import data_from_mime
 
 
 def test_data_from_mime_ignores_body() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1289,28 +1289,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.7"
+version = "0.15.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/5b/dd7406afa6c95e3d8fa9d652b6d6dd17dd4a6bf63cb477014e8ccd3dcd46/ruff-0.14.7.tar.gz", hash = "sha256:3417deb75d23bd14a722b57b0a1435561db65f0ad97435b4cf9f85ffcef34ae5", size = 5727324, upload-time = "2025-11-28T20:55:10.525Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/b1/7ea5647aaf90106f6d102230e5df874613da43d1089864da1553b899ba5e/ruff-0.14.7-py3-none-linux_armv6l.whl", hash = "sha256:b9d5cb5a176c7236892ad7224bc1e63902e4842c460a0b5210701b13e3de4fca", size = 13414475, upload-time = "2025-11-28T20:54:54.569Z" },
-    { url = "https://files.pythonhosted.org/packages/af/19/fddb4cd532299db9cdaf0efdc20f5c573ce9952a11cb532d3b859d6d9871/ruff-0.14.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3f64fe375aefaf36ca7d7250292141e39b4cea8250427482ae779a2aa5d90015", size = 13634613, upload-time = "2025-11-28T20:55:17.54Z" },
-    { url = "https://files.pythonhosted.org/packages/40/2b/469a66e821d4f3de0440676ed3e04b8e2a1dc7575cf6fa3ba6d55e3c8557/ruff-0.14.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93e83bd3a9e1a3bda64cb771c0d47cda0e0d148165013ae2d3554d718632d554", size = 12765458, upload-time = "2025-11-28T20:55:26.128Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/05/0b001f734fe550bcfde4ce845948ac620ff908ab7241a39a1b39bb3c5f49/ruff-0.14.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3838948e3facc59a6070795de2ae16e5786861850f78d5914a03f12659e88f94", size = 13236412, upload-time = "2025-11-28T20:55:28.602Z" },
-    { url = "https://files.pythonhosted.org/packages/11/36/8ed15d243f011b4e5da75cd56d6131c6766f55334d14ba31cce5461f28aa/ruff-0.14.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24c8487194d38b6d71cd0fd17a5b6715cda29f59baca1defe1e3a03240f851d1", size = 13182949, upload-time = "2025-11-28T20:55:33.265Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cf/fcb0b5a195455729834f2a6eadfe2e4519d8ca08c74f6d2b564a4f18f553/ruff-0.14.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79c73db6833f058a4be8ffe4a0913b6d4ad41f6324745179bd2aa09275b01d0b", size = 13816470, upload-time = "2025-11-28T20:55:08.203Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/5d/34a4748577ff7a5ed2f2471456740f02e86d1568a18c9faccfc73bd9ca3f/ruff-0.14.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:12eb7014fccff10fc62d15c79d8a6be4d0c2d60fe3f8e4d169a0d2def75f5dad", size = 15289621, upload-time = "2025-11-28T20:55:30.837Z" },
-    { url = "https://files.pythonhosted.org/packages/53/53/0a9385f047a858ba133d96f3f8e3c9c66a31cc7c4b445368ef88ebeac209/ruff-0.14.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c623bbdc902de7ff715a93fa3bb377a4e42dd696937bf95669118773dbf0c50", size = 14975817, upload-time = "2025-11-28T20:55:24.107Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/d7/2f1c32af54c3b46e7fadbf8006d8b9bcfbea535c316b0bd8813d6fb25e5d/ruff-0.14.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f53accc02ed2d200fa621593cdb3c1ae06aa9b2c3cae70bc96f72f0000ae97a9", size = 14284549, upload-time = "2025-11-28T20:55:06.08Z" },
-    { url = "https://files.pythonhosted.org/packages/92/05/434ddd86becd64629c25fb6b4ce7637dd52a45cc4a4415a3008fe61c27b9/ruff-0.14.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:281f0e61a23fcdcffca210591f0f53aafaa15f9025b5b3f9706879aaa8683bc4", size = 14071389, upload-time = "2025-11-28T20:55:35.617Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/50/fdf89d4d80f7f9d4f420d26089a79b3bb1538fe44586b148451bc2ba8d9c/ruff-0.14.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:dbbaa5e14148965b91cb090236931182ee522a5fac9bc5575bafc5c07b9f9682", size = 14202679, upload-time = "2025-11-28T20:55:01.472Z" },
-    { url = "https://files.pythonhosted.org/packages/77/54/87b34988984555425ce967f08a36df0ebd339bb5d9d0e92a47e41151eafc/ruff-0.14.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1464b6e54880c0fe2f2d6eaefb6db15373331414eddf89d6b903767ae2458143", size = 13147677, upload-time = "2025-11-28T20:55:19.933Z" },
-    { url = "https://files.pythonhosted.org/packages/67/29/f55e4d44edfe053918a16a3299e758e1c18eef216b7a7092550d7a9ec51c/ruff-0.14.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f217ed871e4621ea6128460df57b19ce0580606c23aeab50f5de425d05226784", size = 13151392, upload-time = "2025-11-28T20:55:21.967Z" },
-    { url = "https://files.pythonhosted.org/packages/36/69/47aae6dbd4f1d9b4f7085f4d9dcc84e04561ee7ad067bf52e0f9b02e3209/ruff-0.14.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6be02e849440ed3602d2eb478ff7ff07d53e3758f7948a2a598829660988619e", size = 13412230, upload-time = "2025-11-28T20:55:12.749Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/4b/6e96cb6ba297f2ba502a231cd732ed7c3de98b1a896671b932a5eefa3804/ruff-0.14.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:19a0f116ee5e2b468dfe80c41c84e2bbd6b74f7b719bee86c2ecde0a34563bcc", size = 14195397, upload-time = "2025-11-28T20:54:56.896Z" },
-    { url = "https://files.pythonhosted.org/packages/69/82/251d5f1aa4dcad30aed491b4657cecd9fb4274214da6960ffec144c260f7/ruff-0.14.7-py3-none-win32.whl", hash = "sha256:e33052c9199b347c8937937163b9b149ef6ab2e4bb37b042e593da2e6f6cccfa", size = 13126751, upload-time = "2025-11-28T20:55:03.47Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b5/d0b7d145963136b564806f6584647af45ab98946660d399ec4da79cae036/ruff-0.14.7-py3-none-win_amd64.whl", hash = "sha256:e17a20ad0d3fad47a326d773a042b924d3ac31c6ca6deb6c72e9e6b5f661a7c6", size = 14531726, upload-time = "2025-11-28T20:54:59.121Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/d2/1637f4360ada6a368d3265bf39f2cf737a0aaab15ab520fc005903e883f8/ruff-0.14.7-py3-none-win_arm64.whl", hash = "sha256:be4d653d3bea1b19742fcc6502354e32f65cd61ff2fbdb365803ef2c2aec6228", size = 13609215, upload-time = "2025-11-28T20:55:15.375Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
 ]
 
 [[package]]
@@ -1339,6 +1338,21 @@ rich = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "build" },
+    { name = "flake8" },
+    { name = "griffe" },
+    { name = "griffe-public-wildcard-imports" },
+    { name = "griffecli" },
+    { name = "mypy", marker = "implementation_name != 'pypy'" },
+    { name = "pip" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "rich" },
+    { name = "ruff" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
 docs = [
     { name = "griffe-public-wildcard-imports" },
     { name = "mkdocs" },
@@ -1376,6 +1390,21 @@ requires-dist = [
 provides-extras = ["rich", "simple", "toml"]
 
 [package.metadata.requires-dev]
+dev = [
+    { name = "build" },
+    { name = "flake8" },
+    { name = "griffe" },
+    { name = "griffe-public-wildcard-imports" },
+    { name = "griffecli" },
+    { name = "mypy", marker = "implementation_name != 'pypy'" },
+    { name = "pip" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "rich" },
+    { name = "ruff" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
 docs = [
     { name = "griffe-public-wildcard-imports" },
     { name = "mkdocs" },
@@ -1540,6 +1569,17 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "griffe-public-wildcard-imports" },
+    { name = "mkdocs" },
+    { name = "mkdocs-include-markdown-plugin" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+    { name = "pygithub", marker = "sys_platform != 'win32'" },
+    { name = "pygments" },
+    { name = "towncrier" },
+    { name = "types-setuptools" },
+]
 docs = [
     { name = "griffe-public-wildcard-imports" },
     { name = "mkdocs" },
@@ -1563,6 +1603,17 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+dev = [
+    { name = "griffe-public-wildcard-imports" },
+    { name = "mkdocs" },
+    { name = "mkdocs-include-markdown-plugin" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29" },
+    { name = "pygithub", marker = "sys_platform != 'win32'", specifier = ">=2.0.0" },
+    { name = "pygments" },
+    { name = "towncrier", specifier = ">=23.11.0" },
+    { name = "types-setuptools" },
+]
 docs = [
     { name = "griffe-public-wildcard-imports" },
     { name = "mkdocs" },


### PR DESCRIPTION
## Summary

- **Pre-commit**: bump `ruff-pre-commit` (Ruff **0.15.7**), `mirrors-mypy`, `scientific-python/cookie`, `codespell`; add `ci` block (`autofix_commit_msg`, `autoupdate_schedule: monthly`).
- **Ruff**: `per-file-ignores` for setuptools_scm backward-compat re-export modules (`PLC0414`) and `_own_version_helper.py`; per-file ignores for intentional test/tooling patterns (bandit / blind `Exception`).
- **Code**: `subprocess.run(..., check=False)` where return codes are asserted; simplify `if` / return in `pyproject_reading` and `version_inference` for Ruff 0.15.
- **Workspace**: root `dependency-groups.dev` (repo-review PP006); `dev` group in setuptools-scm including `test`.
- **Lockfile**: `uv.lock` updated so `uv run ruff` matches the pre-commit Ruff version.

## Changelog

`setuptools-scm/changelog.d/1311.misc.md`

## Checklist

- [x] `pre-commit run --all-files` passes
