### PR TITLE
fix: use towncrier-fragments scheme in vcs-versioning bootstrap and bump pin

### DIFF
--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=77.0.3",
-  "vcs-versioning>=1.0.0.dev0",
+  "vcs-versioning>=2.0.0.dev0",
   # https://github.com/pypa/setuptools-scm/issues/1222: was <=2.0.2 for #1090 (old pip+toml);
   # pip 21.2+ vendors tomli, so the workaround is no longer needed.
   'tomli>=1; python_version < "3.11"',
@@ -37,7 +37,7 @@ dynamic = [
 ]
 dependencies = [
   # Core VCS functionality - workspace dependency
-  "vcs-versioning>=1.0.0.dev0",
+  "vcs-versioning>=2.0.0.dev0",
   "packaging>=20",
   # https://github.com/pypa/setuptools-scm/issues/1112 - re-pin in a breaking release
   "setuptools", # >= 61",

--- a/vcs-versioning/setup.py
+++ b/vcs-versioning/setup.py
@@ -23,8 +23,8 @@ from vcs_versioning._version_schemes import (
     ScmVersion,
     get_local_node_and_date,
     get_no_local_node,
-    guess_next_dev_version,
 )
+from vcs_versioning._version_schemes._towncrier import version_from_fragments
 
 log = logging.getLogger("vcs_versioning")
 
@@ -73,7 +73,7 @@ def _package_version() -> str:
         fallback_root=".",
         relative_to=str(_pyproject_path),
         parse=_parse,
-        version_scheme=guess_next_dev_version,
+        version_scheme=version_from_fragments,
         local_scheme=local_scheme,
         tag_regex=r"^vcs-versioning-(?P<version>v?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
         scm={


### PR DESCRIPTION
## Summary

- **Root cause**: `vcs-versioning/setup.py` (the bootstrap build path) hardcoded `guess_next_dev_version` as the version scheme, ignoring the `towncrier-fragments` scheme in pyproject.toml. This produced version `1.1.2.dev` (patch bump) instead of `2.0.0.dev` (major bump from `removed-accessors.removal.md`).
- **Effect**: CI failed because `setuptools-scm` requires `vcs-versioning>=2.0.0.dev0` but the built wheel was only `1.1.2.dev`.
- Switches `setup.py` to use `version_from_fragments` directly, so the bootstrap build respects changelog fragment-driven versioning.
- Also includes the minimum pin bump (`>=1.0.0.dev0` → `>=2.0.0.dev0`) for setuptools-scm's dependency on vcs-versioning.

Fixes #1380

## Test plan

- [x] `uv build vcs-versioning/ --wheel` produces `2.0.0.dev*` (major bump detected)
- [x] `uv build setuptools-scm/ --wheel` succeeds
- [x] Both wheels install together without dependency conflict
- [ ] CI passes (all test matrices)


Made with [Cursor](https://cursor.com)