### PR TITLE
fix: skip writing non-package version files to build_lib (#1364)

### DIFF
--- a/setuptools-scm/src/setuptools_scm/_integration/build_py.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/build_py.py
@@ -25,32 +25,46 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _sanitize_relative_path(relative_path: str) -> Path:
+    """Validate and return a safe relative path for writing under ``build_lib``.
+
+    Defense-in-depth: these values come from the project's own
+    ``pyproject.toml`` / ``setup.py`` (not a trust boundary), but we
+    reject obvious mistakes that could escape the build directory.
+
+    Raises:
+        ValueError: If the path is absolute or contains ``..`` segments.
+    """
+    p = Path(relative_path)
+    if p.is_absolute():
+        raise ValueError(
+            f"Version file path must be relative, got absolute: {relative_path}"
+        )
+    if ".." in p.parts:
+        raise ValueError(
+            f"Version file path must not contain '..' traversal: {relative_path}"
+        )
+    return p
+
+
 def _is_inside_package(relative_path: str, packages: list[str] | None) -> bool:
-    """Check if a file path is inside one of the distribution's packages.
+    """Check if a version file path is inside one of the distribution's packages.
 
     Files at the root level (e.g., ``VERSION``) or outside any declared
     package (e.g., ``version.h``) should NOT be written to ``build_lib``
     because that would include them in the wheel.
-
-    Args:
-        relative_path: The file path relative to build_lib (already transformed)
-        packages: The list of packages from the distribution
-
-    Returns:
-        True if the file is inside a declared package, False otherwise
     """
     if not packages:
         return False
 
-    file_path = Path(relative_path)
-    if not file_path.parts[:-1]:
-        # Root-level file (e.g., "VERSION", "_version.py")
+    path = _sanitize_relative_path(relative_path)
+    if len(path.parts) < 2:
         return False
 
     for pkg in packages:
-        pkg_dir = Path(pkg.replace(".", "/"))
+        pkg_path = Path(pkg.replace(".", "/"))
         try:
-            file_path.relative_to(pkg_dir)
+            path.relative_to(pkg_path)
             return True
         except ValueError:
             continue
@@ -276,6 +290,12 @@ class ScmVersionFileMixin(_build_py):
         from vcs_versioning._dump_version import DummyScmVersion
         from vcs_versioning._dump_version import _validate_template
         from vcs_versioning._version_cls import _version_as_tuple
+
+        try:
+            _sanitize_relative_path(relative_path)
+        except ValueError as e:
+            log.warning("Refusing to write version file: %s", e)
+            return None
 
         target = build_lib / relative_path
         log.debug("Writing version file: %s", target)

--- a/setuptools-scm/src/setuptools_scm/_integration/build_py.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/build_py.py
@@ -25,6 +25,39 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _is_inside_package(relative_path: str, packages: list[str] | None) -> bool:
+    """Check if a file path is inside one of the distribution's packages.
+
+    Files at the root level (e.g., ``VERSION``) or outside any declared
+    package (e.g., ``version.h``) should NOT be written to ``build_lib``
+    because that would include them in the wheel.
+
+    Args:
+        relative_path: The file path relative to build_lib (already transformed)
+        packages: The list of packages from the distribution
+
+    Returns:
+        True if the file is inside a declared package, False otherwise
+    """
+    if not packages:
+        return False
+
+    file_path = Path(relative_path)
+    if not file_path.parts[:-1]:
+        # Root-level file (e.g., "VERSION", "_version.py")
+        return False
+
+    for pkg in packages:
+        pkg_dir = Path(pkg.replace(".", "/"))
+        try:
+            file_path.relative_to(pkg_dir)
+            return True
+        except ValueError:
+            continue
+
+    return False
+
+
 def _transform_version_file_path(
     version_file: str, package_dir: dict[str, str] | None
 ) -> str:
@@ -157,6 +190,11 @@ class ScmVersionFileMixin(_build_py):
     def _write_version_files(self) -> list[str]:
         """Write version files to the build directory.
 
+        Only writes files that are inside one of the distribution's packages.
+        Root-level files (e.g., ``VERSION``) or files outside any package
+        (e.g., ``version.h``) are skipped to avoid polluting the wheel with
+        files that were never meant to be distributed.
+
         Returns a list of absolute paths to the files written, for use
         in get_outputs() so editable wheels include them.
         """
@@ -174,35 +212,52 @@ class ScmVersionFileMixin(_build_py):
         log.info("Writing version files to build directory: %s", build_lib)
 
         package_dir = getattr(self.distribution, "package_dir", None)
+        packages: list[str] | None = getattr(self.distribution, "packages", None)
         written: list[str] = []
 
         if config.write_to:
             transformed_path = _transform_version_file_path(
                 str(config.write_to), package_dir
             )
-            target = self._write_single_version_file(
-                build_lib=build_lib,
-                relative_path=transformed_path,
-                template=config.write_to_template,
-                version=data.version,
-                scm_version=data.scm_version,
-            )
-            if target is not None:
-                written.append(target)
+            if not _is_inside_package(transformed_path, packages):
+                log.debug(
+                    "Skipping write_to=%s (transformed=%s): "
+                    "not inside any distribution package",
+                    config.write_to,
+                    transformed_path,
+                )
+            else:
+                target = self._write_single_version_file(
+                    build_lib=build_lib,
+                    relative_path=transformed_path,
+                    template=config.write_to_template,
+                    version=data.version,
+                    scm_version=data.scm_version,
+                )
+                if target is not None:
+                    written.append(target)
 
         if config.version_file:
             transformed_path = _transform_version_file_path(
                 str(config.version_file), package_dir
             )
-            target = self._write_single_version_file(
-                build_lib=build_lib,
-                relative_path=transformed_path,
-                template=config.version_file_template,
-                version=data.version,
-                scm_version=data.scm_version,
-            )
-            if target is not None:
-                written.append(target)
+            if not _is_inside_package(transformed_path, packages):
+                log.debug(
+                    "Skipping version_file=%s (transformed=%s): "
+                    "not inside any distribution package",
+                    config.version_file,
+                    transformed_path,
+                )
+            else:
+                target = self._write_single_version_file(
+                    build_lib=build_lib,
+                    relative_path=transformed_path,
+                    template=config.version_file_template,
+                    version=data.version,
+                    scm_version=data.scm_version,
+                )
+                if target is not None:
+                    written.append(target)
 
         return written
 

--- a/setuptools-scm/testing_scm/test_integration.py
+++ b/setuptools-scm/testing_scm/test_integration.py
@@ -1670,3 +1670,106 @@ def test_manifest_in_excludes_scm_tracked_files(
     assert any("test_pkg/__init__.py" in n for n in names), (
         f"test_pkg/__init__.py should still be in sdist: {names}"
     )
+
+
+class TestIsInsidePackage:
+    """Unit tests for _is_inside_package."""
+
+    def test_root_level_file_not_inside_package(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        assert not _is_inside_package("VERSION", ["mypackage"])
+
+    def test_root_level_py_file_not_inside_package(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        assert not _is_inside_package("_version.py", ["mypackage"])
+
+    def test_file_inside_package(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        assert _is_inside_package("mypackage/_version.py", ["mypackage"])
+
+    def test_file_inside_nested_package(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        assert _is_inside_package("mypackage/sub/_version.py", ["mypackage"])
+
+    def test_file_inside_dotted_package(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        assert _is_inside_package("mypackage/sub/_version.py", ["mypackage.sub"])
+
+    def test_file_not_in_any_package(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        assert not _is_inside_package("other/version.h", ["mypackage"])
+
+    def test_no_packages(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        assert not _is_inside_package("mypackage/_version.py", None)
+        assert not _is_inside_package("mypackage/_version.py", [])
+
+
+@pytest.mark.issue(1364)
+def test_root_level_version_file_not_in_wheel(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Root-level version files (e.g. VERSION) must not end up in the wheel.
+
+    Regression test for GH-1364: upgrading to setuptools-scm 10 caused
+    files like ``VERSION`` to appear at the wheel root because build_py
+    unconditionally wrote them to ``build_lib``.
+    """
+    monkeypatch.chdir(wd.cwd)
+
+    wd.write(
+        "pyproject.toml",
+        textwrap.dedent("""\
+            [build-system]
+            requires = ["setuptools>=61", "setuptools-scm"]
+            build-backend = "setuptools.build_meta"
+
+            [project]
+            name = "root-version-file-pkg"
+            dynamic = ["version"]
+
+            [tool.setuptools_scm]
+            write_to = "VERSION.txt"
+
+            [tool.setuptools.packages.find]
+            where = ["."]
+        """),
+    )
+
+    pkg_dir = wd.cwd / "root_version_file_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+
+    wd.commit_testfile()
+    wd("git tag v1.0.0")
+
+    build_result = subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--no-isolation"],
+        cwd=wd.cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert build_result.returncode == 0, (
+        f"Build failed:\nstdout: {build_result.stdout}\nstderr: {build_result.stderr}"
+    )
+
+    import zipfile
+
+    dist_dir = wd.cwd / "dist"
+    wheels = list(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+
+    with zipfile.ZipFile(wheels[0], "r") as whl:
+        names = whl.namelist()
+        assert not any(n == "VERSION.txt" for n in names), (
+            f"Root-level VERSION.txt should NOT be in wheel, got: {names}"
+        )

--- a/setuptools-scm/testing_scm/test_integration.py
+++ b/setuptools-scm/testing_scm/test_integration.py
@@ -1711,6 +1711,62 @@ class TestIsInsidePackage:
         assert not _is_inside_package("mypackage/_version.py", None)
         assert not _is_inside_package("mypackage/_version.py", [])
 
+    @pytest.mark.skipif(os.name != "posix", reason="posix absolute path form")
+    def test_rejects_absolute_path(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        with pytest.raises(ValueError, match="must be relative"):
+            _is_inside_package("/etc/passwd", ["mypackage"])
+
+    @pytest.mark.skipif(os.name != "nt", reason="windows absolute path form")
+    def test_rejects_absolute_path_windows(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        with pytest.raises(ValueError, match="must be relative"):
+            _is_inside_package("C:\\Users\\evil.py", ["mypackage"])
+
+    def test_rejects_traversal(self) -> None:
+        from setuptools_scm._integration.build_py import _is_inside_package
+
+        with pytest.raises(ValueError, match="must not contain"):
+            _is_inside_package("mypackage/../../etc/passwd", ["mypackage"])
+
+
+class TestSanitizeRelativePath:
+    """Unit tests for _sanitize_relative_path."""
+
+    def test_accepts_simple_relative(self) -> None:
+        from setuptools_scm._integration.build_py import _sanitize_relative_path
+
+        result = _sanitize_relative_path("mypackage/_version.py")
+        assert result == Path("mypackage/_version.py")
+
+    @pytest.mark.skipif(os.name != "posix", reason="posix absolute path form")
+    def test_rejects_absolute_posix(self) -> None:
+        from setuptools_scm._integration.build_py import _sanitize_relative_path
+
+        with pytest.raises(ValueError, match="must be relative"):
+            _sanitize_relative_path("/tmp/evil.py")
+
+    @pytest.mark.skipif(os.name != "nt", reason="windows absolute path form")
+    def test_rejects_absolute_windows(self) -> None:
+        from setuptools_scm._integration.build_py import _sanitize_relative_path
+
+        with pytest.raises(ValueError, match="must be relative"):
+            _sanitize_relative_path("C:\\Windows\\evil.py")
+
+    def test_rejects_dotdot(self) -> None:
+        from setuptools_scm._integration.build_py import _sanitize_relative_path
+
+        with pytest.raises(ValueError, match="must not contain"):
+            _sanitize_relative_path("pkg/../../outside.py")
+
+    def test_accepts_root_level(self) -> None:
+        from setuptools_scm._integration.build_py import _sanitize_relative_path
+
+        result = _sanitize_relative_path("VERSION.txt")
+        assert result == Path("VERSION.txt")
+
 
 @pytest.mark.issue(1364)
 def test_root_level_version_file_not_in_wheel(


### PR DESCRIPTION
## Summary

- Root-level version files (e.g. `VERSION`, `VERSION.txt`) and files outside any declared package were unconditionally written to `build_lib` by the `build_py` mixin, causing them to appear in wheels where they never did in setuptools-scm 9.x
- Added `_is_inside_package()` check in `_write_version_files()` that skips writing to `build_lib` when the file isn't inside any of the distribution's declared packages
- Files inside packages (e.g. `mypackage/_version.py`) continue to be written to `build_lib` as before

Fixes #1364

## Test plan

- [x] Unit tests for `_is_inside_package()` covering root-level files, in-package files, nested packages, dotted packages, and edge cases (7 tests)
- [x] Integration test `test_root_level_version_file_not_in_wheel` verifying `write_to = "VERSION.txt"` does NOT appear in the built wheel
- [x] All existing build_py tests still pass (version file in package, src layout transformation, custom build_py, editable installs)
- [x] Full test suite passes (645 passed)
- [x] Pre-commit clean (ruff, mypy, codespell)

Made with [Cursor](https://cursor.com)