### PR TITLE
docs: add missing changelog fragment for #1364

### DIFF
--- a/setuptools-scm/changelog.d/1364.bugfix.md
+++ b/setuptools-scm/changelog.d/1364.bugfix.md
@@ -1,0 +1,1 @@
+Skip writing non-package version files to build_lib, fixing incorrect inclusion of root-level version files in wheels.


### PR DESCRIPTION
## Summary

- Adds missing towncrier changelog fragment for issue #1364 (root-level version files incorrectly included in wheels), which was fixed in PR #1403 but lacked a fragment.

## Test plan

- [x] Fragment follows naming convention (`1364.bugfix.md`)
- [x] Pre-commit hooks pass

Made with [Cursor](https://cursor.com)