### PR TITLE
fix: filter MQ pseudo-tags and iterate all hg tags for version resolution

### DIFF
--- a/vcs-versioning/changelog.d/310.bugfix.md
+++ b/vcs-versioning/changelog.d/310.bugfix.md
@@ -1,0 +1,1 @@
+Filter Mercurial pseudo-tags (tip, qbase, qtip, qparent) and iterate all tags when resolving versions, fixing spurious "no version found" warnings from MQ extension tags.

--- a/vcs-versioning/src/vcs_versioning/_backends/_hg.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_hg.py
@@ -18,6 +18,8 @@ from ._scm_workdir import Workdir, get_latest_file_mtime
 
 log = logging.getLogger(__name__)
 
+_HG_PSEUDO_TAGS = frozenset({"tip", "qbase", "qtip", "qparent"})
+
 
 def _get_hg_command() -> str:
     """Get the hg command from override context or environment."""
@@ -75,7 +77,7 @@ class HgWorkdir(Workdir):
         """Get node, tags, and date information from mercurial log."""
         try:
             node, tags_str, node_date_str = self.hg_log(
-                ".", "{node}\n{tag}\n{date|shortdate}"
+                ".", "{node}\n{tags}\n{date|shortdate}"
             ).split("\n")
             return node, tags_str, node_date_str
         except ValueError:
@@ -123,20 +125,25 @@ class HgWorkdir(Workdir):
         )
 
     def _parse_tags(self, tags_str: str) -> list[str]:
-        """Parse and filter tags from mercurial output."""
-        tags = tags_str.split()
-        if "tip" in tags:
-            # tip is not a real tag
-            tags.remove("tip")
-        return tags
+        """Parse and filter tags from mercurial output.
+
+        Filters out pseudo-tags that are never version tags:
+        tip (hg internal), qbase/qtip/qparent (MQ extension).
+        """
+        return [t for t in tags_str.split() if t not in _HG_PSEUDO_TAGS]
 
     def _get_version_from_tags(
         self, tags: list[str], config: Configuration
     ) -> Version | None:
-        """Try to get a version from the current tags."""
-        if tags:
-            tag = tag_to_version(tags[0], config)
-            return tag
+        """Try to get a version from the current tags.
+
+        Iterates all tags and returns the first that parses as a version,
+        so non-version tags (e.g. from MQ or user conventions) are skipped.
+        """
+        for tag_str in tags:
+            version = tag_to_version(tag_str, config)
+            if version is not None:
+                return version
         return None
 
     def _get_distance_based_version(

--- a/vcs-versioning/src/vcs_versioning/_backends/_hg.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_hg.py
@@ -137,10 +137,13 @@ class HgWorkdir(Workdir):
     ) -> Version | None:
         """Try to get a version from the current tags.
 
-        Iterates all tags and returns the first that parses as a version,
-        so non-version tags (e.g. from MQ or user conventions) are skipped.
+        Pre-filters with tag_regex so non-version tags are silently skipped
+        without emitting warnings from tag_to_version().
         """
         for tag_str in tags:
+            if not config.tag_regex.match(tag_str):
+                log.debug("skipping non-version tag %r", tag_str)
+                continue
             version = tag_to_version(tag_str, config)
             if version is not None:
                 return version

--- a/vcs-versioning/testing_vcs/test_mercurial.py
+++ b/vcs-versioning/testing_vcs/test_mercurial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 
 import pytest
 import vcs_versioning._file_finders  # noqa: F401
@@ -248,4 +249,11 @@ def test_non_version_tag_does_not_shadow_version(wd: WorkDir) -> None:
     """Non-version tags (like MQ pseudo-tags) should not prevent version detection."""
     wd('hg tag qbase -u test -d "0 0" -r 1.0.0')
     wd("hg up 1.0.0")
-    assert wd.get_version() == "1.0.0"
+
+    tags_output = wd('hg log -r 1.0.0 -T "{tags}\\n"')
+    assert "qbase" in tags_output and "1.0.0" in tags_output
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert wd.get_version() == "1.0.0"
+    assert not caught, f"unexpected warnings: {caught}"

--- a/vcs-versioning/testing_vcs/test_mercurial.py
+++ b/vcs-versioning/testing_vcs/test_mercurial.py
@@ -240,3 +240,12 @@ def test_feature_branch_increments_major(wd: WorkDir) -> None:
     assert wd.get_version(version_scheme="semver-pep440").startswith("1.0.1")
     wd("hg branch feature/fun")
     assert wd.get_version(version_scheme="semver-pep440").startswith("1.1.0")
+
+
+@pytest.mark.issue(310)
+@pytest.mark.usefixtures("version_1_0")
+def test_non_version_tag_does_not_shadow_version(wd: WorkDir) -> None:
+    """Non-version tags (like MQ pseudo-tags) should not prevent version detection."""
+    wd('hg tag qbase -u test -d "0 0" -r 1.0.0')
+    wd("hg up 1.0.0")
+    assert wd.get_version() == "1.0.0"


### PR DESCRIPTION
## Summary

Fixes #310 — Mercurial Queues (MQ) pseudo-tags (`qbase`, `qtip`, `qparent`) caused spurious `UserWarning: tag 'qbase' no version found` warnings during version resolution.

- Filter MQ pseudo-tags alongside `tip` in `_parse_tags()` using a `frozenset` lookup
- Iterate all tags in `_get_version_from_tags()` instead of only trying the first one, so non-version tags don't shadow version tags
- Switch `{tag}` to `{tags}` in `hg log` template (canonical Mercurial keyword since 4.x)
- Add integration test that places a non-version tag on a version-tagged revision

## Details

The Mercurial backend had two issues in the tag resolution path:

1. `_parse_tags()` only filtered `tip` but not MQ pseudo-tags (`qbase`, `qtip`, `qparent`), which are injected by the MQ extension into `{tags}` output.

2. `_get_version_from_tags()` only tried `tags[0]`. If any non-version tag appeared first in the list, the version tag was skipped entirely and the code fell through to the slower distance-based path, emitting a spurious warning along the way.

Both are fixed. As a minor modernization, the template keyword is also updated from `{tag}` (undocumented/namespace-auto-registered) to `{tags}` (the canonical registered keyword in modern Mercurial).

## Test plan

- [x] Pre-commit checks pass (ruff, mypy, codespell)
- [x] Full test suite passes (505 passed, 0 failed)
- [ ] CI hg tests exercise the new integration test (`test_non_version_tag_does_not_shadow_version`)

Made with [Cursor](https://cursor.com)