### PR TITLE
fix: dirty-workdir improvements for #1238 / #468

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -167,6 +167,14 @@ of the version, they should be location independent.
 `no-local-version`
 : Omits local version, useful e.g. because PyPI does not support it
 
+`no-local-version-strict`
+: Like `no-local-version` but raises
+  [`DirtyWorkingTreeError`][vcs_versioning._version_schemes.DirtyWorkingTreeError]
+  when the working tree is dirty. Equivalent to
+  `["fail-on-uncommitted-changes", "no-local-version"]` as a single scheme name.
+  Recommended for release CI where you want PyPI-compatible versions **and** an
+  explicit build failure on uncommitted changes.
+
 `fail-on-uncommitted-changes`
 :   When the working tree is dirty (`ScmVersion.dirty` is true), raises
     [`DirtyWorkingTreeError`][vcs_versioning._version_schemes.DirtyWorkingTreeError].

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -55,7 +55,7 @@ This configuration uses the `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}` environm
 
 When publishing packages to PyPI or test-PyPI from CI/CD pipelines, you often need to remove local version components that are not allowed on public package indexes according to [PEP 440](https://peps.python.org/pep-0440/#local-version-identifiers).
 
-setuptools-scm provides the `no-local-version` local scheme and environment variable overrides to handle this scenario cleanly.
+setuptools-scm provides local scheme overrides to handle this scenario cleanly.
 
 #### The Problem
 
@@ -68,15 +68,19 @@ These local version components (`+g1a2b3c4d5`, `+dirty`) prevent uploading to Py
 
 #### The Solution
 
-Use the `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}` environment variable to override the `local_scheme` to `no-local-version` when building for upload to PyPI.
+Use the `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}` environment variable to override the `local_scheme` when building for upload to PyPI.
+
+For **release builds** use `no-local-version-strict` — it strips the local segment like `no-local-version` but additionally **fails the build** when the working tree is dirty, catching accidental pollution early.
+
+For **development uploads** (test-PyPI, nightly) where the tree may be dirty, use `no-local-version` instead.
 
 ### GitHub Actions Example
 
 Here's a complete GitHub Actions workflow that:
 
 - Runs tests on all branches
-- Uploads development versions to test-PyPI from feature branches
-- Uploads development versions to PyPI from the main branch (with no-local-version)
+- Uploads development versions to test-PyPI from feature branches (with `no-local-version`)
+- Uploads development versions to PyPI from the main branch (with `no-local-version-strict`)
 - Uploads tagged releases to PyPI (using exact tag versions)
 
 ```yaml title=".github/workflows/ci.yml"
@@ -156,7 +160,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     env:
       # Replace MYPACKAGE with your actual package name (normalized)
-      SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = "no-local-version"}'
+      # "strict" fails the build on dirty trees — catches accidental pollution
+      SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = "no-local-version-strict"}'
 
     steps:
     - uses: actions/checkout@v4
@@ -185,6 +190,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    env:
+      # Fail on dirty trees for release builds
+      SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = "no-local-version-strict"}'
 
     steps:
     - uses: actions/checkout@v4
@@ -263,7 +271,8 @@ publish-pypi:
     TWINE_USERNAME: __token__
     TWINE_PASSWORD: $PYPI_API_TOKEN
     # Replace MYPACKAGE with your actual package name (normalized)
-    SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = "no-local-version"}'
+    # "strict" fails the build on dirty trees — catches accidental pollution
+    SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = "no-local-version-strict"}'
   script:
     - pip install build twine
     - python -m build
@@ -277,6 +286,8 @@ publish-release:
   variables:
     TWINE_USERNAME: __token__
     TWINE_PASSWORD: $PYPI_API_TOKEN
+    # Fail on dirty trees for release builds
+    SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = "no-local-version-strict"}'
   script:
     - pip install build twine
     - python -m build
@@ -299,7 +310,7 @@ The environment variable `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}` must be set
 
 2. **Value** must be a valid TOML inline table format:
    ```bash
-   SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = "no-local-version"}'
+   SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = "no-local-version-strict"}'
    ```
 
 #### Alternative Approaches
@@ -310,23 +321,31 @@ Instead of environment variables, you can configure this in your `pyproject.toml
 
 ```toml title="pyproject.toml"
 [tool.setuptools_scm]
-# Use no-local-version by default for CI builds
-local_scheme = "no-local-version"
+# Fail on dirty trees and strip local version — recommended for release CI
+local_scheme = "no-local-version-strict"
 ```
 
 However, the environment variable approach is preferred for CI/CD as it allows different schemes for local development vs. CI builds.
 
+#### Choosing a local scheme for CI
+
+| Scheme | Dirty tree | Local segment | Use case |
+|--------|-----------|---------------|----------|
+| `no-local-version` | Silently allowed | Stripped | Dev/nightly uploads where dirty is acceptable |
+| `no-local-version-strict` | **Build fails** | Stripped | Release CI — catches accidental pollution |
+| `["fail-on-uncommitted-changes", "node-and-date"]` | **Build fails** | Kept (node + date) | When you want dirty protection with full local info |
+
 #### Version Examples
 
-**Development versions from main branch** (with `local_scheme = "no-local-version"`):
+**Development versions** (with `local_scheme = "no-local-version"`):
 
 - Development commit: `1.2.3.dev4+g1a2b3c4d5` → `1.2.3.dev4` ✅ (uploadable to PyPI)
 - Dirty working directory: `1.2.3+dirty` → `1.2.3` ✅ (uploadable to PyPI)
 
-**Tagged releases** (without overrides, using default local scheme):
+**Release versions** (with `local_scheme = "no-local-version-strict"`):
 
 - Tagged commit: `1.2.3` → `1.2.3` ✅ (uploadable to PyPI)
-- Tagged release on dirty workdir: `1.2.3+dirty` → `1.2.3+dirty` ❌ (should not happen in CI)
+- Tagged release on dirty workdir → **build fails** with `DirtyWorkingTreeError` ✅ (caught early)
 
 ### Security Notes
 

--- a/docs/integrators.md
+++ b/docs/integrators.md
@@ -442,7 +442,7 @@ with GlobalOverrides.from_env("MY_TOOL"):
 | Pretend Version (generic) | `{TOOL}_PRETEND_VERSION`<br>`VCS_VERSIONING_PRETEND_VERSION` | `HATCH_VCS_PRETEND_VERSION=1.0.0` |
 | Pretend Metadata (specific) | `{TOOL}_PRETEND_METADATA_FOR_{DIST}`<br>`VCS_VERSIONING_PRETEND_METADATA_FOR_{DIST}` | `HATCH_VCS_PRETEND_METADATA_FOR_MY_PKG='{node="g123", distance=4}'` |
 | Pretend Metadata (generic) | `{TOOL}_PRETEND_METADATA`<br>`VCS_VERSIONING_PRETEND_METADATA` | `HATCH_VCS_PRETEND_METADATA='{dirty=true}'` |
-| Config Overrides (specific) | `{TOOL}_OVERRIDES_FOR_{DIST}`<br>`VCS_VERSIONING_OVERRIDES_FOR_{DIST}` | `HATCH_VCS_OVERRIDES_FOR_MY_PKG='{"local_scheme": "no-local-version"}'` |
+| Config Overrides (specific) | `{TOOL}_OVERRIDES_FOR_{DIST}`<br>`VCS_VERSIONING_OVERRIDES_FOR_{DIST}` | `HATCH_VCS_OVERRIDES_FOR_MY_PKG='{local_scheme = "no-local-version"}'` |
 
 ## Complete Integration Example
 

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -147,46 +147,48 @@ Control timestamps for reproducible builds (from [reproducible-builds.org](https
     **Example:**
     ```bash
     # Override local_scheme for CI builds
-    export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = "no-local-version"}'
+    export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = "no-local-version-strict"}'
     ```
 
 #### Fail on uncommitted changes in release CI
 
-To stop a build when the working tree has uncommitted changes (the same `dirty` state
-setuptools-scm uses for local version segments), set `local_scheme` to a **list** whose
-first entry is `fail-on-uncommitted-changes` and whose second entry is your usual local
-scheme (match what you use in `pyproject.toml`, for example `node-and-date` or
-`no-local-version`). This keeps your chosen `version_scheme` unchanged.
+The simplest way to enforce a clean tree **and** strip local segments for PyPI uploads
+is `no-local-version-strict`:
 
-This takes precedence over `[tool.setuptools_scm]` / `[tool.vcs-versioning]` in
-`pyproject.toml` (see priority under [About Overrides](#about-overrides)).
+```bash
+export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = "no-local-version-strict"}'
+```
 
-Use the distribution-specific variable so the override applies only to your package (the
-name is normalized the same way as for other `*_FOR_${DIST_NAME}` variables; see
-[integrations](integrations.md#publishing-to-pypi-from-cicd)):
+This fails the build when the working tree is dirty and otherwise produces a version
+without a local segment — exactly what release CI needs.
+
+If you need a different fallback local scheme (e.g. `node-and-date` instead of
+stripping the local part), use a **list** whose first entry is
+`fail-on-uncommitted-changes` and whose second entry is your usual scheme:
 
 ```bash
 export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = ["fail-on-uncommitted-changes", "node-and-date"]}'
 ```
 
-With `no-local-version` for PyPI uploads:
+These overrides take precedence over `[tool.setuptools_scm]` / `[tool.vcs-versioning]`
+in `pyproject.toml` (see priority under [About Overrides](#about-overrides)).
 
-```bash
-export SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE='{local_scheme = ["fail-on-uncommitted-changes", "no-local-version"]}'
-```
+Use the distribution-specific variable so the override applies only to your package (the
+name is normalized the same way as for other `*_FOR_${DIST_NAME}` variables; see
+[integrations](integrations.md#publishing-to-pypi-from-cicd)).
 
 If you use `[tool.vcs-versioning]` (and not setuptools-scm), set the same TOML value on
 `VCS_VERSIONING_OVERRIDES_FOR_${DIST_NAME}` instead, for example:
 
 ```bash
-export VCS_VERSIONING_OVERRIDES_FOR_MYPACKAGE='{local_scheme = ["fail-on-uncommitted-changes", "node-and-date"]}'
+export VCS_VERSIONING_OVERRIDES_FOR_MYPACKAGE='{local_scheme = "no-local-version-strict"}'
 ```
 
 **GitHub Actions:** set `env` on the job or step that builds release artifacts:
 
 ```yaml
 env:
-  SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = ["fail-on-uncommitted-changes", "node-and-date"]}'
+  SETUPTOOLS_SCM_OVERRIDES_FOR_MYPACKAGE: '{local_scheme = "no-local-version-strict"}'
 ```
 
 ### SCM Root Discovery

--- a/vcs-versioning/pyproject.toml
+++ b/vcs-versioning/pyproject.toml
@@ -71,6 +71,7 @@ Source = "https://github.com/pypa/setuptools-scm"
 dirty-tag = "vcs_versioning._version_schemes:get_local_dirty_tag"
 "fail-on-uncommitted-changes" = "vcs_versioning._version_schemes:get_local_fail_on_uncommitted_changes"
 no-local-version = "vcs_versioning._version_schemes:get_no_local_node"
+no-local-version-strict = "vcs_versioning._version_schemes:get_no_local_node_strict"
 node-and-date = "vcs_versioning._version_schemes:get_local_node_and_date"
 node-and-timestamp = "vcs_versioning._version_schemes:get_local_node_and_timestamp"
 

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -110,6 +110,12 @@ class GitWorkdir(Workdir):
             default=False,
         )
 
+    def is_file_tracked(self, path: Path) -> bool:
+        return (
+            run_git(["ls-files", "--error-unmatch", str(path)], self.path).returncode
+            == 0
+        )
+
     def get_branch(self) -> str | None:
         return run_git(
             ["rev-parse", "--abbrev-ref", "HEAD"],

--- a/vcs-versioning/src/vcs_versioning/_backends/_hg.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_hg.py
@@ -42,6 +42,9 @@ class HgWorkdir(Workdir):
             return None
         return cls(Path(res.stdout))
 
+    def is_file_tracked(self, path: Path) -> bool:
+        return run_hg(["files", str(path)], cwd=self.path).returncode == 0
+
     def get_meta(self, config: Configuration) -> ScmVersion | None:
         # TODO: support bookmarks and topics (but nowadays bookmarks are
         # mainly used to emulate Git branches, which is already supported with

--- a/vcs-versioning/src/vcs_versioning/_backends/_scm_workdir.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_scm_workdir.py
@@ -49,3 +49,7 @@ class Workdir:
 
     def run_describe(self, config: Configuration) -> ScmVersion:
         raise NotImplementedError(self.run_describe)
+
+    def is_file_tracked(self, path: Path) -> bool:
+        """Return True if *path* is tracked by version control."""
+        raise NotImplementedError(self.is_file_tracked)

--- a/vcs-versioning/src/vcs_versioning/_get_version_impl.py
+++ b/vcs-versioning/src/vcs_versioning/_get_version_impl.py
@@ -93,7 +93,7 @@ def _warn_if_tracked(target: Path, root: Path) -> None:
                 f"version file {target.relative_to(root)} is tracked by"
                 " version control. This will cause dirty-state version bumps"
                 " when the file is rewritten during builds."
-                " Remove it from version control and add it to .gitignore."
+                " Remove it from version control and add it to your VCS ignore file."
                 " See https://github.com/pypa/setuptools-scm/issues/468",
                 stacklevel=3,
             )

--- a/vcs-versioning/src/vcs_versioning/_get_version_impl.py
+++ b/vcs-versioning/src/vcs_versioning/_get_version_impl.py
@@ -74,11 +74,42 @@ def parse_version(config: Configuration) -> ScmVersion | None:
     return _apply_metadata_overrides(scm_version, config)
 
 
+def _warn_if_tracked(target: Path, root: Path) -> None:
+    """Warn when *target* is tracked in version control (#468).
+
+    Writing a version file that is tracked makes ``git describe --dirty``
+    report a dirty tree on tag checkouts, causing wrong version numbers.
+    """
+    from ._backends._git import GitWorkdir
+    from ._backends._hg import HgWorkdir
+
+    for workdir_cls in (GitWorkdir, HgWorkdir):
+        try:
+            wd = workdir_cls.from_potential_worktree(root)
+        except Exception:
+            continue
+        if wd is not None and wd.is_file_tracked(target):
+            warnings.warn(
+                f"version file {target.relative_to(root)} is tracked by"
+                " version control. This will cause dirty-state version bumps"
+                " when the file is rewritten during builds."
+                " Remove it from version control and add it to .gitignore."
+                " See https://github.com/pypa/setuptools-scm/issues/468",
+                stacklevel=3,
+            )
+            return
+
+
 def write_version_files(
     config: Configuration, version: str, scm_version: ScmVersion
 ) -> None:
+    root = Path(config.absolute_root)
     if config.write_to is not None:
         from ._dump_version import dump_version
+
+        write_to = Path(config.write_to)
+        target = root / write_to if not write_to.is_absolute() else write_to
+        _warn_if_tracked(target, root)
 
         dump_version(
             root=config.root,
@@ -95,6 +126,8 @@ def write_version_files(
         # todo: use a better name than fallback root
         assert config.relative_to is not None
         target = Path(config.relative_to).parent.joinpath(version_file)
+        _warn_if_tracked(target, root)
+
         write_version_to_path(
             target,
             template=config.version_file_template,

--- a/vcs-versioning/src/vcs_versioning/_version_schemes/__init__.py
+++ b/vcs-versioning/src/vcs_versioning/_version_schemes/__init__.py
@@ -25,6 +25,7 @@ from ._standard import (
     get_local_node_and_date,
     get_local_node_and_timestamp,
     get_no_local_node,
+    get_no_local_node_strict,
     guess_next_date_ver,
     guess_next_dev_version,
     guess_next_simple_semver,
@@ -71,6 +72,7 @@ __all__ = [
     "get_local_node_and_date",
     "get_local_node_and_timestamp",
     "get_no_local_node",
+    "get_no_local_node_strict",
     # Towncrier
     "version_from_fragments",
     # Utilities

--- a/vcs-versioning/src/vcs_versioning/_version_schemes/_standard.py
+++ b/vcs-versioning/src/vcs_versioning/_version_schemes/_standard.py
@@ -273,3 +273,16 @@ def get_local_dirty_tag(version: ScmVersion) -> str:
 
 def get_no_local_node(version: ScmVersion) -> str:
     return ""
+
+
+def get_no_local_node_strict(version: ScmVersion) -> str:
+    """Strip local version, but fail when the working tree is dirty.
+
+    Equivalent to ``["fail-on-uncommitted-changes", "no-local-version"]``
+    as a single entry-point name: ``no-local-version-strict``.
+    """
+    if version.dirty:
+        raise DirtyWorkingTreeError(
+            "Working tree has uncommitted changes (SCM reports dirty)."
+        )
+    return ""

--- a/vcs-versioning/src/vcs_versioning/overrides.py
+++ b/vcs-versioning/src/vcs_versioning/overrides.py
@@ -225,7 +225,7 @@ class EnvReader:
             >>> class MySchema(TypedDict, total=False):
             ...     local_scheme: str
             >>> reader = EnvReader(tools_names=("TOOL",), env={
-            ...     "TOOL_OVERRIDES": '{"local_scheme": "no-local-version"}',
+            ...     "TOOL_OVERRIDES": '{local_scheme = "no-local-version"}',
             ... })
             >>> result: MySchema = reader.read_toml("OVERRIDES", schema=MySchema)
             >>> result["local_scheme"]

--- a/vcs-versioning/testing_vcs/test_regressions.py
+++ b/vcs-versioning/testing_vcs/test_regressions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
@@ -87,6 +88,54 @@ def test_write_to_absolute_path_passes_when_subdir_of_root(tmp_path: Path) -> No
         match=r".*VERSION.py' .* .*subdir.*",
     ):
         write_version_files(replace(c, root=subdir), "1.0", v)
+
+
+@pytest.mark.issue(468)
+@pytest.mark.parametrize("scm", ["git", "hg"])
+def test_warn_when_version_file_tracked(tmp_path: Path, scm: str) -> None:
+    """Writing a version file that is tracked should emit a warning."""
+    wd = WorkDir(tmp_path)
+    if scm == "git":
+        wd.setup_git()
+    else:
+        wd.setup_hg()
+    version_file = tmp_path / "_version.py"
+    version_file.write_text("__version__ = '0.0.0'\n")
+    wd.add_and_commit("add tracked version file")
+
+    c = Configuration(root=tmp_path, write_to="_version.py")
+    v = meta("1.0", config=c)
+
+    from vcs_versioning._get_version_impl import write_version_files
+
+    with pytest.warns(UserWarning, match="tracked by version control"):
+        write_version_files(c, "1.0", v)
+
+
+@pytest.mark.issue(468)
+@pytest.mark.parametrize("scm", ["git", "hg"])
+def test_no_warn_when_version_file_not_tracked(tmp_path: Path, scm: str) -> None:
+    """An untracked version file should not trigger the warning."""
+    wd = WorkDir(tmp_path)
+    if scm == "git":
+        wd.setup_git()
+    else:
+        wd.setup_hg()
+    wd.write("dummy.txt", "hello")
+    wd.add_and_commit("initial commit")
+
+    c = Configuration(root=tmp_path, write_to="_version.py")
+    v = meta("1.0", config=c)
+
+    from vcs_versioning._get_version_impl import write_version_files
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        write_version_files(c, "1.0", v)
+    tracked_warnings = [
+        w for w in caught if "tracked by version control" in str(w.message)
+    ]
+    assert tracked_warnings == []
 
 
 @pytest.mark.parametrize(

--- a/vcs-versioning/testing_vcs/test_version_schemes.py
+++ b/vcs-versioning/testing_vcs/test_version_schemes.py
@@ -229,6 +229,53 @@ def test_fail_on_uncommitted_changes_clean_delegates_to_next_local_scheme() -> N
     assert format_version(configured_version) == "1.1"
 
 
+@pytest.mark.issue(1238)
+class TestNoLocalVersionStrict:
+    """Tests for the no-local-version-strict local scheme."""
+
+    def test_raises_when_dirty(self) -> None:
+        from dataclasses import replace
+
+        scm_version = VERSIONS["dirty"]
+        configured = replace(
+            scm_version,
+            config=replace(scm_version.config, local_scheme="no-local-version-strict"),
+        )
+        with pytest.raises(DirtyWorkingTreeError, match="uncommitted changes"):
+            format_version(configured)
+
+    def test_returns_empty_when_clean(self) -> None:
+        from dataclasses import replace
+
+        scm_version = VERSIONS["exact"]
+        configured = replace(
+            scm_version,
+            config=replace(scm_version.config, local_scheme="no-local-version-strict"),
+        )
+        assert format_version(configured) == "1.1"
+
+    def test_distance_clean_no_local_segment(self) -> None:
+        from dataclasses import replace
+
+        scm_version = VERSIONS["distance-clean"]
+        configured = replace(
+            scm_version,
+            config=replace(scm_version.config, local_scheme="no-local-version-strict"),
+        )
+        assert format_version(configured) == "1.2.dev3"
+
+    def test_distance_dirty_raises(self) -> None:
+        from dataclasses import replace
+
+        scm_version = VERSIONS["distance-dirty"]
+        configured = replace(
+            scm_version,
+            config=replace(scm_version.config, local_scheme="no-local-version-strict"),
+        )
+        with pytest.raises(DirtyWorkingTreeError, match="uncommitted changes"):
+            format_version(configured)
+
+
 def test_has_command() -> None:
     with pytest.warns(RuntimeWarning, match="yadayada"):
         assert not has_command("yadayada_setuptools_aint_ne")


### PR DESCRIPTION
## Summary

- **docs:** Fix JSON syntax in TOML override examples — `docs/integrators.md` and `overrides.py` docstring used JSON colons instead of TOML equals
- **fix:** Warn when `version_file`/`write_to` target is tracked in VCS (#468) — adds `Workdir.is_file_tracked()` for Git and Hg, emits `UserWarning` at write time
- **feat:** Add `no-local-version-strict` local scheme (#1238) — combines `fail-on-uncommitted-changes` + `no-local-version` as a single entry-point; recommended for release CI
- **docs:** Update CI integration docs (GitHub Actions, GitLab CI, overrides) to recommend `no-local-version-strict` for release builds

## Motivation

Issue #1238 reported that `python -m build` on an exact tag produced `0.1.2.dev0+g...` instead of `0.1.1`. The root cause was a tracked `_version.py` being rewritten during the build, dirtying the tree. Users were confused that `local_scheme = "no-local-version"` didn't help (it only strips the local segment, the `dev0` bump is in the public version).

These changes address the three gaps identified:
1. The docs had wrong TOML syntax (JSON colons)
2. No warning when the version file target is tracked (#468)
3. No single scheme that both strips local segments and fails on dirty trees

## Follow-up

- #1346 — the `Workdir` re-discovery in `_warn_if_tracked` is ad-hoc; the workdir should be threaded through the API after parsing

## Test plan

- [x] `test_warn_when_version_file_tracked[git]` / `[hg]` — warns on tracked files
- [x] `test_no_warn_when_version_file_not_tracked[git]` / `[hg]` — no false positives
- [x] `TestNoLocalVersionStrict` — raises on dirty, returns empty on clean, handles distance cases
- [x] Full test suite: 508 passed, 48 skipped (hg/windows), 1 pre-existing failure (`test_dump_version_mypy`)