### PR TITLE
fix: make vcs-versioning tests independent of setuptools_scm (#1353)

### DIFF
--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -98,14 +98,6 @@ setuptools_scm = "vcs_versioning._file_finders:find_files"
 [project.entry-points."setuptools.finalize_distribution_options"]
 setuptools_scm = "setuptools_scm._integration.setuptools:infer_version"
 
-[project.entry-points."setuptools_scm.files_command"]
-".git" = "vcs_versioning._file_finders._git:git_find_files"
-".hg" = "vcs_versioning._file_finders._hg:hg_find_files"
-
-[project.entry-points."setuptools_scm.files_command_fallback"]
-".git_archival.txt" = "vcs_versioning._file_finders._git:git_archive_find_files"
-".hg_archival.txt" = "vcs_versioning._file_finders._hg:hg_archive_find_files"
-
 [project.entry-points."vcs_versioning.discover_workdir"]
 pkginfo = "setuptools_scm._integration._discover:discover_pkginfo"
 egg-info = "setuptools_scm._integration._discover:discover_egg_info_metadata"

--- a/setuptools-scm/testing_scm/test_setuptools_git.py
+++ b/setuptools-scm/testing_scm/test_setuptools_git.py
@@ -1,0 +1,132 @@
+"""Tests for setuptools_scm integration with git via setup.py use_scm_version.
+
+These tests require setuptools_scm to be installed because they exercise the
+distutils.setup_keywords hook (use_scm_version).
+
+Moved from vcs-versioning/testing_vcs/test_git.py as part of #1353.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from vcs_versioning._run_cmd import run
+from vcs_versioning.test_api import WorkDir
+
+
+@pytest.fixture
+def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> WorkDir:
+    """Set up git for setuptools integration tests."""
+    wd.setup_git(monkeypatch)
+    return wd
+
+
+def test_root_relative_to(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG", raising=False)
+    p = wd.cwd.joinpath("sub/package")
+    p.mkdir(parents=True)
+    p.joinpath("setup.py").write_text(
+        """from setuptools import setup
+setup(use_scm_version={"root": "../..",
+                       "relative_to": __file__})
+""",
+        encoding="utf-8",
+    )
+    res = run([sys.executable, "setup.py", "--version"], p)
+    assert res.stdout == "0.1.dev0+d20090213"
+
+
+def test_root_search_parent_directories(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG", raising=False)
+    p = wd.cwd.joinpath("sub/package")
+    p.mkdir(parents=True)
+    p.joinpath("setup.py").write_text(
+        """from setuptools import setup
+setup(use_scm_version={"search_parent_directories": True})
+""",
+        encoding="utf-8",
+    )
+    res = run([sys.executable, "setup.py", "--version"], p)
+    assert res.stdout == "0.1.dev0+d20090213"
+
+
+setup_py_with_normalize: dict[str, str] = {
+    "false": """
+        from setuptools import setup
+        setup(use_scm_version={'normalize': False, 'write_to': 'VERSION.txt'})
+        """,
+    "with_created_class": """
+from setuptools import setup
+
+class MyVersion:
+    def __init__(self, tag_str: str):
+        self.version = tag_str
+
+    def __repr__(self):
+        return self.version
+
+    @property
+    def public(self):
+        return self.version.split('+')[0]
+
+    @property
+    def local(self):
+        if '+' in self.version:
+            return self.version.split('+', 1)[1]
+        return None
+
+setup(use_scm_version={'version_cls': MyVersion, 'write_to': 'VERSION.txt'})
+        """,
+    "with_named_import": """
+        from setuptools import setup
+        setup(use_scm_version={
+            'version_cls': 'setuptools_scm.NonNormalizedVersion',
+            'write_to': 'VERSION.txt'
+        })
+        """,
+}
+
+
+@pytest.mark.parametrize(
+    "setup_py_txt",
+    [pytest.param(text, id=key) for key, text in setup_py_with_normalize.items()],
+)
+def test_git_version_unnormalized_setuptools(
+    setup_py_txt: str, wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Test that when integrating with setuptools without normalization,
+    the version is not normalized in write_to files,
+    but still normalized by setuptools for the final dist metadata.
+    """
+    monkeypatch.setenv("SETUPTOOLS_SCM_WRITE_TO_SOURCE", "1")
+    monkeypatch.chdir(wd.cwd)
+    wd.write("setup.py", dedent(setup_py_txt))
+
+    wd.commit_testfile()
+    wd("git tag 17.33.0-rc1")
+
+    res = wd([sys.executable, "setup.py", "--version"])
+    assert res == "17.33.0rc1"
+
+    assert wd.cwd.joinpath("VERSION.txt").read_text(encoding="utf-8") == "17.33.0-rc1"
+
+
+@pytest.mark.issue(193)
+@pytest.mark.xfail(reason="sometimes relative path results")
+def test_git_worktree_support(wd: WorkDir, tmp_path: Path) -> None:
+
+    wd.commit_testfile()
+    worktree = tmp_path / "work_tree"
+    wd(f"git worktree add -b work-tree {worktree}")
+
+    res = run([sys.executable, "-m", "setuptools_scm", "ls"], cwd=worktree)
+    assert "test.txt" in res.stdout
+    assert str(worktree) in res.stdout

--- a/vcs-versioning/pyproject.toml
+++ b/vcs-versioning/pyproject.toml
@@ -60,6 +60,14 @@ Source = "https://github.com/pypa/setuptools-scm"
 hg-git = "vcs_versioning._backends._discover_vcs:discover"
 archival = "vcs_versioning._fallback_workdir:discover_archival"
 
+[project.entry-points."setuptools_scm.files_command"]
+".git" = "vcs_versioning._file_finders._git:git_find_files"
+".hg" = "vcs_versioning._file_finders._hg:hg_find_files"
+
+[project.entry-points."setuptools_scm.files_command_fallback"]
+".git_archival.txt" = "vcs_versioning._file_finders._git:git_archive_find_files"
+".hg_archival.txt" = "vcs_versioning._file_finders._hg:hg_archive_find_files"
+
 [project.entry-points."setuptools_scm.local_scheme"]
 dirty-tag = "vcs_versioning._version_schemes:get_local_dirty_tag"
 "fail-on-uncommitted-changes" = "vcs_versioning._version_schemes:get_local_fail_on_uncommitted_changes"

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -4,13 +4,11 @@ import contextlib
 import os
 import shutil
 import subprocess
-import sys
 import textwrap
 from collections.abc import Generator
 from datetime import date, datetime, timezone
 from os.path import join as opj
 from pathlib import Path
-from textwrap import dedent
 from unittest.mock import Mock, patch
 
 import pytest
@@ -59,37 +57,6 @@ def test_parse_describe_output(
 ) -> None:
     parsed = _git._git_parse_describe(given)
     assert parsed == (tag, number, node, dirty)
-
-
-def test_root_relative_to(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG", raising=False)
-    p = wd.cwd.joinpath("sub/package")
-    p.mkdir(parents=True)
-    p.joinpath("setup.py").write_text(
-        """from setuptools import setup
-setup(use_scm_version={"root": "../..",
-                       "relative_to": __file__})
-""",
-        encoding="utf-8",
-    )
-    res = run([sys.executable, "setup.py", "--version"], p)
-    assert res.stdout == "0.1.dev0+d20090213"
-
-
-def test_root_search_parent_directories(
-    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("SETUPTOOLS_SCM_DEBUG", raising=False)
-    p = wd.cwd.joinpath("sub/package")
-    p.mkdir(parents=True)
-    p.joinpath("setup.py").write_text(
-        """from setuptools import setup
-setup(use_scm_version={"search_parent_directories": True})
-""",
-        encoding="utf-8",
-    )
-    res = run([sys.executable, "setup.py", "--version"], p)
-    assert res.stdout == "0.1.dev0+d20090213"
 
 
 def test_git_gone(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -196,75 +163,9 @@ def test_version_from_git(wd: WorkDir) -> None:
     assert wd.get_version(normalize=False) == "17.33.0-rc"
     assert wd.get_version(version_cls=NonNormalizedVersion) == "17.33.0-rc"
     assert (
-        wd.get_version(version_cls="setuptools_scm.NonNormalizedVersion")
+        wd.get_version(version_cls="vcs_versioning.NonNormalizedVersion")
         == "17.33.0-rc"
     )
-
-
-setup_py_with_normalize: dict[str, str] = {
-    "false": """
-        from setuptools import setup
-        setup(use_scm_version={'normalize': False, 'write_to': 'VERSION.txt'})
-        """,
-    "with_created_class": """
-from setuptools import setup
-
-class MyVersion:
-    def __init__(self, tag_str: str):
-        self.version = tag_str
-
-    def __repr__(self):
-        return self.version
-
-    @property
-    def public(self):
-        return self.version.split('+')[0]
-
-    @property
-    def local(self):
-        if '+' in self.version:
-            return self.version.split('+', 1)[1]
-        return None
-
-setup(use_scm_version={'version_cls': MyVersion, 'write_to': 'VERSION.txt'})
-        """,
-    "with_named_import": """
-        from setuptools import setup
-        setup(use_scm_version={
-            'version_cls': 'setuptools_scm.NonNormalizedVersion',
-            'write_to': 'VERSION.txt'
-        })
-        """,
-}
-
-
-@pytest.mark.parametrize(
-    "setup_py_txt",
-    [pytest.param(text, id=key) for key, text in setup_py_with_normalize.items()],
-)
-def test_git_version_unnormalized_setuptools(
-    setup_py_txt: str, wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """
-    Test that when integrating with setuptools without normalization,
-    the version is not normalized in write_to files,
-    but still normalized by setuptools for the final dist metadata.
-    """
-    # Enable writing version files at inference time (not just at build time)
-    monkeypatch.setenv("SETUPTOOLS_SCM_WRITE_TO_SOURCE", "1")
-    monkeypatch.chdir(wd.cwd)
-    wd.write("setup.py", dedent(setup_py_txt))
-
-    # do git operations and tag
-    wd.commit_testfile()
-    wd("git tag 17.33.0-rc1")
-
-    # setuptools still normalizes using packaging.Version (removing the dash)
-    res = wd([sys.executable, "setup.py", "--version"])
-    assert res == "17.33.0rc1"
-
-    # but the version tag in the file is non-normalized (with the dash)
-    assert wd.cwd.joinpath("VERSION.txt").read_text(encoding="utf-8") == "17.33.0-rc1"
 
 
 def test_unicode_version_scheme(wd: WorkDir) -> None:
@@ -307,18 +208,6 @@ def test_git_dirty_notag(
 
     assert version.startswith("0.1.dev1+g")
     assert version.endswith(tag)
-
-
-@pytest.mark.issue(193)
-@pytest.mark.xfail(reason="sometimes relative path results")
-def test_git_worktree_support(wd: WorkDir, tmp_path: Path) -> None:
-    wd.commit_testfile()
-    worktree = tmp_path / "work_tree"
-    wd(f"git worktree add -b work-tree {worktree}")
-
-    res = run([sys.executable, "-m", "setuptools_scm", "ls"], cwd=worktree)
-    assert "test.txt" in res.stdout
-    assert str(worktree) in res.stdout
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Move `setuptools_scm.files_command` and `setuptools_scm.files_command_fallback` entry-point registrations from setuptools-scm to vcs-versioning, so file finding works without setuptools-scm installed
- Move setuptools integration tests (`use_scm_version` subprocess tests) from `vcs-versioning/testing_vcs/test_git.py` to `setuptools-scm/testing_scm/test_setuptools_git.py`
- Fix `NonNormalizedVersion` string reference to use `vcs_versioning.NonNormalizedVersion` instead of `setuptools_scm.NonNormalizedVersion` (avoids runtime import of setuptools_scm)

## Test plan

- [x] vcs-versioning tests pass (478 passed)
- [x] setuptools-scm tests pass including moved tests (630 passed total)
- [x] Pre-commit passes (ruff, mypy)
- [ ] CI passes on all platforms

## Follow-up

Filed #1400 to track renaming `setuptools_scm.*` entry-point groups to `vcs_versioning.*` naming.

Fixes #1353

Made with [Cursor](https://cursor.com)