### PR TITLE
fix: read towncrier fragment directory from config (#1380)

### DIFF
--- a/vcs-versioning/changelog.d/1380.bugfix.md
+++ b/vcs-versioning/changelog.d/1380.bugfix.md
@@ -1,0 +1,1 @@
+Read towncrier fragment directory from `[tool.towncrier]` config in `pyproject.toml` or `towncrier.toml` instead of hardcoding `changelog.d/`.

--- a/vcs-versioning/changelog.d/1380.bugfix.md
+++ b/vcs-versioning/changelog.d/1380.bugfix.md
@@ -1,1 +1,1 @@
-Read towncrier fragment directory from `[tool.towncrier]` config in `pyproject.toml` or `towncrier.toml` instead of hardcoding `changelog.d/`.
+Read towncrier fragment directory from `[tool.towncrier]` in `pyproject.toml` or the top-level `directory` key in `towncrier.toml` instead of hardcoding `changelog.d/`.

--- a/vcs-versioning/src/vcs_versioning/_version_schemes/_towncrier.py
+++ b/vcs-versioning/src/vcs_versioning/_version_schemes/_towncrier.py
@@ -1,7 +1,8 @@
 """Version scheme based on towncrier changelog fragments.
 
-This version scheme analyzes changelog fragments in the changelog.d/ directory
-to determine the appropriate version bump:
+This version scheme analyzes changelog fragments in the configured towncrier
+fragment directory (resolved from pyproject.toml or towncrier.toml, defaulting
+to changelog.d/) to determine the appropriate version bump:
 - Major bump: if 'major', 'breaking', or 'removal' fragments are present
 - Minor bump: if 'feature' or 'deprecation' fragments are present
 - Patch bump: if only 'bugfix', 'doc', or 'misc' fragments are present

--- a/vcs-versioning/src/vcs_versioning/_version_schemes/_towncrier.py
+++ b/vcs-versioning/src/vcs_versioning/_version_schemes/_towncrier.py
@@ -15,10 +15,13 @@ import logging
 from pathlib import Path
 
 from .._scm_version import ScmVersion
+from .._toml import read_toml_content
 from ._common import SEMVER_MINOR, SEMVER_PATCH
 from ._standard import guess_next_dev_version, guess_next_simple_semver
 
 log = logging.getLogger(__name__)
+
+DEFAULT_FRAGMENT_DIRECTORY = "changelog.d"
 
 # Fragment types that indicate different version bumps
 MAJOR_FRAGMENT_TYPES = {"major", "breaking", "removal"}
@@ -28,8 +31,33 @@ PATCH_FRAGMENT_TYPES = {"bugfix", "doc", "misc"}
 ALL_FRAGMENT_TYPES = MAJOR_FRAGMENT_TYPES | MINOR_FRAGMENT_TYPES | PATCH_FRAGMENT_TYPES
 
 
+def _resolve_fragment_directory(root: Path) -> str:
+    """Resolve the towncrier fragment directory from config files.
+
+    Checks (in order):
+    1. pyproject.toml [tool.towncrier] directory
+    2. towncrier.toml top-level directory
+
+    Falls back to "changelog.d" if not configured.
+    """
+    pyproject_path = root / "pyproject.toml"
+    pyproject_data = read_toml_content(pyproject_path, default={})
+    towncrier_section = pyproject_data.get("tool", {}).get("towncrier", {})
+    if directory := towncrier_section.get("directory"):
+        log.debug("Found towncrier directory in pyproject.toml: %s", directory)
+        return str(directory)
+
+    towncrier_toml_path = root / "towncrier.toml"
+    towncrier_data = read_toml_content(towncrier_toml_path, default={})
+    if directory := towncrier_data.get("directory"):
+        log.debug("Found towncrier directory in towncrier.toml: %s", directory)
+        return str(directory)
+
+    return DEFAULT_FRAGMENT_DIRECTORY
+
+
 def _find_fragments(
-    root: Path, changelog_dir: str = "changelog.d"
+    root: Path, changelog_dir: str = DEFAULT_FRAGMENT_DIRECTORY
 ) -> dict[str, list[str]]:
     """Find and categorize changelog fragments.
 
@@ -145,7 +173,8 @@ def version_from_fragments(version: ScmVersion) -> str:
     log.debug("Analyzing fragments in %s", root)
 
     # Find and analyze fragments
-    fragments = _find_fragments(root)
+    changelog_dir = _resolve_fragment_directory(root)
+    fragments = _find_fragments(root, changelog_dir=changelog_dir)
     bump_type = _determine_bump_type(fragments)
 
     if bump_type is None:
@@ -188,7 +217,8 @@ def get_release_version(version: ScmVersion) -> str | None:
     root = _get_changelog_root(version)
     log.debug("Analyzing fragments for release version in %s", root)
 
-    fragments = _find_fragments(root)
+    changelog_dir = _resolve_fragment_directory(root)
+    fragments = _find_fragments(root, changelog_dir=changelog_dir)
     bump_type = _determine_bump_type(fragments)
 
     if bump_type is None:

--- a/vcs-versioning/testing_vcs/test_version_scheme_towncrier.py
+++ b/vcs-versioning/testing_vcs/test_version_scheme_towncrier.py
@@ -11,6 +11,7 @@ from vcs_versioning._version_cls import Version
 from vcs_versioning._version_schemes._towncrier import (
     _determine_bump_type,
     _find_fragments,
+    _resolve_fragment_directory,
     version_from_fragments,
 )
 
@@ -514,3 +515,65 @@ def test_version_from_fragments_dirty(
     result = version_from_fragments(version)
     # Should still bump correctly, dirty flag affects local version
     assert result.startswith("1.3.0.dev5")
+
+
+class TestResolveFragmentDirectory:
+    """Tests for _resolve_fragment_directory config resolution."""
+
+    def test_default_when_no_config(self, tmp_path: Path) -> None:
+        """Falls back to changelog.d when no config files exist."""
+        assert _resolve_fragment_directory(tmp_path) == "changelog.d"
+
+    def test_reads_from_pyproject_toml(self, tmp_path: Path) -> None:
+        """Reads directory from [tool.towncrier] in pyproject.toml."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[tool.towncrier]\ndirectory = "changes"\n')
+
+        assert _resolve_fragment_directory(tmp_path) == "changes"
+
+    def test_reads_from_towncrier_toml(self, tmp_path: Path) -> None:
+        """Reads directory from towncrier.toml when pyproject.toml has no setting."""
+        towncrier_toml = tmp_path / "towncrier.toml"
+        towncrier_toml.write_text('directory = "my-fragments"\n')
+
+        assert _resolve_fragment_directory(tmp_path) == "my-fragments"
+
+    def test_pyproject_takes_priority_over_towncrier_toml(self, tmp_path: Path) -> None:
+        """pyproject.toml [tool.towncrier] takes priority over towncrier.toml."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[tool.towncrier]\ndirectory = "from-pyproject"\n')
+        towncrier_toml = tmp_path / "towncrier.toml"
+        towncrier_toml.write_text('directory = "from-towncrier"\n')
+
+        assert _resolve_fragment_directory(tmp_path) == "from-pyproject"
+
+    def test_pyproject_without_towncrier_section(self, tmp_path: Path) -> None:
+        """Falls back to default when pyproject.toml exists but has no towncrier section."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[tool.other]\nfoo = 1\n")
+
+        assert _resolve_fragment_directory(tmp_path) == "changelog.d"
+
+
+@pytest.mark.issue(1380)
+def test_version_from_fragments_custom_directory(tmp_path: Path) -> None:
+    """End-to-end: towncrier-fragments reads custom directory from config."""
+    # Configure towncrier to use a custom directory
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.towncrier]\ndirectory = "changes"\n')
+
+    # Create fragments in the custom directory
+    changes_dir = tmp_path / "changes"
+    changes_dir.mkdir()
+    (changes_dir / "42.feature.md").write_text("New feature")
+
+    config = _config.Configuration(root=tmp_path)
+    version = ScmVersion(
+        tag=Version("1.0.0"),
+        distance=3,
+        node="abc123",
+        dirty=False,
+        config=config,
+    )
+    result = version_from_fragments(version)
+    assert result.startswith("1.1.0.dev3")


### PR DESCRIPTION
## Summary

- Resolves the hardcoded `changelog.d/` path in the `towncrier-fragments` version scheme
- Now reads `[tool.towncrier] directory` from `pyproject.toml` or `towncrier.toml`
- Falls back to the default `changelog.d` when no config is found

Closes #1380

## Test plan

- [x] Unit tests for `_resolve_fragment_directory()` covering pyproject.toml, towncrier.toml, priority, and fallback
- [x] End-to-end test with custom directory configured
- [x] All existing tests pass (no regressions)
- [x] pre-commit (ruff, mypy) passes

Made with [Cursor](https://cursor.com)