### PR TITLE
Add `py.typed` marker file to `vcs-versioning`

### DIFF
--- a/vcs-versioning/changelog.d/1392.bugfix.md
+++ b/vcs-versioning/changelog.d/1392.bugfix.md
@@ -1,0 +1,1 @@
+Add the py.typed marker file.


### PR DESCRIPTION
Without the marker file type checkers [are not allowed](https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information) to use type annotations in `vcs-versioning` when type-checking downstream packages. This is a bug because the annotations that now reside in `vcs-versioning` could be used for downstream type-checking with e.g. `setuptools-scm==9.2.2` which was released before the codebase was split.