### PR TITLE
build: update trove classifiers and add Python 3.14 support

### DIFF
--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Version Control",
   "Topic :: System :: Software Distribution",

--- a/vcs-versioning/pyproject.toml
+++ b/vcs-versioning/pyproject.toml
@@ -23,13 +23,14 @@ authors = [
 ]
 requires-python = ">=3.10"
 classifiers = [
-  "Development Status :: 1 - Planning",
+  "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
   "version",


### PR DESCRIPTION
## Summary

- **vcs-versioning**: Update Development Status from `1 - Planning` to `4 - Beta`
- **Both packages**: Add `Programming Language :: Python :: 3.14` trove classifier

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI passes on all Python versions

Made with [Cursor](https://cursor.com)