### PR TITLE
fix(ci): update PyPy 3.10 to PyPy 3.11 in test matrix

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [ '3.10', '3.11', '3.12', '3.13', 'pypy-3.10' ]
+        python_version: [ '3.10', '3.11', '3.12', '3.13', 'pypy-3.11' ]
         os: [windows-latest, ubuntu-latest] #, macos-latest]
         include:
         - os: windows-latest

--- a/setuptools-scm/changelog.d/1421.bugfix.md
+++ b/setuptools-scm/changelog.d/1421.bugfix.md
@@ -1,0 +1,1 @@
+Update CI to use PyPy 3.11 as cryptography has no PyPy 3.10 build available

--- a/vcs-versioning/changelog.d/1421.bugfix.md
+++ b/vcs-versioning/changelog.d/1421.bugfix.md
@@ -1,0 +1,1 @@
+Update CI to use PyPy 3.11 as cryptography has no PyPy 3.10 build available


### PR DESCRIPTION
## Summary
- Update CI test matrix from PyPy 3.10 to PyPy 3.11 since cryptography has no build available for PyPy 3.10
- Add bugfix changelog entries for both packages

## Test plan
- [ ] CI passes with PyPy 3.11

Made with [Cursor](https://cursor.com)