### PR TITLE
_run_cmd: override user aliases in run()

### DIFF
--- a/vcs-versioning/src/vcs_versioning/_run_cmd.py
+++ b/vcs-versioning/src/vcs_versioning/_run_cmd.py
@@ -155,6 +155,7 @@ def run(
             LC_ALL="C.UTF-8",
             LANGUAGE="",
             HGPLAIN="1",
+            HGRCPATH="",
         ),
         text=True,
         encoding="utf-8",


### PR DESCRIPTION
If a user aliased `hg log` to `hg log --graph` [^1] (apparently this is widespread, see [^2]), mercurial based setups do not work, because `hg log` output needs to be reset to a canonical form.

This is done setting the environment variable `HGRCPATH=` to an empty value.

A previous attempt at normalizing hg output was done on 2010-08-29, when e0954e3fe093 ("inline getoutput, set HGPLAIN to disable hg i18n"), introduced `HGPLAIN=1`, but this change is not sufficient for protecting against `hg log` aliasing.

An example of command that is fixed with this change is the compilation of mercurial itself in local mode (here shown for 7.2.1):

```
  $ make local
  ...
  File "<HOME>/.cache/uv/builds-v0/.tmpcFxMQB/lib64/python3.14/site-packages/vcs_versioning/_run_cmd.py", line 173, in run
    res.check_returncode()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.14/subprocess.py", line 508, in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
                             self.stderr)
subprocess.CalledProcessError: Command '['hg', 'log', '-r', '.', '-T', '{node}\n{tag}\n{date|shortdate}']' returned non-zero exit status 255.
```

[^1]: `hg log` can be aliased editing the contents of `hgrc`:
    ```
    [alias]
    log = log --graph
    ```

[^2]: https://foss.heptapod.net/mercurial/mercurial-devel/-/commit/604c086ddde6f40309c03ae7e5050c7c8d87e75a