### PR TITLE
fix(ci): set pretend versions on release PRs to fix wheel builds

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -44,6 +44,46 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set pretend versions from release PR title
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            console.log(`PR title: ${title}`);
+
+            const scmMatch = title.match(/setuptools-scm v(\d+\.\d+\.\d+)/);
+            const vcsMatch = title.match(/vcs-versioning v(\d+\.\d+\.\d+)/);
+
+            if (!scmMatch && !vcsMatch) {
+              console.log('No release versions in PR title (normal for non-release PRs)');
+              return;
+            }
+
+            const fs = require('fs');
+            const envFile = process.env.GITHUB_ENV;
+
+            if (scmMatch) {
+              const ver = `${scmMatch[1]}.dev0`;
+              fs.appendFileSync(envFile, `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SETUPTOOLS_SCM=${ver}\n`);
+              console.log(`Set setuptools-scm pretend version: ${ver}`);
+            }
+            if (vcsMatch) {
+              const ver = `${vcsMatch[1]}.dev0`;
+              fs.appendFileSync(envFile, `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VCS_VERSIONING=${ver}\n`);
+              fs.appendFileSync(envFile, `VCS_VERSIONING_PRETEND_VERSION_FOR_VCS_VERSIONING=${ver}\n`);
+              console.log(`Set vcs-versioning pretend version: ${ver}`);
+            }
+
+      - name: Debug version inference
+        shell: bash
+        run: |
+          echo "=== Version Debug for ${{ matrix.package }} ==="
+          echo "Git describe:"
+          git describe --dirty --tags --long --match "${{ matrix.package }}-*" 2>&1 || echo "(no matching tags)"
+          echo "Relevant PRETEND env vars:"
+          env | grep -i PRETEND || echo "(none set)"
+
       - name: Build ${{ matrix.package }}
         uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         with:
@@ -131,10 +171,10 @@ jobs:
       - name: Install built wheels
         shell: bash
         run: |
-          # Install vcs-versioning first (dependency of setuptools-scm)
-          uv pip install dist/vcs_versioning-*.whl
-          # Then install setuptools-scm
-          uv pip install dist/setuptools_scm-*.whl
+          # Use --no-deps: uv sync already resolved all dependencies from workspace;
+          # we just replace the editable installs with the built wheels.
+          uv pip install --no-deps dist/vcs_versioning-*.whl
+          uv pip install --no-deps dist/setuptools_scm-*.whl
       - run: |
           $(hg debuginstall --template "{pythonexe}") -m pip install hg-git --user
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
## Summary

- Extract release versions from PR title on release branch PRs and set `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_*` env vars before building wheels
- Add version debugging step that logs `git describe` and pretend env vars before builds
- Use `--no-deps` for wheel install in test job (uv sync already resolves workspace deps)

## Problem

On `release/develop`, towncrier removes changelog fragments. The `towncrier-fragments` version scheme falls back to `guess-next-dev` (patch bump), producing wrong versions:
- vcs-versioning: `1.1.2.dev173` instead of `2.0.0.devN`
- setuptools-scm: `10.0.6.dev181` instead of `10.1.0.devN`

This breaks the test job because `setuptools-scm` requires `vcs-versioning>=2.0.0.dev0` but the built wheel is only `1.1.2.dev173`.

## Fix

The release PR title already contains the correct versions (e.g. `Release: setuptools-scm v10.1.0, vcs-versioning v2.0.0`). A `github-script` step now extracts these and sets pretend version env vars so the build produces correctly-versioned wheels.

## Test plan

- [ ] Release PR (`release/develop`) CI should now pass the package build + install steps
- [ ] Non-release PRs should be unaffected (step is a no-op when title doesn't match)
- [ ] Tagged builds (workflow_dispatch) still use `version.exact` and don't need pretend versions

Made with [Cursor](https://cursor.com)