### PR TITLE
feat: add write_to_source pyproject.toml option with deprecation cycle

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -165,6 +165,31 @@ Callables or other Python objects must be passed in `setup.py` (via the `use_scm
     `version_tuple` is a tuple of split numbers/strings and
     `scm_version` is the `ScmVersion` instance the current `version` was rendered from
 
+`write_to_source: bool | None = None`
+:   Controls whether version files (specified by `version_file` or `write_to`) are
+    written to the source tree during version inference.
+
+    | Value   | Behavior |
+    |---------|----------|
+    | unset   | Writes to source tree **and** emits a `DeprecationWarning` advising you to set this option explicitly, since the default will change in a future major release. |
+    | `true`  | Writes to source tree, no warning — explicit opt-in. |
+    | `false` | Does **not** write to source tree, no warning — explicit opt-out. Version files are still written to the build directory during `build_py`. |
+
+    The `SETUPTOOLS_SCM_WRITE_TO_SOURCE` environment variable overrides this setting
+    (see [Environment Variables](#environment-variables) below).
+
+    !!! note "Deprecation cycle"
+
+        In a future major release, the default will change from writing to source to
+        **not** writing to source. Set `write_to_source = true` now if you rely on
+        version files being present in your source tree.
+
+    ```toml title="pyproject.toml"
+    [tool.setuptools_scm]
+    version_file = "mypackage/_version.py"
+    write_to_source = true
+    ```
+
 ## setuptools-scm Specific Configuration
 
 These options control setuptools integration behavior.
@@ -233,6 +258,11 @@ These environment variables control setuptools-scm specific behavior.
 `SETUPTOOLS_SCM_OVERRIDES_FOR_${DIST_NAME}`
 :   A TOML inline table to override configuration from `pyproject.toml`.
     See the [overrides documentation](overrides.md#config-overrides) for details.
+
+`SETUPTOOLS_SCM_WRITE_TO_SOURCE`
+:   Override the `write_to_source` configuration option. Set to `1`/`true`/`yes`
+    to write version files to the source tree, or `0`/`false`/`no` to disable it.
+    When set, no deprecation warning is emitted regardless of the pyproject.toml setting.
 
 `SETUPTOOLS_SCM_SUBPROCESS_TIMEOUT`
 :   Override the subprocess timeout (default: 40 seconds).

--- a/setuptools-scm/changelog.d/1301.feature.md
+++ b/setuptools-scm/changelog.d/1301.feature.md
@@ -1,0 +1,1 @@
+Add `write_to_source` pyproject.toml option to control whether version files are written to the source tree. When unset, a deprecation warning advises setting it explicitly before the default changes in a future major release. The `SETUPTOOLS_SCM_WRITE_TO_SOURCE` environment variable overrides this setting.

--- a/setuptools-scm/src/setuptools_scm/_integration/version_inference.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/version_inference.py
@@ -29,12 +29,18 @@ _FALSY_VALUES = frozenset(("0", "false", "no"))
 def _should_write_to_source(config: _config.Configuration) -> bool:
     """Check if version files should be written to source at inference time.
 
-    Uses the config's environment (tool names + dist name) to read
-    ``WRITE_TO_SOURCE`` -- e.g. ``SETUPTOOLS_SCM_WRITE_TO_SOURCE``.
+    Resolution order:
 
-    Returns True by default.  Returns False only when the resolved value
-    is a falsy string (``"0"``, ``"false"``, ``"no"``).
+    1. **Environment variable** (``SETUPTOOLS_SCM_WRITE_TO_SOURCE`` /
+       ``VCS_VERSIONING_WRITE_TO_SOURCE``) — highest priority, no warning.
+    2. **pyproject.toml** ``write_to_source`` option — explicit opt-in/out,
+       no warning.
+    3. **Unset** (neither env var nor config) — write to source **and** emit
+       a ``DeprecationWarning`` advising the user to set the option
+       explicitly, since the default will change in the next major release.
     """
+    import warnings
+
     from vcs_versioning.overrides import EnvReader
 
     reader = EnvReader(
@@ -42,10 +48,25 @@ def _should_write_to_source(config: _config.Configuration) -> bool:
         env=os.environ,
         dist_name=config.dist_name,
     )
-    value = reader.read("WRITE_TO_SOURCE")
-    if value is None:
-        return True
-    return value.lower() not in _FALSY_VALUES
+    env_value = reader.read("WRITE_TO_SOURCE")
+
+    if env_value is not None:
+        return env_value.lower() not in _FALSY_VALUES
+
+    if config.write_to_source is not None:
+        return config.write_to_source
+
+    warnings.warn(
+        "setuptools-scm writes version files to the source tree by default, "
+        "but this will change in a future major release. "
+        "Set 'write_to_source = true' (to keep current behavior) or "
+        "'write_to_source = false' (to only write to the build directory) "
+        "in [tool.setuptools_scm] in pyproject.toml to silence this warning. "
+        "You can also set the SETUPTOOLS_SCM_WRITE_TO_SOURCE environment variable.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return True
 
 
 def infer_version_with_config(

--- a/setuptools-scm/testing_scm/test_version_inference.py
+++ b/setuptools-scm/testing_scm/test_version_inference.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 from types import SimpleNamespace
 from typing import Any
 
@@ -10,6 +12,7 @@ from setuptools_scm._integration.version_inference import VersionAlreadySetWarni
 from setuptools_scm._integration.version_inference import VersionInferenceConfig
 from setuptools_scm._integration.version_inference import VersionInferenceNoOp
 from setuptools_scm._integration.version_inference import VersionInferenceResult
+from setuptools_scm._integration.version_inference import _should_write_to_source
 from setuptools_scm._integration.version_inference import get_version_inference_config
 
 # Common test data
@@ -266,3 +269,78 @@ class TestVersionInferenceDecision:
             pyproject_data=pyproject_data,
             expected=WARNING_PACKAGE,
         )
+
+
+def _make_config(
+    write_to_source: bool | None = None,
+    tool_names: tuple[str, ...] = ("SETUPTOOLS_SCM", "VCS_VERSIONING"),
+) -> Any:
+    """Create a minimal Configuration-like object for _should_write_to_source tests."""
+    from vcs_versioning._config import Configuration
+    from vcs_versioning._environment import VcsEnvironment
+
+    env = VcsEnvironment(tool_names=tool_names)
+    config = Configuration(write_to_source=write_to_source, _env=env)
+    return config
+
+
+@pytest.mark.issue(1301)
+class TestShouldWriteToSource:
+    """Test the three-state write_to_source config + env var override."""
+
+    def test_config_true_writes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SETUPTOOLS_SCM_WRITE_TO_SOURCE", raising=False)
+        config = _make_config(write_to_source=True)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert _should_write_to_source(config) is True
+        assert not any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_config_false_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SETUPTOOLS_SCM_WRITE_TO_SOURCE", raising=False)
+        config = _make_config(write_to_source=False)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert _should_write_to_source(config) is False
+        assert not any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_config_unset_writes_with_deprecation_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SETUPTOOLS_SCM_WRITE_TO_SOURCE", raising=False)
+        monkeypatch.delenv("VCS_VERSIONING_WRITE_TO_SOURCE", raising=False)
+        config = _make_config(write_to_source=None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = _should_write_to_source(config)
+        assert result is True
+        dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warnings) == 1
+        assert "write_to_source" in str(dep_warnings[0].message)
+
+    @pytest.mark.parametrize("env_val", ["1", "true", "yes", "True", "YES"])
+    def test_env_var_truthy_overrides_config_false(
+        self, monkeypatch: pytest.MonkeyPatch, env_val: str
+    ) -> None:
+        monkeypatch.setenv("SETUPTOOLS_SCM_WRITE_TO_SOURCE", env_val)
+        config = _make_config(write_to_source=False)
+        assert _should_write_to_source(config) is True
+
+    @pytest.mark.parametrize("env_val", ["0", "false", "no", "False", "NO"])
+    def test_env_var_falsy_overrides_config_true(
+        self, monkeypatch: pytest.MonkeyPatch, env_val: str
+    ) -> None:
+        monkeypatch.setenv("SETUPTOOLS_SCM_WRITE_TO_SOURCE", env_val)
+        config = _make_config(write_to_source=True)
+        assert _should_write_to_source(config) is False
+
+    def test_env_var_set_suppresses_deprecation_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When env var is set, no deprecation warning even if config is unset."""
+        monkeypatch.setenv("SETUPTOOLS_SCM_WRITE_TO_SOURCE", "1")
+        config = _make_config(write_to_source=None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _should_write_to_source(config)
+        assert not any(issubclass(x.category, DeprecationWarning) for x in w)

--- a/vcs-versioning/src/vcs_versioning/_config.py
+++ b/vcs-versioning/src/vcs_versioning/_config.py
@@ -196,6 +196,19 @@ class Configuration:
 
     parent: _t.PathT | None = None
 
+    write_to_source: bool | None = None
+    """Whether to write version files to the source tree at inference time.
+
+    - ``None`` (default): write to source **and** emit a ``DeprecationWarning``
+      telling users to set this explicitly, since the default will change
+      in the next major release.
+    - ``True``: write to source tree, no warning.
+    - ``False``: do **not** write to source tree, no warning.
+
+    The ``SETUPTOOLS_SCM_WRITE_TO_SOURCE`` / ``VCS_VERSIONING_WRITE_TO_SOURCE``
+    environment variable overrides this setting.
+    """
+
     # Nested SCM configurations
     scm: ScmConfiguration = dataclasses.field(
         default_factory=lambda: ScmConfiguration()


### PR DESCRIPTION
## Summary

Implements #1301 — adds a `write_to_source` configuration option to `[tool.setuptools_scm]` in `pyproject.toml` with a deprecation cycle toward build-only version file writing.

- **`write_to_source = true`**: write version files to the source tree (explicit opt-in, no warning)
- **`write_to_source = false`**: skip source-tree writing (explicit opt-out, no warning)
- **Unset (default)**: write to source tree + emit a `DeprecationWarning` advising users to set the option explicitly, since the default will change in a future major release

The `SETUPTOOLS_SCM_WRITE_TO_SOURCE` environment variable remains the highest-priority override and suppresses any deprecation warning when set.

### Changes

- `vcs-versioning/src/vcs_versioning/_config.py`: Add `write_to_source: bool | None` field to `Configuration`
- `setuptools-scm/src/setuptools_scm/_integration/version_inference.py`: Update `_should_write_to_source()` with three-state resolution (env var > config > default-with-warning)
- `setuptools-scm/testing_scm/test_version_inference.py`: Add `TestShouldWriteToSource` covering all config/env combinations
- `docs/config.md`: Document the new option and the env var
- `setuptools-scm/changelog.d/1301.feature.md`: Towncrier fragment

## Test plan

- [x] `TestShouldWriteToSource::test_config_true_writes` — config true writes without warning
- [x] `TestShouldWriteToSource::test_config_false_skips` — config false skips without warning
- [x] `TestShouldWriteToSource::test_config_unset_writes_with_deprecation_warning` — unset emits DeprecationWarning
- [x] `TestShouldWriteToSource::test_env_var_truthy_overrides_config_false` — env var overrides config
- [x] `TestShouldWriteToSource::test_env_var_falsy_overrides_config_true` — env var overrides config
- [x] `TestShouldWriteToSource::test_env_var_set_suppresses_deprecation_warning` — env var suppresses warning
- [x] Full test suite: 669 passed, pre-commit clean

Closes #1301


Made with [Cursor](https://cursor.com)