### PR TITLE
fix: suppress conflicting tag.strict warnings

### DIFF
--- a/vcs-versioning/src/vcs_versioning/_config.py
+++ b/vcs-versioning/src/vcs_versioning/_config.py
@@ -347,27 +347,19 @@ class Configuration:
                     self.tag, regex=_check_tag_regex(tag_regex)
                 )
 
+        # TODO(#1429): re-introduce these warnings with non-conflicting logic
         if self.tag.strict is None:
-            warnings.warn(
-                "tag.strict is not set. Currently defaults to False (permissive "
-                "tag matching). In a future major version the default will change "
-                "to True (require tags to contain a dot). "
-                "Set tag.strict = true or tag.strict = false explicitly in your "
-                "[tool.setuptools_scm] / [tool.vcs-versioning] config to silence "
-                "this warning.",
-                FutureWarning,
-                stacklevel=2,
+            log.debug(
+                "tag.strict is not set — defaults to False (permissive tag matching)"
             )
 
         if (
             self.tag.prefix or self.tag.strict is not None
         ) and self.scm.git.describe_command is not None:
-            warnings.warn(
+            log.debug(
                 "Both tag.prefix/tag.strict and scm.git.describe_command are set. "
                 "The explicit describe_command takes precedence; tag.prefix and "
-                "tag.strict will have no effect on the git describe match pattern.",
-                UserWarning,
-                stacklevel=2,
+                "tag.strict will have no effect on the git describe match pattern."
             )
 
         self._resolved_paths = resolve_paths(

--- a/vcs-versioning/src/vcs_versioning/_run_cmd.py
+++ b/vcs-versioning/src/vcs_versioning/_run_cmd.py
@@ -166,6 +166,7 @@ def run(
         ),
         text=True,
         encoding="utf-8",
+        errors="surrogateescape",
         timeout=timeout,
     )
 

--- a/vcs-versioning/testing_vcs/test_tag_config.py
+++ b/vcs-versioning/testing_vcs/test_tag_config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import warnings
 
-import pytest
 from vcs_versioning import Configuration
 from vcs_versioning._config import TagConfiguration
 from vcs_versioning._scm_version import tag_to_version
@@ -59,8 +58,10 @@ class TestDescribeMatchGlob:
 
 
 class TestTagStrictWarning:
-    def test_none_strict_emits_future_warning(self) -> None:
-        with pytest.warns(FutureWarning, match="tag.strict is not set"):
+    def test_none_strict_no_warning(self) -> None:
+        """tag.strict=None no longer warns (suppressed per #1422, see #1429)."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
             Configuration(tag=TagConfiguration(strict=None))
 
     def test_true_strict_no_warning(self) -> None:
@@ -78,17 +79,13 @@ class TestTagPrefixStripping:
     """Test that tag.prefix is stripped before tag_regex matching."""
 
     def test_prefix_stripped_from_tag(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            config = Configuration(tag=TagConfiguration(prefix="hatchling-v"))
+        config = Configuration(tag=TagConfiguration(prefix="hatchling-v"))
         version = tag_to_version("hatchling-v1.0.0", config)
         assert version is not None
         assert str(version) == "1.0.0"
 
     def test_no_prefix_no_stripping(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            config = Configuration(tag=TagConfiguration(prefix=""))
+        config = Configuration(tag=TagConfiguration(prefix=""))
         version = tag_to_version("v1.0.0", config)
         assert version is not None
         assert str(version) == "1.0.0"
@@ -100,17 +97,13 @@ class TestTagPrefixStripping:
         may still parse -- but the prefix is NOT stripped, meaning
         git describe --match would have already filtered it out in practice.
         """
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            config = Configuration(tag=TagConfiguration(prefix="other-"))
+        config = Configuration(tag=TagConfiguration(prefix="other-"))
         version = tag_to_version("hatchling-v1.0.0", config)
         # Default tag_regex matches and extracts "v1.0.0" from dashed prefix
         assert version is not None
 
     def test_prefix_v_strips_v(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            config = Configuration(tag=TagConfiguration(prefix="v"))
+        config = Configuration(tag=TagConfiguration(prefix="v"))
         version = tag_to_version("v1.2.3", config)
         assert version is not None
         assert str(version) == "1.2.3"
@@ -120,20 +113,19 @@ class TestConfigFromData:
     """Test that Configuration.from_data correctly parses tag config."""
 
     def test_tag_in_from_data(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            config = Configuration.from_data(
-                relative_to=".",
-                data={
-                    "dist_name": "test",
-                    "tag": {"prefix": "mylib-", "strict": True},
-                },
-            )
+        config = Configuration.from_data(
+            relative_to=".",
+            data={
+                "dist_name": "test",
+                "tag": {"prefix": "mylib-", "strict": True},
+            },
+        )
         assert config.tag.prefix == "mylib-"
         assert config.tag.strict is True
 
     def test_no_tag_in_from_data(self) -> None:
-        with pytest.warns(FutureWarning, match="tag.strict"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
             config = Configuration.from_data(
                 relative_to=".",
                 data={"dist_name": "test"},
@@ -143,13 +135,12 @@ class TestConfigFromData:
 
 
 class TestDescribeCommandConflictWarning:
-    def test_warns_when_prefix_and_describe_command_both_set(self) -> None:
+    def test_no_warning_when_prefix_and_describe_command_both_set(self) -> None:
+        """Suppressed per #1422, see #1429 for follow-up."""
         from vcs_versioning._config import GitConfiguration, ScmConfiguration
 
-        with pytest.warns(
-            UserWarning,
-            match="Both tag.prefix/tag.strict and scm.git.describe_command are set",
-        ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
             Configuration(
                 tag=TagConfiguration(prefix="v", strict=True),
                 scm=ScmConfiguration(


### PR DESCRIPTION
## Summary

- Downgrades the `tag.strict` FutureWarning and the "both tag.prefix/tag.strict and describe_command" UserWarning to debug-level log messages, fixing the unwinnable warning situation reported in #1422
- Follow-up issue #1429 tracks re-introducing these warnings with proper non-conflicting logic

## Test plan

- [x] `test_tag_config.py` updated to verify no warnings are emitted
- [x] All vcs-versioning tests pass (519 passed)
- [x] Pre-commit (ruff, mypy, codespell) passes

Closes #1422

Made with [Cursor](https://cursor.com)