### PR TITLE
fix: remove workspace source override from setuptools-scm member (fixes #1330)

### DIFF
--- a/setuptools-scm/changelog.d/1330.bugfix.md
+++ b/setuptools-scm/changelog.d/1330.bugfix.md
@@ -1,0 +1,1 @@
+Remove `[tool.uv.sources]` from `setuptools-scm/pyproject.toml` to fix sdist builds outside the workspace — the workspace root already declares the source mapping for development.

--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -8,8 +8,6 @@ requires = [
   'tomli>=1; python_version < "3.11"',
   'typing-extensions; python_version < "3.11"',
 ]
-[tool.uv.sources]
-vcs-versioning = { workspace = true }
 [project]
 name = "setuptools-scm"
 description = "the blessed package to manage your versions by scm tags"


### PR DESCRIPTION
## Summary

- Removes `[tool.uv.sources]` with `vcs-versioning = { workspace = true }` from `setuptools-scm/pyproject.toml`
- This section was baked into the sdist and caused uv to fail when building setuptools-scm outside the monorepo workspace (e.g. installing from PyPI)
- The workspace root `pyproject.toml` already declares the same source mapping, which is sufficient for development

## Context

Reported in #1330: when users install `setuptools-scm==10.0.4` via `uv sync`, the build fails with:

```
`vcs-versioning` references a workspace in `tool.uv.sources`
(e.g., `vcs-versioning = { workspace = true }`),
but is not a workspace member
```

The `[tool.uv.sources]` section in the member `pyproject.toml` gets included in the sdist. Outside the monorepo there is no workspace, so uv rejects it.

## Test plan

- [x] `uv sync --all-packages --all-groups` resolves correctly (workspace development still works)
- [x] `uv build setuptools-scm/ --sdist` produces an sdist without `[tool.uv.sources]`
- [x] All 505 tests pass (`uv run pytest -n12`)

Closes #1330

Made with [Cursor](https://cursor.com)