### PR TITLE
feat(git): skip shallow pre-parse when HEAD is on exact tag

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -121,9 +121,9 @@ Callables or other Python objects must be passed in `setup.py` (via the `use_scm
 :   A string specifying which git pre-parse function to use before parsing version information.
     Available options:
 
-    - `"warn_on_shallow"` (default): Warns when the repository is shallow
-    - `"fail_on_shallow"`: Fails with an error when the repository is shallow
-    - `"fetch_on_shallow"`: Automatically fetches to rectify shallow repositories
+    - `"warn_on_shallow"` (default): Warns when the repository is shallow (skipped when `HEAD` is exactly on a tag, where a shallow clone is sufficient)
+    - `"fail_on_shallow"`: Fails with an error when the repository is shallow (not when `HEAD` is exactly on a tag)
+    - `"fetch_on_shallow"`: Automatically fetches to rectify shallow repositories (skipped when `HEAD` is exactly on a tag)
     - `"fail_on_missing_submodules"`: Fails when submodules are defined but not initialized
 
         The `"fail_on_missing_submodules"` option is useful to prevent packaging incomplete

--- a/vcs-versioning/changelog.d/1241.feature.md
+++ b/vcs-versioning/changelog.d/1241.feature.md
@@ -1,0 +1,1 @@
+When ``HEAD`` is exactly on a tag (``git describe --exact-match``), shallow Git worktrees no longer trigger ``warn_on_shallow``, ``fail_on_shallow``, or ``fetch_on_shallow``—shallow clones are enough for tagged release builds and avoid unnecessary unshallow fetches.

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -178,6 +178,14 @@ class GitWorkdir(Workdir):
     def is_shallow(self) -> bool:
         return self.path.joinpath(".git/shallow").is_file()
 
+    def head_is_exact_tag(self) -> bool:
+        """True when HEAD points exactly at a tag (including lightweight tags)."""
+        res = run_git(
+            ["describe", "--exact-match", "--tags", "HEAD"],
+            self.path,
+        )
+        return res.returncode == 0
+
     def fetch_shallow(self) -> None:
         try:
             run_git(
@@ -206,13 +214,13 @@ class GitWorkdir(Workdir):
 
 def warn_on_shallow(wd: GitWorkdir) -> None:
     """experimental, may change at any time"""
-    if wd.is_shallow():
+    if wd.is_shallow() and not wd.head_is_exact_tag():
         warnings.warn(f'"{wd.path}" is shallow and may cause errors', stacklevel=2)
 
 
 def fetch_on_shallow(wd: GitWorkdir) -> None:
     """experimental, may change at any time"""
-    if wd.is_shallow():
+    if wd.is_shallow() and not wd.head_is_exact_tag():
         warnings.warn(
             f'"{wd.path}" was shallow, git fetch was used to rectify', stacklevel=2
         )
@@ -221,7 +229,7 @@ def fetch_on_shallow(wd: GitWorkdir) -> None:
 
 def fail_on_shallow(wd: GitWorkdir) -> None:
     """experimental, may change at any time"""
-    if wd.is_shallow():
+    if wd.is_shallow() and not wd.head_is_exact_tag():
         raise ValueError(
             f'{wd.path} is shallow, please correct with "git fetch --unshallow"'
         )

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -338,6 +338,47 @@ def test_git_parse_shallow_warns(
     assert "is shallow and may cause errors" in str(msg.message)
 
 
+@pytest.fixture
+def shallow_tagged_wd(wd: WorkDir, tmp_path: Path) -> Path:
+    wd.commit_testfile()
+    wd("git tag v0.1.0")
+    target = tmp_path / "wd_shallow_tag"
+    run(
+        [
+            "git",
+            "clone",
+            f"file://{wd.cwd}",
+            str(target),
+            "--depth=1",
+            "--branch",
+            "v0.1.0",
+        ],
+        tmp_path,
+        check=True,
+    )
+    return target
+
+
+@pytest.mark.issue(1241)
+def test_git_parse_shallow_exact_tag_no_warn(
+    shallow_tagged_wd: Path, recwarn: pytest.WarningsRecorder
+) -> None:
+    git.parse(shallow_tagged_wd, Configuration())
+    for w in recwarn:
+        assert "is shallow and may cause errors" not in str(w.message)
+
+
+@pytest.mark.issue(1241)
+def test_git_parse_shallow_exact_tag_fail_on_shallow_ok(
+    shallow_tagged_wd: Path,
+) -> None:
+    git.parse(
+        shallow_tagged_wd,
+        Configuration(),
+        pre_parse=git.fail_on_shallow,
+    )
+
+
 def test_git_parse_shallow_fail(shallow_wd: Path) -> None:
     with pytest.raises(ValueError, match="git fetch"):
         git.parse(str(shallow_wd), Configuration(), pre_parse=git.fail_on_shallow)


### PR DESCRIPTION
## Summary

Implements [issue #1241](https://github.com/pypa/setuptools-scm/issues/1241): when `HEAD` is exactly on a tag (`git describe --exact-match --tags`), shallow Git worktrees no longer trigger `warn_on_shallow`, `fail_on_shallow`, or `fetch_on_shallow`. Shallow clones are enough for tagged release builds and avoid unnecessary unshallow fetches.

## Changes

- Add `GitWorkdir.head_is_exact_tag()` using `git describe --exact-match --tags HEAD`.
- Apply the check to all three shallow pre-parse handlers.
- Tests for no-warn and `fail_on_shallow` on a shallow clone of a tag.
- Document `scm.git.pre_parse` behavior in `docs/config.md`.
- Towncrier fragment `1241.feature.md`.

Closes #1241

Made with [Cursor](https://cursor.com)