### PR TITLE
fix: handle empty describe-name in git archivals from tagless repos

### DIFF
--- a/vcs-versioning/changelog.d/1288.bugfix.md
+++ b/vcs-versioning/changelog.d/1288.bugfix.md
@@ -1,0 +1,1 @@
+Fix git archivals from repositories with no tags failing to determine a version.

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -486,6 +486,8 @@ def archival_to_version(
     archival_describe = data.get("describe-name", DESCRIBE_UNSUPPORTED)
     if DESCRIBE_UNSUPPORTED in archival_describe:
         warnings.warn("git archive did not support describe output", stacklevel=2)
+    elif not archival_describe:
+        log.debug("describe-name is empty (no tags in repo), falling through")
     else:
         tag, number, node, _ = _git_parse_describe(archival_describe)
         return meta(

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -634,6 +634,7 @@ def test_git_getdate_signed_commit(signed_commit_wd: WorkDir) -> None:
             },
         ),
         ("0.0", {"node": "0" * 20}),
+        ("0.0", {"describe-name": "", "node": "0" * 20}),
         ("1.2.2", {"describe-name": "release-1.2.2-0-g00000"}),
         ("1.2.2.dev0", {"ref-names": "tag: release-1.2.2.dev"}),
         ("1.2.2", {"describe-name": "v1.2.2"}),


### PR DESCRIPTION
## Summary

- Fix git archivals from repositories with no tags failing with `AssertionError`
- When `describe-name` is empty (no tags → `git describe` produces nothing), fall through to the existing node-based fallback that produces version `0.0`
- Adds test case and changelog fragment

Fixes #1288

## Test plan

- [x] New parametrized test case: empty `describe-name` with `node` present → produces `0.0`
- [x] All existing archival tests still pass
- [x] Pre-commit (ruff, mypy, codespell) passes

Made with [Cursor](https://cursor.com)