### PR TITLE
chore: update pre-commit hooks and ignore RUF076

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: debug-statements
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.12
+  rev: v0.15.18
   hooks:
     # Explicit --config so hooks match `uv run ruff` (astral-sh/ruff#11924).
     # Workspace = everything except setuptools-scm/ (src/, vcs-versioning/, docs/, …).
@@ -44,7 +44,7 @@ repos:
         - --config=setuptools-scm/pyproject.toml
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+    rev: v2.1.0
     hooks:
     -   id: mypy
         # Both are named setup.py → duplicate module "setup"; runtime path hacks are not modeled
@@ -61,7 +61,7 @@ repos:
             - towncrier>=23.11.0
 
 -   repo: https://github.com/scientific-python/cookie
-    rev: 2026.04.04
+    rev: 2026.06.18
     hooks:
       - id: sp-repo-review
 

--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -129,7 +129,7 @@ scm.git.describe_command = ["git", "describe", "--dirty", "--tags", "--long", "-
 
 [tool.ruff]
 lint.extend-select = ["YTT", "B", "C4", "DTZ", "ISC", "LOG", "G", "PIE", "PYI", "PT", "FLY", "I", "C90", "PERF", "W", "PGH", "PLE", "UP", "FURB", "RUF"]
-lint.ignore = ["B028", "LOG015", "PERF203"]
+lint.ignore = ["B028", "LOG015", "PERF203", "RUF076"]
 lint.preview = true
 
 # setuptools_scm alias modules: explicit `from m import x as x` re-exports for API stability


### PR DESCRIPTION
## Summary

- Update pre-commit hook versions (ruff v0.15.18, mypy v2.1.0, sp-repo-review 2026.06.18)
- Ignore `RUF076` (pytest-fixture-autouse) — a new preview rule that incorrectly discourages `autouse=True` in `conftest.py`, which is the standard pytest pattern for directory-scoped setup

## Context

Filed upstream bug: https://github.com/astral-sh/ruff/issues/26178

The rule is useful for discouraging autouse in individual test files but shouldn't fire in conftest.py where it's expected behavior.

## Test plan

- [x] `pre-commit run --all-files` passes

Made with [Cursor](https://cursor.com)