### PR TITLE
fix: add backward-compat shim for parse_version (#1423)

### DIFF
--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=77.0.3",
-  "vcs-versioning>=2.0.0.dev0",
+  "vcs-versioning>=2.0.0.dev0,<3",
   # https://github.com/pypa/setuptools-scm/issues/1222: was <=2.0.2 for #1090 (old pip+toml);
   # pip 21.2+ vendors tomli, so the workaround is no longer needed.
   'tomli>=1; python_version < "3.11"',
@@ -37,7 +37,8 @@ dynamic = [
 ]
 dependencies = [
   # Core VCS functionality - workspace dependency
-  "vcs-versioning>=2.0.0.dev0",
+  # Upper pin: setuptools-scm imports vcs-versioning internals; keep in sync.
+  "vcs-versioning>=2.0.0.dev0,<3",
   "packaging>=20",
   # https://github.com/pypa/setuptools-scm/issues/1112 - re-pin in a breaking release
   "setuptools", # >= 61",

--- a/vcs-versioning/src/vcs_versioning/_get_version_impl.py
+++ b/vcs-versioning/src/vcs_versioning/_get_version_impl.py
@@ -29,6 +29,18 @@ EMPTY_TAG_REGEX_DEPRECATION = DeprecationWarning(
 log = logging.getLogger(__name__)
 
 
+def parse_version(config: Configuration) -> ScmVersion | None:
+    """Backward-compat shim for setuptools-scm <=10.0.x.
+
+    Those releases import ``parse_version`` from this module.  The function
+    was inlined during the 10.1 / vcs-versioning 2.0 refactor, but we keep
+    the name importable so that older setuptools-scm pins still work with
+    newer vcs-versioning releases.
+    """
+    scm_version = _resolve_version(config)
+    return _apply_metadata_overrides(scm_version, config)
+
+
 def _finalize(
     scm_version: ScmVersion,
     config: Configuration,

--- a/vcs-versioning/testing_vcs/test_regressions.py
+++ b/vcs-versioning/testing_vcs/test_regressions.py
@@ -138,6 +138,30 @@ def test_no_warn_when_version_file_not_tracked(tmp_path: Path, scm: str) -> None
     assert tracked_warnings == []
 
 
+@pytest.mark.issue(1423)
+def test_parse_version_importable_from_get_version_impl() -> None:
+    """setuptools-scm <=10.0.x imports parse_version from this module."""
+    from vcs_versioning._get_version_impl import parse_version
+
+    assert callable(parse_version)
+
+
+@pytest.mark.issue(1423)
+def test_parse_version_shim_returns_version(tmp_path: Path) -> None:
+    """The compat shim should resolve and return a ScmVersion."""
+    wd = WorkDir(tmp_path).setup_git()
+    wd.add_and_commit("initial")
+    wd("git tag -a v1.0.0 -m v1.0.0")
+
+    c = Configuration(root=tmp_path)
+
+    from vcs_versioning._get_version_impl import parse_version
+    from vcs_versioning._scm_version import ScmVersion
+
+    result = parse_version(c)
+    assert isinstance(result, ScmVersion)
+
+
 @pytest.mark.parametrize(
     ("input", "expected"),
     [


### PR DESCRIPTION
## Summary

- Add a `parse_version()` backward-compat shim to `vcs_versioning._get_version_impl` so that setuptools-scm <=10.0.x (which imports this name) works with vcs-versioning >=2.0.
- Add `<3` upper pin on `vcs-versioning` in setuptools-scm's build-system requires and runtime dependencies to prevent future cross-package breakage.
- Add regression tests verifying the shim is importable and functional.

Fixes #1423

## Test plan

- [x] `test_parse_version_importable_from_get_version_impl` — verifies the import path works
- [x] `test_parse_version_shim_returns_version` — verifies the shim resolves a version from a real git repo
- [x] Pre-commit passes

Made with [Cursor](https://cursor.com)