### PR TITLE
fix: enter GlobalOverrides for setuptools_scm.get_version (fixes #1314)

### DIFF
--- a/setuptools-scm/changelog.d/1314.bugfix.md
+++ b/setuptools-scm/changelog.d/1314.bugfix.md
@@ -1,0 +1,1 @@
+Enter ``GlobalOverrides`` for ``SETUPTOOLS_SCM`` when using ``setuptools_scm.get_version`` / ``_get_version``, avoiding implicit context warnings for direct API callers.

--- a/setuptools-scm/src/setuptools_scm/__init__.py
+++ b/setuptools-scm/src/setuptools_scm/__init__.py
@@ -12,8 +12,9 @@ from vcs_versioning import Version
 from vcs_versioning._config import DEFAULT_LOCAL_SCHEME
 from vcs_versioning._config import DEFAULT_VERSION_SCHEME
 from vcs_versioning._dump_version import dump_version  # soft deprecated
-from vcs_versioning._get_version_impl import _get_version
-from vcs_versioning._get_version_impl import get_version  # soft deprecated
+
+from ._get_version import _get_version
+from ._get_version import get_version  # soft deprecated
 
 # Public API
 __all__ = [

--- a/setuptools-scm/src/setuptools_scm/_get_version.py
+++ b/setuptools-scm/src/setuptools_scm/_get_version.py
@@ -1,0 +1,76 @@
+"""setuptools-scm wrappers for vcs_versioning get_version APIs.
+
+``get_version`` and ``_get_version`` enter :class:`~vcs_versioning.overrides.GlobalOverrides`
+for the ``SETUPTOOLS_SCM`` tool prefix so callers (e.g. ``setup.py`` / library code) do not
+trigger implicit context auto-creation warnings from vcs_versioning.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from re import Pattern
+from typing import Any
+
+from vcs_versioning import _config
+from vcs_versioning import _types as _t
+from vcs_versioning._config import Configuration
+from vcs_versioning._get_version_impl import _get_version as _get_version_core
+from vcs_versioning._get_version_impl import get_version as _get_version_public
+from vcs_versioning.overrides import ensure_context
+
+_setuptools_scm_logger = logging.getLogger("setuptools_scm")
+
+
+def _get_version(
+    config: Configuration, force_write_version_files: bool | None = None
+) -> str | None:
+    with ensure_context("SETUPTOOLS_SCM", additional_loggers=_setuptools_scm_logger):
+        return _get_version_core(
+            config, force_write_version_files=force_write_version_files
+        )
+
+
+def get_version(
+    root: _t.PathT = ".",
+    version_scheme: _t.VERSION_SCHEME = _config.DEFAULT_VERSION_SCHEME,
+    local_scheme: _t.VERSION_SCHEME = _config.DEFAULT_LOCAL_SCHEME,
+    write_to: _t.PathT | None = None,
+    write_to_template: str | None = None,
+    version_file: _t.PathT | None = None,
+    version_file_template: str | None = None,
+    relative_to: _t.PathT | None = None,
+    tag_regex: str | Pattern[str] = _config.DEFAULT_TAG_REGEX,
+    parentdir_prefix_version: str | None = None,
+    fallback_version: str | None = None,
+    fallback_root: _t.PathT = ".",
+    parse: Any | None = None,
+    git_describe_command: _t.CMD_TYPE | None = None,
+    dist_name: str | None = None,
+    version_cls: Any | None = None,
+    normalize: bool = True,
+    search_parent_directories: bool = False,
+    scm: dict[str, Any] | None = None,
+) -> str:
+    with ensure_context("SETUPTOOLS_SCM", additional_loggers=_setuptools_scm_logger):
+        return _get_version_public(
+            root=root,
+            version_scheme=version_scheme,
+            local_scheme=local_scheme,
+            write_to=write_to,
+            write_to_template=write_to_template,
+            version_file=version_file,
+            version_file_template=version_file_template,
+            relative_to=relative_to,
+            tag_regex=tag_regex,
+            parentdir_prefix_version=parentdir_prefix_version,
+            fallback_version=fallback_version,
+            fallback_root=fallback_root,
+            parse=parse,
+            git_describe_command=git_describe_command,
+            dist_name=dist_name,
+            version_cls=version_cls,
+            normalize=normalize,
+            search_parent_directories=search_parent_directories,
+            scm=scm,
+        )

--- a/setuptools-scm/testing_scm/test_integration.py
+++ b/setuptools-scm/testing_scm/test_integration.py
@@ -58,6 +58,39 @@ def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> WorkDir:
     return wd.setup_git(monkeypatch)
 
 
+@pytest.mark.issue("1314")
+def test_get_version_no_implicit_global_overrides_warning_subprocess(
+    wd: WorkDir,
+) -> None:
+    """setuptools_scm.get_version must not rely on implicit GlobalOverrides auto-create.
+
+    Pytest's vcs_versioning plugin installs a global ``GlobalOverrides`` context, so
+    this check runs in a subprocess without that fixture (see GitHub issue #1314).
+    """
+    root = os.fspath(wd.cwd)
+    script = textwrap.dedent(
+        f"""
+        import warnings
+
+        warnings.filterwarnings(
+            "error",
+            message="No GlobalOverrides context is active",
+            category=UserWarning,
+        )
+        import setuptools_scm
+
+        setuptools_scm.get_version(root={root!r})
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (proc.stdout, proc.stderr)
+
+
 def test_pyproject_support(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG")
     pkg = tmp_path / "package"


### PR DESCRIPTION
## Summary

Wrap `setuptools_scm.get_version` / `_get_version` with `ensure_context("SETUPTOOLS_SCM", ...)` so direct API callers (e.g. libraries calling `get_version` from `__init__.py`) do not hit vcs_versioning’s implicit `GlobalOverrides` auto-create path and the associated `UserWarning` (see #1314).

## Changes

- New `setuptools_scm/_get_version.py` delegating to vcs_versioning behind `ensure_context`, matching the setuptools integration hooks.
- Subprocess integration test: `warnings.filterwarnings("error", …)` for the implicit-context message, then `setuptools_scm.get_version` (subprocess avoids pytest’s global overrides fixture).
- Towncrier fragment `1314.bugfix.md`.

## Testing

`uv run pytest setuptools-scm/testing_scm -n12`