### PR TITLE
ci: run release and publish workflows only on primary repo

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -15,8 +15,9 @@ permissions:
 
 jobs:
   sync-main-to-develop:
-    # Only run when a release PR is merged to main
+    # Only run when a release PR is merged to main (primary repo only — no sync PRs on forks)
     if: |
+      github.repository == 'pypa/setuptools-scm' &&
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release-tags.yml
+++ b/.github/workflows/create-release-tags.yml
@@ -12,8 +12,9 @@ permissions:
 
 jobs:
   create-tags:
-    # Only run if PR was merged and has release labels
+    # Only run if PR was merged and has release labels (primary repo — tags/PyPI dispatch)
     if: |
+      github.repository == 'pypa/setuptools-scm' &&
       github.event.pull_request.merged == true &&
       (contains(github.event.pull_request.labels.*.name, 'release:setuptools-scm') ||
        contains(github.event.pull_request.labels.*.name, 'release:vcs-versioning'))

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -145,9 +145,10 @@ jobs:
   dist_upload_setuptools_scm:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/setuptools-scm-v')) ||
+      github.repository == 'pypa/setuptools-scm' &&
+      ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/setuptools-scm-v')) ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/setuptools-scm-v')) ||
-      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'setuptools-scm-v'))
+      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'setuptools-scm-v')))
     permissions:
       id-token: write
     needs: [test]
@@ -163,9 +164,10 @@ jobs:
   dist_upload_vcs_versioning:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vcs-versioning-v')) ||
+      github.repository == 'pypa/setuptools-scm' &&
+      ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vcs-versioning-v')) ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/vcs-versioning-v')) ||
-      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'vcs-versioning-v'))
+      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'vcs-versioning-v')))
     permissions:
       id-token: write
     needs: [test]
@@ -181,8 +183,9 @@ jobs:
   upload-release-assets-setuptools-scm:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'setuptools-scm-v')) ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/setuptools-scm-v'))
+      github.repository == 'pypa/setuptools-scm' &&
+      ((github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'setuptools-scm-v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/setuptools-scm-v')))
     needs: [test]
     permissions:
       contents: write
@@ -201,8 +204,9 @@ jobs:
   upload-release-assets-vcs-versioning:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'vcs-versioning-v')) ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/vcs-versioning-v'))
+      github.repository == 'pypa/setuptools-scm' &&
+      ((github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'vcs-versioning-v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/vcs-versioning-v')))
     needs: [test]
     permissions:
       contents: write
@@ -220,7 +224,10 @@ jobs:
 
   test-pypi-upload:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: |
+      github.repository == 'pypa/setuptools-scm' &&
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
     needs: [test]
     permissions:
       id-token: write

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   # Version determination + changelog build for each project (parallel)
-  # Forks: run on pull_request only (validation). Skip on fork push — no release branches/PRs there.
+  # Forks: run on pull_request only (validation). Intentionally skip fork pushes; do not act on fork release branches/PRs.
   setuptools-scm:
     if: github.repository == 'pypa/setuptools-scm' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-towncrier-release.yml

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -11,13 +11,16 @@ permissions: {}
 
 jobs:
   # Version determination + changelog build for each project (parallel)
+  # Forks: run on pull_request only (validation). Skip on fork push — no release branches/PRs there.
   setuptools-scm:
+    if: github.repository == 'pypa/setuptools-scm' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-towncrier-release.yml
     with:
       project_name: setuptools-scm
       project_directory: setuptools-scm
 
   vcs-versioning:
+    if: github.repository == 'pypa/setuptools-scm' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-towncrier-release.yml
     with:
       project_name: vcs-versioning
@@ -56,6 +59,7 @@ jobs:
   create-release-pr:
     needs: [setuptools-scm, vcs-versioning]
     if: |
+      github.repository == 'pypa/setuptools-scm' &&
       github.event_name == 'push' &&
       (needs.setuptools-scm.outputs.has_fragments == 'true' ||
        needs.vcs-versioning.outputs.has_fragments == 'true')


### PR DESCRIPTION
## Summary

Restrict release/sync/publish-related GitHub Actions jobs to `pypa/setuptools-scm` using `github.repository == 'pypa/setuptools-scm'` so forks do not:

- push release branches or open release PRs (`release-proposal.yml`)
- create main→develop sync PRs (`branch-sync.yml`)
- create tags/releases or dispatch PyPI workflows (`create-release-tags.yml`)
- publish to PyPI, Test PyPI, or attach release assets (`python-tests.yml`)

Towncrier reusable jobs still run on `pull_request` (including from forks) for validation; fork pushes to `main`/`develop` skip the towncrier work.

## Changelog

Skipped — internal CI change; label: `skip news`.

Made with [Cursor](https://cursor.com)