### PR TITLE
fix: add dist_name to setup.py get_version() calls

### DIFF
--- a/setuptools-scm/setup.py
+++ b/setuptools-scm/setup.py
@@ -41,6 +41,7 @@ def _package_version() -> str:
         local_scheme=local_scheme,
         tag_regex=r"^setuptools-scm-(?P<version>v?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
         scm={"git": {"describe_command": make_describe_command("setuptools-scm-*")}},
+        dist_name="setuptools-scm",
     )
 
 

--- a/vcs-versioning/setup.py
+++ b/vcs-versioning/setup.py
@@ -79,6 +79,7 @@ def _package_version() -> str:
         scm={
             "git": {"describe_command": git.make_describe_command("vcs-versioning-*")}
         },
+        dist_name="vcs-versioning",
         fallback_version="0.1.1+pre.tag",
     )
 


### PR DESCRIPTION
## Summary

- Add `dist_name="vcs-versioning"` to `vcs-versioning/setup.py`'s `get_version()` call
- Add `dist_name="setuptools-scm"` to `setuptools-scm/setup.py`'s `get_version()` call

## Problem

PR #1418 added a github-script step that sets `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SETUPTOOLS_SCM` and `VCS_VERSIONING_PRETEND_VERSION_FOR_VCS_VERSIONING` env vars on release PRs. However, these were silently ignored because both `setup.py` files call `get_version()` without `dist_name`.

Without `dist_name`, the `EnvReader` only checks generic env vars (`SETUPTOOLS_SCM_PRETEND_VERSION`, `VCS_VERSIONING_PRETEND_VERSION`) and never looks for the `_FOR_*` variants.

## Fix

Pass `dist_name` so the `_FOR_VCS_VERSIONING` / `_FOR_SETUPTOOLS_SCM` env vars are properly discovered during PEP 517 builds.

## Test plan

- [ ] Release PR CI should now honor pretend versions and build correct wheel versions
- [ ] Normal builds (develop, feature branches) unaffected — pretend vars not set, so dist_name is irrelevant

Made with [Cursor](https://cursor.com)