### PR TITLE
fix: suppress spurious "toml section missing" warnings

### DIFF
--- a/vcs-versioning/changelog.d/1368.bugfix.md
+++ b/vcs-versioning/changelog.d/1368.bugfix.md
@@ -1,0 +1,1 @@
+Suppress spurious "toml section missing" warnings when setuptools-scm is used only for file finding or with simplified activation. The log message is now debug-level and only emitted when the package is actually a build requirement.

--- a/vcs-versioning/src/vcs_versioning/_pyproject_reading.py
+++ b/vcs-versioning/src/vcs_versioning/_pyproject_reading.py
@@ -231,8 +231,8 @@ def read_pyproject(
             actual_tool_name = name
             break
 
-    if not section_present:
-        log.warning(
+    if not section_present and is_required:
+        log.debug(
             "toml section missing %r does not contain any of the tool sections: %s",
             path,
             tool_names,


### PR DESCRIPTION
## Summary

- Suppress the `toml section missing` warning that fired unconditionally in `read_pyproject()`, even when setuptools-scm was used only for file finding or with simplified activation
- Guard with `is_required`: only emit when the package is in `build-system.requires`
- Downgrade from `log.warning` to `log.debug`: callers already receive `section_present` in `PyProjectData` to decide what to do

## Issues closed

- Closes #1368 — Spurious warnings when not using version inference
- Closes #1201 — Don't show warnings/errors in cases where they add no value
- Closes #1387 — Warning about missing tool sections still appears with simplified activation
- Closes #1348 — `No GlobalOverrides context is active` (already fixed by the `ensure_context` refactoring, but can be formally closed)

## Test plan

- [x] Full test suite passes (`uv run pytest -n12` — 630 passed)
- [x] Pre-commit passes (ruff, mypy, codespell)
- [x] Verified: file-finder-only projects (static `version=`, no `[tool.setuptools_scm]`) produce no warning
- [x] Verified: simplified activation (`setuptools-scm[simple]` + `dynamic = ["version"]`) produces no warning
- [x] Verified: projects with explicit `[tool.setuptools_scm]` still work normally


Made with [Cursor](https://cursor.com)