### PR TITLE
fix: bump vcs-versioning minimum pin to >=2.0.0.dev0

### DIFF
--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=77.0.3",
-  "vcs-versioning>=1.0.0.dev0",
+  "vcs-versioning>=2.0.0.dev0",
   # https://github.com/pypa/setuptools-scm/issues/1222: was <=2.0.2 for #1090 (old pip+toml);
   # pip 21.2+ vendors tomli, so the workaround is no longer needed.
   'tomli>=1; python_version < "3.11"',
@@ -37,7 +37,7 @@ dynamic = [
 ]
 dependencies = [
   # Core VCS functionality - workspace dependency
-  "vcs-versioning>=1.0.0.dev0",
+  "vcs-versioning>=2.0.0.dev0",
   "packaging>=20",
   # https://github.com/pypa/setuptools-scm/issues/1112 - re-pin in a breaking release
   "setuptools", # >= 61",


### PR DESCRIPTION
## Summary

- Bumps the `vcs-versioning` dependency pin from `>=1.0.0.dev0` to `>=2.0.0.dev0` in both `[build-system].requires` and `[project].dependencies`
- The workdir-centric-api merge introduced new modules (`_environment`, `_legacy_parse`, `_fallback_workdir`, `_scm_metadata`, `_paths`, `_worktree_discovery`) and new `Configuration` fields/methods that setuptools-scm now imports at runtime
- Without this bump, pip could resolve a published vcs-versioning 1.x that lacks these modules, causing `ImportError`

## Test plan

- [ ] `uv sync --all-packages` resolves correctly
- [ ] `uv run pytest setuptools-scm/testing_scm -n12` passes
- [ ] Verify no published vcs-versioning 2.x exists yet (this is a forward-looking pin for the next release)


Made with [Cursor](https://cursor.com)