### PR TITLE
add recommended_tag_format option

### DIFF
--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -354,6 +354,8 @@ def version_from_describe(
 ) -> ScmVersion | None:
     if config.scm.git.describe_command is not None:
         describe_command = config.scm.git.describe_command
+    elif config.scm.git.recommended_tag_format:
+        describe_command = make_describe_command("*[vV][0-9]*")
 
     if describe_command is not None:
         if isinstance(describe_command, str):

--- a/vcs-versioning/src/vcs_versioning/_config.py
+++ b/vcs-versioning/src/vcs_versioning/_config.py
@@ -148,6 +148,7 @@ class GitConfiguration:
         default_factory=lambda: _get_default_git_pre_parse()
     )
     describe_command: _t.CMD_TYPE | None = None
+    recommended_tag_format: bool = False
 
     @classmethod
     def from_data(cls, data: dict[str, Any]) -> GitConfiguration:

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -878,6 +878,32 @@ def test_git_describe_command_init_conflict() -> None:
             )
 
 
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1385")
+def test_recommended_tag_format_default_is_false() -> None:
+    """Default value for recommended_tag_format is False."""
+    config = Configuration()
+    assert config.scm.git.recommended_tag_format is False
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1385")
+def test_recommended_tag_format_from_data() -> None:
+    """Test that recommended_tag_format is parsed from nested SCM configuration."""
+    config_data = {"scm": {"git": {"recommended_tag_format": True}}}
+    config = Configuration.from_data(relative_to=".", data=config_data)
+    assert config.scm.git.recommended_tag_format is True
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1385")
+def test_recommended_tag_format_ignores_non_version_tag(wd: WorkDir) -> None:
+    """recommended_tag_format restricts describe to v/V-prefixed numeric tags."""
+    wd.commit_testfile()
+    wd("git tag v0.1.0")
+    wd.commit_testfile()
+    wd("git tag 2026-event")
+    scm = {"git": {"recommended_tag_format": True}}
+    assert wd.get_version(scm=scm).startswith("0.1.1")
+
+
 def test_git_no_commits_uses_fallback_version(wd: WorkDir) -> None:
     """Test that when git describe fails (no commits), fallback_version is used instead of 0.0."""
     # Reinitialize as empty repo to remove any existing commits


### PR DESCRIPTION
Closes #1385

Introduce a boolean `scm.git.recommended_tag_format` config option, with a default value of `False`.

When `True`, the `make_describe_command` is given `"*[vV][0-9]*"` and the result overrides the current describe command which is generated with `make_describe_command("*[0-9]*")`.

I'll mark as ready for review when the following are complete, but welcome comments anytime.

- [ ] consider FutureWarning to change default to True when `setuptools-scm[simple]` is in the build requirements
- [ ] include in docs
- [ ] changelog entry


