### PR TITLE
feat(vcs-versioning): fail-on-uncommitted-changes local scheme (fixes #1205)

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -141,8 +141,9 @@ representing the version.
 ### `setuptools_scm.local_scheme`
 
 Configures how the local part of a version is rendered given a
-[ScmVersion][vcs_versioning.ScmVersion] instance and should return a string
-representing the local version.
+[ScmVersion][vcs_versioning.ScmVersion] instance. A callable should return a string
+for the local segment, or you may pass a list of scheme names—each is tried in order
+until one returns a string (see `fail-on-uncommitted-changes` below).
 Dates and times are in Coordinated Universal Time (UTC), because as part
 of the version, they should be location independent.
 
@@ -159,3 +160,16 @@ of the version, they should be location independent.
 
 `no-local-version`
 : Omits local version, useful e.g. because PyPI does not support it
+
+`fail-on-uncommitted-changes`
+:   When the working tree is dirty (`ScmVersion.dirty` is true), raises
+    `DirtyWorkingTreeError`. When clean, returns no local segment so the **next** scheme in
+    a `local_scheme` list
+    runs—pair it with your usual local scheme (for example `node-and-date` or
+    `no-local-version`). This works with any `version_scheme`, so release CI can enforce a
+    clean tree without a separate implementation per version scheme.
+
+    **Example:** `local_scheme = ["fail-on-uncommitted-changes", "node-and-date"]`
+
+    See [Configuration Overrides](overrides.md#fail-on-uncommitted-changes-in-release-ci) for
+    enabling this via environment variables in CI without editing `pyproject.toml`.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -37,6 +37,11 @@
       show_root_heading: yes
       heading_level: 4
 
+::: vcs_versioning._version_schemes.DirtyWorkingTreeError
+    options:
+      show_root_heading: yes
+      heading_level: 4
+
 ## Version number construction
 
 ### `setuptools_scm.version_scheme`
@@ -143,7 +148,8 @@ representing the version.
 Configures how the local part of a version is rendered given a
 [ScmVersion][vcs_versioning.ScmVersion] instance. A callable should return a string
 for the local segment, or you may pass a list of scheme names—each is tried in order
-until one returns a string (see `fail-on-uncommitted-changes` below).
+until one returns a non-`None` value (an empty string still stops the chain; return
+`None` to defer to the next scheme—see `fail-on-uncommitted-changes` below).
 Dates and times are in Coordinated Universal Time (UTC), because as part
 of the version, they should be location independent.
 
@@ -163,8 +169,8 @@ of the version, they should be location independent.
 
 `fail-on-uncommitted-changes`
 :   When the working tree is dirty (`ScmVersion.dirty` is true), raises
-    `DirtyWorkingTreeError`. When clean, returns no local segment so the **next** scheme in
-    a `local_scheme` list
+    [`DirtyWorkingTreeError`][vcs_versioning._version_schemes.DirtyWorkingTreeError].
+    When clean, returns `None` so the **next** scheme in a `local_scheme` list
     runs—pair it with your usual local scheme (for example `node-and-date` or
     `no-local-version`). This works with any `version_scheme`, so release CI can enforce a
     clean tree without a separate implementation per version scheme.

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -150,6 +150,45 @@ Control timestamps for reproducible builds (from [reproducible-builds.org](https
     export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{"local_scheme": "no-local-version"}'
     ```
 
+#### Fail on uncommitted changes in release CI
+
+To stop a build when the working tree has uncommitted changes (the same `dirty` state
+setuptools-scm uses for local version segments), set `local_scheme` to a **list** whose
+first entry is `fail-on-uncommitted-changes` and whose second entry is your usual local
+scheme (match what you use in `pyproject.toml`, for example `node-and-date` or
+`no-local-version`). This keeps your chosen `version_scheme` unchanged.
+
+This takes precedence over `[tool.setuptools_scm]` / `[tool.vcs-versioning]` in
+`pyproject.toml` (see priority under [About Overrides](#about-overrides)).
+
+Use the distribution-specific variable so the override applies only to your package (the
+name is normalized the same way as for other `*_FOR_${DIST_NAME}` variables; see
+[integrations](integrations.md#publishing-to-pypi-from-cicd)):
+
+```bash
+export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = ["fail-on-uncommitted-changes", "node-and-date"]}'
+```
+
+With `no-local-version` for PyPI uploads:
+
+```bash
+export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = ["fail-on-uncommitted-changes", "no-local-version"]}'
+```
+
+If you use `[tool.vcs-versioning]` (and not setuptools-scm), set the same TOML value on
+`VCS_VERSIONING_OVERRIDES_FOR_${DIST_NAME}` instead, for example:
+
+```bash
+export VCS_VERSIONING_OVERRIDES_FOR_MYPACKAGE='{local_scheme = ["fail-on-uncommitted-changes", "node-and-date"]}'
+```
+
+**GitHub Actions:** set `env` on the job or step that builds release artifacts:
+
+```yaml
+env:
+  SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = ["fail-on-uncommitted-changes", "node-and-date"]}'
+```
+
 ### SCM Root Discovery
 
 `SETUPTOOLS_SCM_IGNORE_VCS_ROOTS`

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -147,7 +147,7 @@ Control timestamps for reproducible builds (from [reproducible-builds.org](https
     **Example:**
     ```bash
     # Override local_scheme for CI builds
-    export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{"local_scheme": "no-local-version"}'
+    export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = "no-local-version"}'
     ```
 
 #### Fail on uncommitted changes in release CI

--- a/vcs-versioning/changelog.d/1205.feature.md
+++ b/vcs-versioning/changelog.d/1205.feature.md
@@ -1,0 +1,1 @@
+Add ``fail-on-uncommitted-changes`` as a composable local scheme: raise when the working tree is dirty, otherwise defer to the next local scheme in the list so any ``version_scheme`` can be used.

--- a/vcs-versioning/pyproject.toml
+++ b/vcs-versioning/pyproject.toml
@@ -63,6 +63,7 @@ Source = "https://github.com/pypa/setuptools-scm"
 
 [project.entry-points."setuptools_scm.local_scheme"]
 dirty-tag = "vcs_versioning._version_schemes:get_local_dirty_tag"
+"fail-on-uncommitted-changes" = "vcs_versioning._version_schemes:get_local_fail_on_uncommitted_changes"
 no-local-version = "vcs_versioning._version_schemes:get_no_local_node"
 node-and-date = "vcs_versioning._version_schemes:get_local_node_and_date"
 node-and-timestamp = "vcs_versioning._version_schemes:get_local_node_and_timestamp"

--- a/vcs-versioning/src/vcs_versioning/_config.py
+++ b/vcs-versioning/src/vcs_versioning/_config.py
@@ -194,8 +194,8 @@ class Configuration:
 
     relative_to: _t.PathT | None = None
     root: _t.PathT = "."
-    version_scheme: _t.VERSION_SCHEME = DEFAULT_VERSION_SCHEME
-    local_scheme: _t.VERSION_SCHEME = DEFAULT_LOCAL_SCHEME
+    version_scheme: _t.VERSION_SCHEMES = DEFAULT_VERSION_SCHEME
+    local_scheme: _t.VERSION_SCHEMES = DEFAULT_LOCAL_SCHEME
     tag_regex: Pattern[str] = DEFAULT_TAG_REGEX
     parentdir_prefix_version: str | None = None
     fallback_version: str | None = None

--- a/vcs-versioning/src/vcs_versioning/_entrypoints.py
+++ b/vcs-versioning/src/vcs_versioning/_entrypoints.py
@@ -55,7 +55,7 @@ def _iter_version_schemes(
     entrypoint: str,
     scheme_value: _t.VERSION_SCHEMES,
     _memo: set[object] | None = None,
-) -> Iterator[Callable[[ScmVersion], str]]:
+) -> Iterator[Callable[[ScmVersion], str | None]]:
     if _memo is None:
         _memo = set()
     if isinstance(scheme_value, str):

--- a/vcs-versioning/src/vcs_versioning/_exceptions.py
+++ b/vcs-versioning/src/vcs_versioning/_exceptions.py
@@ -1,0 +1,5 @@
+"""Exceptions raised by vcs-versioning."""
+
+
+class DirtyWorkingTreeError(ValueError):
+    """Raised when the ``fail-on-uncommitted-changes`` local scheme sees a dirty tree."""

--- a/vcs-versioning/src/vcs_versioning/_types.py
+++ b/vcs-versioning/src/vcs_versioning/_types.py
@@ -20,8 +20,9 @@ __all__ = [
 
 CMD_TYPE: TypeAlias = Sequence[PathT] | str
 
-VERSION_SCHEME: TypeAlias = str | Callable[["ScmVersion"], str]
-VERSION_SCHEMES: TypeAlias = list[str] | tuple[str, ...] | VERSION_SCHEME
+VERSION_SCHEME_CALLABLE: TypeAlias = Callable[["ScmVersion"], str | None]
+VERSION_SCHEME: TypeAlias = str | VERSION_SCHEME_CALLABLE
+VERSION_SCHEMES: TypeAlias = Sequence[VERSION_SCHEME] | VERSION_SCHEME
 SCMVERSION: TypeAlias = "ScmVersion"
 
 # Git pre-parse function types

--- a/vcs-versioning/src/vcs_versioning/_version_schemes/__init__.py
+++ b/vcs-versioning/src/vcs_versioning/_version_schemes/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 
 from .. import _entrypoints
+from .._exceptions import DirtyWorkingTreeError
 from .._scm_version import ScmVersion, callable_or_entrypoint, meta, tag_to_version
 from ._common import (
     SEMVER_LEN,
@@ -20,6 +21,7 @@ from ._standard import (
     calver_by_date,
     date_ver_match,
     get_local_dirty_tag,
+    get_local_fail_on_uncommitted_changes,
     get_local_node_and_date,
     get_local_node_and_timestamp,
     get_no_local_node,
@@ -44,6 +46,7 @@ __all__ = [
     "SEMVER_MINOR",
     "SEMVER_PATCH",
     # Core types and utilities
+    "DirtyWorkingTreeError",
     "ScmVersion",
     "meta",
     "tag_to_version",
@@ -63,9 +66,10 @@ __all__ = [
     "guess_next_date_ver",
     "postrelease_version",
     # Local schemes
+    "get_local_dirty_tag",
+    "get_local_fail_on_uncommitted_changes",
     "get_local_node_and_date",
     "get_local_node_and_timestamp",
-    "get_local_dirty_tag",
     "get_no_local_node",
     # Towncrier
     "version_from_fragments",

--- a/vcs-versioning/src/vcs_versioning/_version_schemes/_standard.py
+++ b/vcs-versioning/src/vcs_versioning/_version_schemes/_standard.py
@@ -14,6 +14,7 @@ from re import Match
 from typing import TYPE_CHECKING
 
 from .. import _modify_version
+from .._exceptions import DirtyWorkingTreeError
 from .._scm_version import ScmVersion, _parse_version_tag
 from .._version_cls import Version as PkgVersion
 from ._common import SEMVER_LEN, SEMVER_MINOR, SEMVER_PATCH
@@ -242,6 +243,20 @@ def postrelease_version(version: ScmVersion) -> str:
 
 # Local Schemes
 # -------------
+
+
+def get_local_fail_on_uncommitted_changes(version: ScmVersion) -> str | None:
+    """Fail if dirty; otherwise return None so the next ``local_scheme`` runs.
+
+    Entry-point name: ``fail-on-uncommitted-changes``. Use as the first entry in a
+    ``local_scheme`` list before your usual scheme (for example
+    ``["fail-on-uncommitted-changes", "node-and-date"]``).
+    """
+    if version.dirty:
+        raise DirtyWorkingTreeError(
+            "Working tree has uncommitted changes (SCM reports dirty)."
+        )
+    return None
 
 
 def get_local_node_and_date(version: ScmVersion) -> str:

--- a/vcs-versioning/testing_vcs/test_version.py
+++ b/vcs-versioning/testing_vcs/test_version.py
@@ -248,7 +248,7 @@ def test_format_version_schemes() -> None:
         config=replace(
             c,
             local_scheme="no-local-version",
-            version_scheme=[  # type: ignore[arg-type]
+            version_scheme=[
                 lambda v: None,
                 "guess-next-dev",
             ],
@@ -632,7 +632,7 @@ def test_all_entrypoints_return_none() -> None:
         "1.0",
         config=replace(
             c,
-            version_scheme=lambda v: None,  # type: ignore[arg-type,return-value]
+            version_scheme=lambda v: None,
         ),
     )
     with pytest.raises(

--- a/vcs-versioning/testing_vcs/test_version_schemes.py
+++ b/vcs-versioning/testing_vcs/test_version_schemes.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import pytest
 from vcs_versioning import Configuration
+from vcs_versioning._exceptions import DirtyWorkingTreeError
 from vcs_versioning._run_cmd import has_command
 from vcs_versioning._scm_version import meta, tag_to_version
-from vcs_versioning._version_schemes import format_version, guess_next_version
+from vcs_versioning._version_schemes import (
+    format_version,
+    get_local_fail_on_uncommitted_changes,
+    guess_next_version,
+)
 
 c = Configuration()
 
@@ -181,6 +186,47 @@ def test_format_version_with_build_metadata(
 def test_tag_to_version(tag: str, expected_version: str) -> None:
     version = str(tag_to_version(tag, c))
     assert version == expected_version
+
+
+@pytest.mark.issue(1205)
+def test_get_local_fail_on_uncommitted_changes_direct() -> None:
+    with pytest.raises(DirtyWorkingTreeError):
+        get_local_fail_on_uncommitted_changes(VERSIONS["dirty"])
+    assert get_local_fail_on_uncommitted_changes(VERSIONS["exact"]) is None
+
+
+@pytest.mark.issue(1205)
+def test_fail_on_uncommitted_changes_raises_when_dirty() -> None:
+    from dataclasses import replace
+
+    scm_version = VERSIONS["dirty"]
+    configured_version = replace(
+        scm_version,
+        config=replace(
+            scm_version.config,
+            local_scheme=("fail-on-uncommitted-changes", "node-and-date"),
+        ),
+    )
+    with pytest.raises(DirtyWorkingTreeError) as excinfo:
+        format_version(configured_version)
+    assert str(excinfo.value) == (
+        "Working tree has uncommitted changes (SCM reports dirty)."
+    )
+
+
+@pytest.mark.issue(1205)
+def test_fail_on_uncommitted_changes_clean_delegates_to_next_local_scheme() -> None:
+    from dataclasses import replace
+
+    scm_version = VERSIONS["exact"]
+    configured_version = replace(
+        scm_version,
+        config=replace(
+            scm_version.config,
+            local_scheme=("fail-on-uncommitted-changes", "node-and-date"),
+        ),
+    )
+    assert format_version(configured_version) == "1.1"
 
 
 def test_has_command() -> None:


### PR DESCRIPTION
## Summary

Adds composable local scheme `fail-on-uncommitted-changes` (`get_local_fail_on_uncommitted_changes`): raises `DirtyWorkingTreeError` when the SCM reports a dirty tree; returns `None` when clean so the next `local_scheme` runs—works with any `version_scheme`.

## Docs

- `docs/extending.md`: document the scheme under local schemes
- `docs/overrides.md`: CI examples (setuptools-scm + pinpointed `VCS_VERSIONING_*` for `[tool.vcs-versioning]`)

## Changelog

Towncrier fragment: `vcs-versioning/changelog.d/1205.feature.md`

Fixes #1205

Made with [Cursor](https://cursor.com)