### PR TITLE
fix: replace git archive with git ls-files for file discovery (#662)

### DIFF
--- a/vcs-versioning/changelog.d/662.bugfix.md
+++ b/vcs-versioning/changelog.d/662.bugfix.md
@@ -1,0 +1,1 @@
+Replace git archive with git ls-files for file discovery, fixing freshly added files being hidden while still honoring export-ignore via gitattributes

--- a/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+from pathlib import Path
 
 from .. import _types as _t
+from .._backends._git import run_git
 from .._compat import norm_real, strip_path_suffix
 from .._integration import data_from_mime
 from .._run_cmd import run as _run
@@ -66,9 +68,9 @@ def _git_ls_files_and_dirs(
     # The exclude pathspec filters out files marked with the export-ignore
     # gitattribute, matching the old git-archive behavior.
     # "." is needed as positive pathspec for the exclude to apply against.
-    res = _run(
+    # Uses run_git (--git-dir) to pin to the correct repository.
+    res = run_git(
         [
-            "git",
             "ls-files",
             "-z",
             "--recurse-submodules",
@@ -76,7 +78,7 @@ def _git_ls_files_and_dirs(
             ".",
             ":(exclude,attr:export-ignore)",
         ],
-        cwd=toplevel,
+        Path(toplevel),
         timeout=timeout,
     )
     if res.returncode:

--- a/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
-import tarfile
-from typing import IO
 
 from .. import _types as _t
 from .._compat import norm_real, strip_path_suffix
 from .._integration import data_from_mime
-from .._run_cmd import no_git_env
 from .._run_cmd import run as _run
 from . import is_toplevel_acceptable, scm_find_files
 
@@ -61,54 +58,44 @@ def _git_toplevel(path: str) -> str | None:
         return None
 
 
-def _git_interpret_archive(fd: IO[bytes], toplevel: str) -> tuple[set[str], set[str]]:
-    with tarfile.open(fileobj=fd, mode="r|*") as tf:
-        git_files = set()
-        git_dirs = {toplevel}
-        for member in tf.getmembers():
-            name = os.path.normcase(member.name).replace("/", os.path.sep)
-            if member.type == tarfile.DIRTYPE:
-                git_dirs.add(name)
-            else:
-                git_files.add(name)
-        return git_files, git_dirs
-
-
 def _git_ls_files_and_dirs(
     toplevel: str, *, timeout: int | None = None
 ) -> tuple[set[str], set[str]]:
-    # use git archive instead of git ls-file to honor
-    # export-ignore git attribute
-
-    cmd = ["git", "archive", "--prefix", toplevel + os.path.sep, "HEAD"]
-    log.info("running %s", " ".join(str(x) for x in cmd))
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
+    # Use git ls-files with -z for NUL-separated output (safe parsing).
+    # --recurse-submodules lists files inside submodules with prefixed paths.
+    # The exclude pathspec filters out files marked with the export-ignore
+    # gitattribute, matching the old git-archive behavior.
+    # "." is needed as positive pathspec for the exclude to apply against.
+    res = _run(
+        [
+            "git",
+            "ls-files",
+            "-z",
+            "--recurse-submodules",
+            "--",
+            ".",
+            ":(exclude,attr:export-ignore)",
+        ],
         cwd=toplevel,
-        stderr=subprocess.DEVNULL,
-        env=no_git_env(os.environ),
+        timeout=timeout,
     )
-    assert proc.stdout is not None
-    try:
-        try:
-            return _git_interpret_archive(proc.stdout, toplevel)
-        finally:
-            # ensure we avoid resource warnings by cleaning up the process
-            proc.stdout.close()
-            proc.terminate()
-            wait_timeout = timeout if timeout is not None else 5
-            try:
-                proc.wait(timeout=wait_timeout)
-            except subprocess.TimeoutExpired:
-                log.warning("git archive process did not terminate gracefully, killing")
-                proc.kill()
-                proc.wait()
-    except Exception:
-        # proc.wait() already called in finally block, check if it failed
-        if proc.returncode != 0:
-            log.error("listing git files failed - pretending there aren't any")
+    if res.returncode:
+        log.error("listing git files failed - pretending there aren't any")
         return set(), set()
+
+    git_files: set[str] = set()
+    git_dirs: set[str] = {toplevel}
+    for name in res.stdout.rstrip("\0").split("\0"):
+        if not name:
+            continue
+        name = os.path.normcase(name).replace("/", os.path.sep)
+        fullname = os.path.join(toplevel, name)
+        git_files.add(fullname)
+        dirname = os.path.dirname(fullname)
+        while len(dirname) > len(toplevel) and dirname not in git_dirs:
+            git_dirs.add(dirname)
+            dirname = os.path.dirname(dirname)
+    return git_files, git_dirs
 
 
 def git_find_files(path: _t.PathT = "") -> list[str]:

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -346,6 +346,94 @@ def test_git_archive_run_from_subdirectory(
     assert vcs_versioning._file_finders.find_files(".") == [opj(".", "test1.txt")]
 
 
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/662")
+def test_git_added_but_uncommitted_files_visible(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wd.write("committed.txt", "test")
+    wd("git add committed.txt")
+    wd.commit()
+
+    wd.write("staged.txt", "test")
+    wd("git add staged.txt")
+    monkeypatch.chdir(wd.cwd)
+    found = set(vcs_versioning._file_finders.find_files("."))
+    assert opj(".", "staged.txt") in found
+    assert opj(".", "committed.txt") in found
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/662")
+def test_git_export_ignore_with_staged_files(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wd.write("keep.txt", "test")
+    wd.write("ignore.txt", "test")
+    wd.write(
+        ".gitattributes",
+        "/ignore.txt export-ignore\n",
+    )
+    wd("git add keep.txt ignore.txt .gitattributes")
+    wd.commit()
+
+    wd.write("new_staged.txt", "test")
+    wd("git add new_staged.txt")
+    monkeypatch.chdir(wd.cwd)
+    found = set(vcs_versioning._file_finders.find_files("."))
+    assert opj(".", "keep.txt") in found
+    assert opj(".", "new_staged.txt") in found
+    assert opj(".", "ignore.txt") not in found
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/662")
+def test_git_submodule_files_listed(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Create a separate repo to use as submodule
+    sub_src = wd.cwd.parent / "sub_src"
+    sub_src.mkdir()
+    subprocess.check_call(["git", "init", str(sub_src)])
+    subprocess.check_call(
+        ["git", "-C", str(sub_src), "config", "user.email", "test@example.com"]
+    )
+    subprocess.check_call(["git", "-C", str(sub_src), "config", "user.name", "test"])
+    (sub_src / "sub_file.txt").write_text("sub content", encoding="utf-8")
+    (sub_src / ".gitattributes").write_text(
+        "/sub_ignored.txt export-ignore\n", encoding="utf-8"
+    )
+    (sub_src / "sub_ignored.txt").write_text("ignored", encoding="utf-8")
+    subprocess.check_call(["git", "-C", str(sub_src), "add", "."])
+    subprocess.check_call(["git", "-C", str(sub_src), "commit", "-m", "init sub"])
+
+    # Add as submodule (allow file:// protocol for local clone)
+    wd.write("parent_file.txt", "parent content")
+    wd("git add parent_file.txt")
+    wd.commit()
+    wd(
+        [
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(sub_src),
+            "mysub",
+        ]
+    )
+    wd.commit()
+
+    monkeypatch.chdir(wd.cwd)
+    found = set(vcs_versioning._file_finders.find_files("."))
+
+    # Parent files present
+    assert opj(".", "parent_file.txt") in found
+    assert opj(".", ".gitmodules") in found
+    # Submodule files listed with correct prefixed paths
+    assert opj(".", "mysub", "sub_file.txt") in found
+    assert opj(".", "mysub", ".gitattributes") in found
+    # export-ignore honored inside submodule
+    assert opj(".", "mysub", "sub_ignored.txt") not in found
+
+
 @pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/728")
 def test_git_branch_names_correct(wd: WorkDir) -> None:
     wd.commit_testfile()


### PR DESCRIPTION
## Summary

- Replace `git archive HEAD | tarfile` with `git ls-files -z --recurse-submodules -- . ':(exclude,attr:export-ignore)'` for file discovery
- Fixes freshly `git add`-ed files being invisible to setuptools file discovery (#662)
- Adds native submodule support with correct prefixed paths
- Preserves `export-ignore` honoring via pathspec attr magic

## Background

The archive approach was originally added due to strange git parsing bugs and to honor `export-ignore`. The new approach:

- **`-z`** eliminates parsing issues (NUL-separated output, no quoting)
- **`:(exclude,attr:export-ignore)`** preserves export-ignore filtering without tar parsing
- **`--recurse-submodules`** lists files inside submodules (which `git archive` never did)
- **Index state** means staged files are visible immediately (fixes #662)

## Test plan

- [x] Existing `test_git_archive_export_ignore` passes (export-ignore still honored)
- [x] New `test_git_added_but_uncommitted_files_visible` verifies #662 fix
- [x] New `test_git_export_ignore_with_staged_files` verifies export-ignore with staged files
- [x] New `test_git_submodule_files_listed` verifies submodule paths and export-ignore inside submodules
- [x] All 486 vcs-versioning tests pass
- [x] All 167 setuptools-scm integration tests pass
- [x] Pre-commit (ruff, mypy, codespell) passes


Made with [Cursor](https://cursor.com)