### PR TITLE
Fix DeprecationWarning leak in pretend API (#1424)

### DIFF
--- a/setuptools-scm/changelog.d/1424.bugfix.md
+++ b/setuptools-scm/changelog.d/1424.bugfix.md
@@ -1,0 +1,1 @@
+Fix DeprecationWarning leak by threading VcsEnvironment through VersionInferenceConfig and using env.make_reader() in _should_write_to_source.

--- a/setuptools-scm/src/setuptools_scm/_integration/version_inference.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/version_inference.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -42,13 +41,7 @@ def _should_write_to_source(config: _config.Configuration) -> bool:
     """
     import warnings
 
-    from vcs_versioning.overrides import EnvReader
-
-    reader = EnvReader(
-        tools_names=config.env.tool_names,
-        env=os.environ,
-        dist_name=config.dist_name,
-    )
+    reader = config.env.make_reader(config.dist_name)
     env_value = reader.read("WRITE_TO_SOURCE")
 
     if env_value is not None:
@@ -173,6 +166,7 @@ class VersionInferenceConfig:
     dist_name: str | None
     pyproject_data: PyProjectData | None
     overrides: dict[str, Any] | None
+    env: VcsEnvironment | None = None
 
     def apply(self, dist: Distribution) -> None:
         """Apply version inference to the distribution.
@@ -185,6 +179,7 @@ class VersionInferenceConfig:
             self.dist_name,
             self.pyproject_data,  # type: ignore[arg-type]
             self.overrides,
+            env=self.env,
         )
         # When normalize=False, wrap in setuptools.sic() to prevent
         # setuptools' _normalize_version from re-normalizing (stripping

--- a/setuptools-scm/src/setuptools_scm/_integration/version_inference.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/version_inference.py
@@ -16,6 +16,7 @@ from vcs_versioning._version_cls import NonNormalizedVersion
 
 if TYPE_CHECKING:
     from vcs_versioning import _config
+    from vcs_versioning._environment import VcsEnvironment
 
 from .build_py import VersionInferenceData
 from .build_py import set_version_inference_data
@@ -73,6 +74,8 @@ def infer_version_with_config(
     dist_name: str | None,
     pyproject_data: PyProjectData,
     overrides: dict[str, Any] | None = None,
+    *,
+    env: VcsEnvironment | None = None,
 ) -> VersionInferenceData:
     """Infer version and return VersionInferenceData.
 
@@ -88,7 +91,7 @@ def infer_version_with_config(
     Returns:
         VersionInferenceData containing version, Configuration, ScmVersion, and workdir
     """
-    from vcs_versioning._environment import VcsEnvironment
+    from vcs_versioning._environment import VcsEnvironment as _VcsEnvironment
     from vcs_versioning._get_version_impl import _version_missing
     from vcs_versioning._get_version_impl import write_version_files
     from vcs_versioning._legacy_parse import has_legacy_parse_eps
@@ -98,7 +101,8 @@ def infer_version_with_config(
     from vcs_versioning._overrides import _read_pretended_version_for
     from vcs_versioning._version_schemes import format_version
 
-    env = VcsEnvironment.from_env("SETUPTOOLS_SCM")
+    if env is None:
+        env = _VcsEnvironment.from_env("SETUPTOOLS_SCM")
     config = env.build_config(
         dist_name=dist_name, pyproject_data=pyproject_data, **(overrides or {})
     )
@@ -235,6 +239,7 @@ def infer_version_string(
     overrides: dict[str, Any] | None = None,
     *,
     force_write_version_files: bool = False,
+    env: VcsEnvironment | None = None,
 ) -> str:
     """
     Compute the inferred version string from the given inputs without requiring a
@@ -246,20 +251,25 @@ def infer_version_string(
         pyproject_data: Parsed PyProjectData (may be constructed via for_testing())
         overrides: Optional override configuration (same keys as [tool.setuptools_scm])
         force_write_version_files: When True, apply write_to/version_file effects
+        env: Optional VcsEnvironment. If None, resolves one with SETUPTOOLS_SCM prefix.
 
     Returns:
         The computed version string.
     """
+    from vcs_versioning._environment import VcsEnvironment as _VcsEnvironment
     from vcs_versioning._version_inference import (
         infer_version_string as _vcs_infer_version_string,
     )
 
-    # Delegate to vcs_versioning implementation
+    if env is None:
+        env = _VcsEnvironment.from_env("SETUPTOOLS_SCM")
+
     return _vcs_infer_version_string(
         dist_name,
         pyproject_data,
         overrides,
         force_write_version_files=force_write_version_files,
+        env=env,
     )
 
 

--- a/vcs-versioning/changelog.d/1424.bugfix.md
+++ b/vcs-versioning/changelog.d/1424.bugfix.md
@@ -1,0 +1,1 @@
+Fix DeprecationWarning leak in pretend API by ensuring all public APIs attach VcsEnvironment to Configuration before accessing env-dependent properties.

--- a/vcs-versioning/changelog.d/1424.feature.md
+++ b/vcs-versioning/changelog.d/1424.feature.md
@@ -1,0 +1,1 @@
+Add `VcsEnvironment.build_config_from_pyproject`, `build_config_from_data`, and `pyproject_tool_names` methods for canonical env-first configuration creation.

--- a/vcs-versioning/src/vcs_versioning/__init__.py
+++ b/vcs-versioning/src/vcs_versioning/__init__.py
@@ -91,12 +91,14 @@ def build_configuration_from_pyproject(
     This allows integrators to provide their own transformations
     while still respecting user environment variable overrides.
     """
-    from ._integrator_helpers import build_configuration_from_pyproject_internal
+    from ._environment import resolve_runtime_env
 
-    return build_configuration_from_pyproject_internal(
+    if env is None:
+        env = resolve_runtime_env()
+
+    return env.build_config_from_pyproject(
         pyproject_data=pyproject_data,
         dist_name=dist_name,
-        env=env,
         **integrator_overrides,
     )
 

--- a/vcs-versioning/src/vcs_versioning/__init__.py
+++ b/vcs-versioning/src/vcs_versioning/__init__.py
@@ -25,6 +25,7 @@ def build_configuration_from_pyproject(
     pyproject_data: PyProjectData,
     *,
     dist_name: str | None = None,
+    env: VcsEnvironment | None = None,
     **integrator_overrides: Any,
 ) -> Configuration:
     """Build Configuration from PyProjectData with full workflow.
@@ -36,7 +37,7 @@ def build_configuration_from_pyproject(
     2. Determine dist_name (argument > pyproject.project_name)
     3. Apply integrator overrides (override config file)
     4. Apply environment TOML overrides (highest priority)
-    5. Create and validate Configuration instance
+    5. Create and validate Configuration instance with VcsEnvironment attached
 
     Integrators create PyProjectData themselves:
 
@@ -73,6 +74,8 @@ def build_configuration_from_pyproject(
     Args:
         pyproject_data: Parsed pyproject data (integrator creates this)
         dist_name: Distribution name (overrides pyproject_data.project_name)
+        env: Optional VcsEnvironment. If None, resolves from the active
+             GlobalOverrides context or process environment.
         **integrator_overrides: Integrator-provided config overrides
                                (override config file, but overridden by env)
 
@@ -93,6 +96,7 @@ def build_configuration_from_pyproject(
     return build_configuration_from_pyproject_internal(
         pyproject_data=pyproject_data,
         dist_name=dist_name,
+        env=env,
         **integrator_overrides,
     )
 

--- a/vcs-versioning/src/vcs_versioning/_config.py
+++ b/vcs-versioning/src/vcs_versioning/_config.py
@@ -487,9 +487,12 @@ class Configuration:
         args.update(project_overrides)
 
         # Env overrides: highest priority
-        args.update(
-            read_toml_overrides(args["dist_name"], tool_names=tool_names, env=env)
-        )
+        if _env is not None:
+            args.update(_env.read_toml_overrides(args["dist_name"]))
+        else:
+            args.update(
+                read_toml_overrides(args["dist_name"], tool_names=tool_names, env=env)
+            )
         return cls.from_data(relative_to=relative_to, data=args, _env=_env)
 
     @classmethod

--- a/vcs-versioning/src/vcs_versioning/_config.py
+++ b/vcs-versioning/src/vcs_versioning/_config.py
@@ -450,6 +450,7 @@ class Configuration:
         *,
         tool_names: tuple[str, ...] | None = None,
         env: Mapping[str, str] | None = None,
+        _env: VcsEnvironment | None = None,
         **kwargs: Any,
     ) -> Configuration:
         """
@@ -462,6 +463,7 @@ class Configuration:
         - dist_name: name of the distribution
         - tool_names: env-var prefix order for TOML overrides
         - env: environment mapping for TOML overrides (default: os.environ)
+        - _env: VcsEnvironment to attach to the resulting Configuration
         - **kwargs: additional keyword arguments to pass to the Configuration constructor
         """
 
@@ -488,11 +490,14 @@ class Configuration:
         args.update(
             read_toml_overrides(args["dist_name"], tool_names=tool_names, env=env)
         )
-        return cls.from_data(relative_to=relative_to, data=args)
+        return cls.from_data(relative_to=relative_to, data=args, _env=_env)
 
     @classmethod
     def from_data(
-        cls, relative_to: str | os.PathLike[str], data: dict[str, Any]
+        cls,
+        relative_to: str | os.PathLike[str],
+        data: dict[str, Any],
+        _env: VcsEnvironment | None = None,
     ) -> Configuration:
         """
         given configuration data
@@ -526,6 +531,7 @@ class Configuration:
             version_cls=version_cls,
             tag=tag_config,
             scm=scm_config,
+            _env=_env,
             **data,
         )
 

--- a/vcs-versioning/src/vcs_versioning/_environment.py
+++ b/vcs-versioning/src/vcs_versioning/_environment.py
@@ -251,3 +251,69 @@ class VcsEnvironment:
             tool_names=self.tool_names, env=self._env, _env=self, **kwargs
         )
         return config
+
+    def build_config_from_data(
+        self,
+        relative_to: str | os.PathLike[str],
+        data: dict[str, Any],
+    ) -> _config.Configuration:
+        """Create a ``Configuration`` from pre-assembled data dict.
+
+        Use this when you have already extracted and merged configuration
+        data (e.g. from pyproject section + overrides) and want to build
+        a validated Configuration without re-reading files.
+        """
+        from ._config import Configuration
+
+        return Configuration.from_data(relative_to=relative_to, data=data, _env=self)
+
+    def build_config_from_pyproject(
+        self,
+        pyproject_data: Any,
+        *,
+        dist_name: str | None = None,
+        **integrator_overrides: Any,
+    ) -> _config.Configuration:
+        """Create a ``Configuration`` from PyProjectData with full workflow.
+
+        Canonical entry point for integrators. Orchestrates:
+        1. Extract config from pyproject_data.section
+        2. Determine dist_name
+        3. Apply integrator overrides
+        4. Apply environment TOML overrides
+        5. Build and validate Configuration with this env attached
+        """
+        from ._integrator_helpers import build_configuration_from_pyproject_internal
+
+        return build_configuration_from_pyproject_internal(
+            pyproject_data=pyproject_data,
+            dist_name=dist_name,
+            env=self,
+            **integrator_overrides,
+        )
+
+    def pyproject_tool_names(self) -> list[str]:
+        """Derive TOML section names from env-var prefixes.
+
+        Maps env-var prefixes to their canonical pyproject [tool.X] section
+        names. The ``VCS_VERSIONING`` prefix always maps to ``vcs-versioning``
+        (with dash). Other prefixes are lowercased with underscores preserved.
+
+        Examples:
+            - ``SETUPTOOLS_SCM`` -> ``setuptools_scm``
+            - ``VCS_VERSIONING`` -> ``vcs-versioning``
+            - ``HATCH_VCS`` -> ``hatch_vcs``
+
+        .. todo::
+            This uses special-case mapping (VCS_VERSIONING -> vcs-versioning).
+            The tool names should be made properly configurable via an explicit
+            mapping parameter on VcsEnvironment rather than guessing from
+            env-var prefix casing conventions.
+        """
+        result: list[str] = []
+        for name in self.tool_names:
+            if name == "VCS_VERSIONING":
+                result.append("vcs-versioning")
+            else:
+                result.append(name.lower())
+        return result

--- a/vcs-versioning/src/vcs_versioning/_environment.py
+++ b/vcs-versioning/src/vcs_versioning/_environment.py
@@ -248,7 +248,6 @@ class VcsEnvironment:
         from ._config import Configuration
 
         config = Configuration.from_file(
-            tool_names=self.tool_names, env=self._env, **kwargs
+            tool_names=self.tool_names, env=self._env, _env=self, **kwargs
         )
-        object.__setattr__(config, "_env", self)
         return config

--- a/vcs-versioning/src/vcs_versioning/_environment.py
+++ b/vcs-versioning/src/vcs_versioning/_environment.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     from pytest import MonkeyPatch
 
-    from . import _config, overrides
+    from . import _config, _overrides, overrides
 
 log = logging.getLogger(__name__)
 
@@ -317,3 +317,17 @@ class VcsEnvironment:
             else:
                 result.append(name.lower())
         return result
+
+    def read_toml_overrides(
+        self, dist_name: str | None
+    ) -> _overrides.ConfigOverridesDict:
+        """Read TOML config overrides from environment variables.
+
+        Uses this environment's tool_names and env dict, delegating to
+        the standalone ``read_toml_overrides`` function.
+        """
+        from ._overrides import read_toml_overrides as _read_toml_overrides
+
+        return _read_toml_overrides(
+            dist_name, tool_names=self.tool_names, env=self._env
+        )

--- a/vcs-versioning/src/vcs_versioning/_integrator_helpers.py
+++ b/vcs-versioning/src/vcs_versioning/_integrator_helpers.py
@@ -72,7 +72,6 @@ def build_configuration_from_pyproject_internal(
     # Import here to avoid circular dependencies
     from ._config import Configuration
     from ._environment import resolve_runtime_env
-    from ._overrides import read_toml_overrides
     from ._pyproject_reading import get_args_for_pyproject
 
     if env is None:
@@ -104,9 +103,7 @@ def build_configuration_from_pyproject_internal(
         config_data.update(integrator_overrides)
 
     # Step 4: Apply environment TOML overrides (highest priority)
-    env_overrides = read_toml_overrides(
-        actual_dist_name, tool_names=env.tool_names, env=env._env
-    )
+    env_overrides = env.read_toml_overrides(actual_dist_name)
     if env_overrides:
         log.debug("Applying environment TOML overrides: %s", list(env_overrides.keys()))
         config_data.update(env_overrides)

--- a/vcs-versioning/src/vcs_versioning/_integrator_helpers.py
+++ b/vcs-versioning/src/vcs_versioning/_integrator_helpers.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ._config import Configuration
+    from ._environment import VcsEnvironment
     from ._pyproject_reading import PyProjectData
 
 log = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ def build_configuration_from_pyproject_internal(
     pyproject_data: PyProjectData,
     *,
     dist_name: str | None = None,
+    env: VcsEnvironment | None = None,
     **integrator_overrides: Any,
 ) -> Configuration:
     """Build Configuration with complete workflow orchestration.
@@ -34,7 +36,7 @@ def build_configuration_from_pyproject_internal(
     2. Determine dist_name (argument > pyproject.project_name)
     3. Merge integrator overrides (override config file)
     4. Read and apply env TOML overrides (highest priority)
-    5. Build Configuration with proper validation
+    5. Build Configuration with proper validation and VcsEnvironment attached
 
     Priority order (highest to lowest):
         1. Environment TOML overrides (TOOL_OVERRIDES_FOR_DIST, TOOL_OVERRIDES)
@@ -45,6 +47,8 @@ def build_configuration_from_pyproject_internal(
     Args:
         pyproject_data: Parsed pyproject data from PyProjectData.from_file() or manual composition
         dist_name: Distribution name for env var lookups (overrides pyproject_data.project_name)
+        env: Optional VcsEnvironment. If None, resolves from the active
+             GlobalOverrides context or process environment.
         **integrator_overrides: Integrator-provided config overrides
                                (override config file, but overridden by env)
 
@@ -67,8 +71,12 @@ def build_configuration_from_pyproject_internal(
     """
     # Import here to avoid circular dependencies
     from ._config import Configuration
+    from ._environment import resolve_runtime_env
     from ._overrides import read_toml_overrides
     from ._pyproject_reading import get_args_for_pyproject
+
+    if env is None:
+        env = resolve_runtime_env()
 
     # Step 1: Get base config from pyproject section
     # This also handles dist_name resolution
@@ -96,8 +104,9 @@ def build_configuration_from_pyproject_internal(
         config_data.update(integrator_overrides)
 
     # Step 4: Apply environment TOML overrides (highest priority)
-    tool_names = (pyproject_data.tool_name.upper().replace("-", "_"),)
-    env_overrides = read_toml_overrides(actual_dist_name, tool_names=tool_names)
+    env_overrides = read_toml_overrides(
+        actual_dist_name, tool_names=env.tool_names, env=env._env
+    )
     if env_overrides:
         log.debug("Applying environment TOML overrides: %s", list(env_overrides.keys()))
         config_data.update(env_overrides)
@@ -106,7 +115,7 @@ def build_configuration_from_pyproject_internal(
     relative_to = pyproject_data.path
     log.debug("Building Configuration with relative_to=%s", relative_to)
 
-    return Configuration.from_data(relative_to=relative_to, data=config_data)
+    return Configuration.from_data(relative_to=relative_to, data=config_data, _env=env)
 
 
 __all__ = [

--- a/vcs-versioning/src/vcs_versioning/_overrides.py
+++ b/vcs-versioning/src/vcs_versioning/_overrides.py
@@ -153,18 +153,18 @@ def _read_pretended_metadata_for(
     Returns a dictionary with metadata field overrides like:
     {"node": "g1337beef", "distance": 4}
     """
-    from .overrides import EnvReader
-
-    if env is None:
-        env = config.env._env
-
     log.debug("dist name: %s", config.dist_name)
 
-    reader = EnvReader(
-        tools_names=config.env.tool_names,
-        env=env,
-        dist_name=config.dist_name,
-    )
+    if env is None:
+        reader = config.env.make_reader(config.dist_name)
+    else:
+        from .overrides import EnvReader
+
+        reader = EnvReader(
+            tools_names=config.env.tool_names,
+            env=env,
+            dist_name=config.dist_name,
+        )
 
     try:
         metadata_overrides = reader.read_toml(
@@ -259,18 +259,18 @@ def _read_pretended_version_for(
     tries ``SETUPTOOLS_SCM_PRETEND_VERSION``
     and ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_$UPPERCASE_DIST_NAME``
     """
-    from .overrides import EnvReader
-
-    if env is None:
-        env = config.env._env
-
     log.debug("dist name: %s", config.dist_name)
 
-    reader = EnvReader(
-        tools_names=config.env.tool_names,
-        env=env,
-        dist_name=config.dist_name,
-    )
+    if env is None:
+        reader = config.env.make_reader(config.dist_name)
+    else:
+        from .overrides import EnvReader
+
+        reader = EnvReader(
+            tools_names=config.env.tool_names,
+            env=env,
+            dist_name=config.dist_name,
+        )
     pretended = reader.read("PRETEND_VERSION")
 
     if pretended:

--- a/vcs-versioning/src/vcs_versioning/_version_inference.py
+++ b/vcs-versioning/src/vcs_versioning/_version_inference.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from ._environment import VcsEnvironment
     from ._pyproject_reading import PyProjectData
 
 
@@ -14,6 +15,7 @@ def infer_version_string(
     overrides: dict[str, Any] | None = None,
     *,
     force_write_version_files: bool = False,
+    env: VcsEnvironment | None = None,
 ) -> str:
     """
     Compute the inferred version string from the given inputs.
@@ -27,6 +29,8 @@ def infer_version_string(
         pyproject_data: Parsed PyProjectData (may be constructed via for_testing())
         overrides: Optional override configuration (same keys as [tool.setuptools_scm])
         force_write_version_files: When True, apply write_to/version_file effects
+        env: Optional VcsEnvironment. If None, resolves from the active
+             GlobalOverrides context or process environment.
 
     Returns:
         The computed version string.
@@ -34,10 +38,13 @@ def infer_version_string(
     Raises:
         SystemExit: If version cannot be determined (via _version_missing)
     """
-    from ._config import Configuration
+    from ._environment import resolve_runtime_env
     from ._get_version_impl import _get_version, _version_missing
 
-    config = Configuration.from_file(
+    if env is None:
+        env = resolve_runtime_env()
+
+    config = env.build_config(
         dist_name=dist_name, pyproject_data=pyproject_data, **(overrides or {})
     )
 

--- a/vcs-versioning/testing_vcs/test_chain_api.py
+++ b/vcs-versioning/testing_vcs/test_chain_api.py
@@ -304,3 +304,106 @@ class TestFrozenLegacyConfig:
         frozen = FrozenLegacyConfig(config)
         with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
             frozen.version_scheme = "something"  # type: ignore[attr-defined]
+
+
+class TestInferVersionStringEnv:
+    """Tests that infer_version_string properly resolves and attaches VcsEnvironment."""
+
+    def _pyproject(self) -> PyProjectData:
+        return PyProjectData.for_testing(
+            tool_name="vcs-versioning",
+            is_required=True,
+            section_present=True,
+            project_present=True,
+            project_name="test-pkg",
+        )
+
+    def test_no_deprecation_warning_with_pretend_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """infer_version_string must not leak DeprecationWarning for missing env."""
+        import warnings
+
+        from vcs_versioning._version_inference import infer_version_string
+
+        monkeypatch.setenv("SETUPTOOLS_SCM_PRETEND_VERSION", "1.2.3")
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", category=DeprecationWarning)
+            result = infer_version_string("test-pkg", self._pyproject())
+
+        assert result == "1.2.3"
+
+    def test_resolves_env_from_global_overrides_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """infer_version_string respects the active GlobalOverrides context."""
+        from vcs_versioning._version_inference import infer_version_string
+
+        monkeypatch.setenv("MYTOOL_PRETEND_VERSION", "9.8.7")
+
+        with GlobalOverrides.from_env("MYTOOL"):
+            result = infer_version_string("test-pkg", self._pyproject())
+
+        assert result == "9.8.7"
+
+    def test_accepts_explicit_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """infer_version_string uses an explicitly passed VcsEnvironment."""
+        from vcs_versioning._version_inference import infer_version_string
+
+        env_mapping = {"VCS_VERSIONING_PRETEND_VERSION": "4.5.6"}
+        env = VcsEnvironment.from_env(env=env_mapping)
+
+        result = infer_version_string("test-pkg", self._pyproject(), env=env)
+        assert result == "4.5.6"
+
+
+class TestBuildConfigurationFromPyprojectEnv:
+    """Tests that build_configuration_from_pyproject attaches VcsEnvironment."""
+
+    def _pyproject(self) -> PyProjectData:
+        return PyProjectData.for_testing(
+            tool_name="vcs-versioning",
+            is_required=True,
+            section_present=True,
+            project_present=True,
+            project_name="test-pkg",
+        )
+
+    def test_no_deprecation_warning(self) -> None:
+        """build_configuration_from_pyproject must not leak DeprecationWarning."""
+        import warnings
+
+        from vcs_versioning import build_configuration_from_pyproject
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", category=DeprecationWarning)
+            config = build_configuration_from_pyproject(
+                self._pyproject(), dist_name="test-pkg"
+            )
+
+        assert config._env is not None
+
+    def test_resolves_env_from_global_overrides_context(self) -> None:
+        """build_configuration_from_pyproject uses active GlobalOverrides."""
+        from vcs_versioning import build_configuration_from_pyproject
+
+        with GlobalOverrides.from_env("MYTOOL", env={}):
+            config = build_configuration_from_pyproject(
+                self._pyproject(), dist_name="test-pkg"
+            )
+
+        assert config._env is not None
+        assert "MYTOOL" in config._env.tool_names
+
+    def test_accepts_explicit_env(self) -> None:
+        """build_configuration_from_pyproject passes explicit env through."""
+        from vcs_versioning import build_configuration_from_pyproject
+
+        env = VcsEnvironment.from_env("CUSTOM", env={})
+
+        config = build_configuration_from_pyproject(
+            self._pyproject(), dist_name="test-pkg", env=env
+        )
+
+        assert config._env is env


### PR DESCRIPTION
## Summary

- Ensure all public APIs (`infer_version_string`, `build_configuration_from_pyproject`) attach a `VcsEnvironment` to `Configuration` before accessing env-dependent properties, eliminating the "Configuration was created without VcsEnvironment" `DeprecationWarning` leak
- Add canonical env-first factory methods to `VcsEnvironment`: `build_config_from_data`, `build_config_from_pyproject`, `pyproject_tool_names`, and `read_toml_overrides`
- Thread `VcsEnvironment` through `VersionInferenceConfig` and fix `_should_write_to_source` to use `config.env.make_reader()`

Closes #1424
Follow-up cleanup tracked in #1425

## Test plan

- [x] All 701 tests pass (`uv run pytest -n12`)
- [x] Pre-commit (ruff, mypy strict, codespell) passes
- [x] New unit tests in `test_chain_api.py` verify no DeprecationWarning leak from public APIs
- [ ] CI green on all platforms


Made with [Cursor](https://cursor.com)