### PR TITLE
fix: remove _warn_on_old_setuptools() that warns incorrectly with custom build-backends

### DIFF
--- a/setuptools-scm/changelog.d/1192.bugfix.md
+++ b/setuptools-scm/changelog.d/1192.bugfix.md
@@ -1,0 +1,1 @@
+Remove the `_warn_on_old_setuptools()` check that incorrectly warned when a custom build-backend caused `setuptools.__version__` to return the project version instead of setuptools' version. The minimum setuptools version is now enforced via build-system requirements.

--- a/setuptools-scm/src/setuptools_scm/_integration/setuptools.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/setuptools.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 
 from collections.abc import Callable
 from typing import Any
@@ -59,28 +58,6 @@ def _register_build_py_command(dist: setuptools.Distribution) -> None:
 
     dist.cmdclass["build_py"] = wrapped
     log.debug("Wrapped project build_py with setuptools_scm version-file mixin")
-
-
-def _warn_on_old_setuptools(_version: str = setuptools.__version__) -> None:
-    if int(_version.split(".")[0]) < 61:
-        warnings.warn(
-            RuntimeWarning(
-                f"""
-ERROR: setuptools=={_version} is used in combination with setuptools-scm>=8.x
-
-Your build configuration is incomplete and previously worked by accident!
-setuptools-scm requires setuptools>=61 (recommended: >=80)
-
-Suggested workaround if applicable:
- - migrating from the deprecated setup_requires mechanism to pep517/518
-   and using a pyproject.toml to declare build dependencies
-   which are reliably pre-installed before running the build tools
-"""
-            )
-        )
-
-
-_warn_on_old_setuptools()
 
 
 def _log_hookstart(hook: str, dist: setuptools.Distribution) -> None:

--- a/setuptools-scm/testing_scm/test_integration.py
+++ b/setuptools-scm/testing_scm/test_integration.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     import setuptools
 
 from setuptools_scm import Configuration
-from setuptools_scm._integration.setuptools import _warn_on_old_setuptools
 from vcs_versioning._overrides import PRETEND_KEY
 from vcs_versioning._overrides import PRETEND_KEY_NAMED
 from vcs_versioning._run_cmd import run
@@ -451,12 +450,6 @@ def test_git_tag_with_local_build_data_preserved_with_distance(wd: WorkDir) -> N
 
     # Note: This test verifies that local build data from tags is preserved and combined
     # with SCM data when there's distance, which is the desired behavior for issue 1019.
-
-
-def testwarn_on_broken_setuptools() -> None:
-    _warn_on_old_setuptools("61")
-    with pytest.warns(RuntimeWarning, match="ERROR: setuptools==60"):
-        _warn_on_old_setuptools("60")
 
 
 @pytest.mark.issue(611)


### PR DESCRIPTION
## Summary

- Remove `_warn_on_old_setuptools()` which checked `setuptools.__version__` at import time and emitted a `RuntimeWarning` when the major version was < 61
- With custom build-backends (e.g. qtile's), `setuptools.__version__` can return the **project** version rather than setuptools' actual version, causing a spurious warning
- The minimum setuptools version is already enforced via build-system requires (`setuptools>=77.0.3`), making this runtime check redundant

Fixes #1192

## Test plan

- [x] Existing integration tests pass (`uv run pytest setuptools-scm/testing_scm/test_integration.py -n12` — 49 passed)
- [x] Pre-commit hooks pass (ruff, mypy, codespell, etc.)
- [x] Removed the now-unnecessary `testwarn_on_broken_setuptools` test


Made with [Cursor](https://cursor.com)