### PR TITLE
fix: add MANIFEST.in to vcs-versioning for correct sdist content

### DIFF
--- a/vcs-versioning/MANIFEST.in
+++ b/vcs-versioning/MANIFEST.in
@@ -1,0 +1,13 @@
+exclude *.nix
+exclude .pre-commit-config.yaml
+exclude changelog.d/*
+exclude .git_archival.txt
+exclude .readthedocs.yaml
+include *.py
+include testing_vcs/*.py
+include *.toml
+include LICENSE.txt
+include README.md
+include CHANGELOG.md
+
+prune .cursor

--- a/vcs-versioning/changelog.d/1336.bugfix.md
+++ b/vcs-versioning/changelog.d/1336.bugfix.md
@@ -1,0 +1,1 @@
+Add MANIFEST.in to ensure sdist includes testing_vcs/ when the VCS file finder is unavailable.


### PR DESCRIPTION
## Summary

- Adds `vcs-versioning/MANIFEST.in` to explicitly include `testing_vcs/` and other essential files in the sdist
- vcs-versioning builds with plain setuptools (not setuptools-scm) to avoid the bootstrap cycle (#1302), so no file finder is registered during its build — without a MANIFEST.in, setuptools only includes packages under `src/`, omitting `testing_vcs/` entirely
- Adds changelog fragment for #1336

## Test plan

- [x] Built vcs-versioning sdist and verified `testing_vcs/` (18 files) is included
- [x] Built setuptools-scm sdist and verified `testing_scm/` is still included
- [x] Pre-commit hooks pass

Fixes #1336

Made with [Cursor](https://cursor.com)