### PR TITLE
fix: scope list_tracked_files to project_root in monorepos

### DIFF
--- a/setuptools-scm/src/setuptools_scm/_integration/egg_info.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/egg_info.py
@@ -77,7 +77,7 @@ def _get_tracked_files(data: VersionInferenceData | None) -> list[str] | None:
     if data is None or data.workdir is None:
         return None
     try:
-        files = data.workdir.list_tracked_files()
+        files = data.workdir.list_tracked_files(data.workdir.project_root)
         if files:
             return _normalize_tracked_files(files)
     except NotImplementedError:
@@ -139,7 +139,7 @@ class ScmEggInfoMixin(_egg_info):
 
             if data.workdir is not None:
                 try:
-                    files = data.workdir.list_tracked_files()
+                    files = data.workdir.list_tracked_files(data.workdir.project_root)
                     if files:
                         write_scm_file_list(
                             egg_info_dir, _normalize_tracked_files(files)

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -238,11 +238,15 @@ class GitWorkdir(Workdir):
         return _git_parse_inner(config, self, pre_parse=effective_pre_parse)
 
     def list_tracked_files(self, path: Path | str = "") -> list[str]:
-        """List files tracked by git, honoring export-ignore."""
+        """List files tracked by git, honoring export-ignore.
+
+        When no path is given, scopes to ``project_root`` (not the VCS root)
+        so that monorepo projects only list their own files.
+        """
         from .._file_finders import scm_find_files
         from .._file_finders._git import _git_ls_files_and_dirs
 
-        base = str(path) if path else str(self.path)
+        base = str(path) if path else str(self.project_root)
         git_files, git_dirs = _git_ls_files_and_dirs(
             str(self.path), timeout=self._subprocess_timeout
         )

--- a/vcs-versioning/src/vcs_versioning/_backends/_hg.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_hg.py
@@ -293,7 +293,7 @@ class HgWorkdir(Workdir):
         from .._file_finders import scm_find_files
         from .._file_finders._hg import _hg_ls_files_and_dirs
 
-        base = str(path) if path else str(self.path)
+        base = str(path) if path else str(self.project_root)
         hg_files, hg_dirs = _hg_ls_files_and_dirs(
             str(self.path),
             hg_command=self._hg_command,

--- a/vcs-versioning/src/vcs_versioning/_backends/_hg_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_hg_git.py
@@ -95,7 +95,7 @@ class GitWorkdirHgClient(GitWorkdir, HgWorkdir):
         from .._file_finders import scm_find_files
         from .._file_finders._hg import _hg_ls_files_and_dirs
 
-        base = str(path) if path else str(self.path)
+        base = str(path) if path else str(self.project_root)
         hg_files, hg_dirs = _hg_ls_files_and_dirs(
             str(self.path),
             hg_command=self._hg_command,

--- a/vcs-versioning/src/vcs_versioning/_backends/_jj.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_jj.py
@@ -263,7 +263,7 @@ class JjWorkdir(Workdir):
         from .._file_finders import scm_find_files
         from .._file_finders._jj import _jj_ls_files_and_dirs
 
-        base = str(path) if path else str(self.path)
+        base = str(path) if path else str(self.project_root)
         jj_files, jj_dirs = _jj_ls_files_and_dirs(
             str(self.path), timeout=self._subprocess_timeout
         )

--- a/vcs-versioning/src/vcs_versioning/_backends/_scm_workdir.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_scm_workdir.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from dataclasses import field as dc_field
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from .._scm_version import ScmVersion
 
@@ -14,6 +14,37 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+class _ProjectRootDescriptor:
+    """Descriptor for ``project_root`` that defaults to ``path``.
+
+    Acts as default when no value has been set on the instance.
+    Stores explicitly assigned values in the instance ``__dict__``.
+    """
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        self._name = name
+
+    @overload
+    def __get__(self, obj: None, objtype: type) -> _ProjectRootDescriptor: ...
+
+    @overload
+    def __get__(self, obj: ScmWorkdir, objtype: type | None = None) -> Path: ...
+
+    def __get__(
+        self, obj: ScmWorkdir | None, objtype: type | None = None
+    ) -> Path | _ProjectRootDescriptor:
+        if obj is None:
+            return self
+        value: Path | None = obj.__dict__.get(self._name)
+        if value is None:
+            return obj.path
+        return value
+
+    def __set__(self, obj: ScmWorkdir, value: Path | None) -> None:
+        if isinstance(value, Path):
+            obj.__dict__[self._name] = value
 
 
 def get_latest_file_mtime(changed_files: list[str], base_path: Path) -> date | None:
@@ -61,14 +92,10 @@ class ScmWorkdir:
     """
 
     path: Path
-    project_root: Path | None = dc_field(default=None)
+    project_root: Path = _ProjectRootDescriptor()  # type: ignore[assignment]
 
     _config: Configuration | None = dc_field(default=None, repr=False, compare=False)
     """Back-reference to the ``Configuration`` that discovered this workdir."""
-
-    def __post_init__(self) -> None:
-        if self.project_root is None:
-            self.project_root = self.path
 
     @property
     def _subprocess_timeout(self) -> int | None:
@@ -95,7 +122,6 @@ class ScmWorkdir:
     @property
     def project_path(self) -> str:
         """Discovered relative path from VCS root to project directory."""
-        assert self.project_root is not None
         if self.path == self.project_root:
             return ""
         from .._paths import relative_project_path

--- a/vcs-versioning/src/vcs_versioning/_fallback_workdir.py
+++ b/vcs-versioning/src/vcs_versioning/_fallback_workdir.py
@@ -35,6 +35,11 @@ class FallbackWorkdir:
     """Back-reference to the ``Configuration`` that discovered this workdir."""
 
     @property
+    def project_root(self) -> Path:
+        """Fallback workdirs always live at the project root."""
+        return self.path
+
+    @property
     def config(self) -> Configuration:
         if self._config is None:
             raise RuntimeError(

--- a/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
@@ -85,6 +85,9 @@ def _git_ls_files_and_dirs(
         log.error("listing git files failed - pretending there aren't any")
         return set(), set()
 
+    # Normalize toplevel to match what scm_find_files expects:
+    # absolute, symlinks resolved, case-normalized (normcase).
+    toplevel = norm_real(toplevel)
     git_files: set[str] = set()
     git_dirs: set[str] = {toplevel}
     for name in res.stdout.rstrip("\0").split("\0"):

--- a/vcs-versioning/src/vcs_versioning/_get_version_impl.py
+++ b/vcs-versioning/src/vcs_versioning/_get_version_impl.py
@@ -90,7 +90,7 @@ def _resolve_version(config: Configuration) -> ScmVersion | None:
     return None
 
 
-def _warn_if_tracked(target: Path, root: Path) -> None:
+def _warn_if_tracked(target: Path, root: Path, config: Configuration) -> None:
     """Warn when *target* is tracked in version control (#468).
 
     Writing a version file that is tracked makes ``git describe --dirty``
@@ -101,7 +101,7 @@ def _warn_if_tracked(target: Path, root: Path) -> None:
 
     for workdir_cls in (GitWorkdir, HgWorkdir):
         try:
-            wd = workdir_cls.from_potential_worktree(root)
+            wd = workdir_cls.from_potential_worktree(root, config)
         except Exception:
             continue
         if wd is not None and wd.is_file_tracked(target):
@@ -125,7 +125,7 @@ def write_version_files(
 
         write_to = Path(config.write_to)
         target = root / write_to if not write_to.is_absolute() else write_to
-        _warn_if_tracked(target, root)
+        _warn_if_tracked(target, root, config)
 
         dump_version(
             root=config.root,
@@ -142,7 +142,7 @@ def write_version_files(
         # todo: use a better name than fallback root
         assert config.relative_to is not None
         target = Path(config.relative_to).parent.joinpath(version_file)
-        _warn_if_tracked(target, root)
+        _warn_if_tracked(target, root, config)
 
         write_version_to_path(
             target,

--- a/vcs-versioning/src/vcs_versioning/_legacy_parse.py
+++ b/vcs-versioning/src/vcs_versioning/_legacy_parse.py
@@ -38,12 +38,7 @@ class LegacyParseWorkdir(ScmWorkdir):
     entry-point group.
     """
 
-    _parse_fn: ParseFunction | None = dc_field(default=None, repr=False)
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        if self._parse_fn is None:
-            raise TypeError("LegacyParseWorkdir requires a _parse_fn")
+    parse_fn: ParseFunction = dc_field(repr=False, kw_only=True)
 
     def get_scm_version(self) -> ScmVersion | None:
         warnings.warn(
@@ -53,8 +48,7 @@ class LegacyParseWorkdir(ScmWorkdir):
             DeprecationWarning,
             stacklevel=2,
         )
-        assert self._parse_fn is not None
-        result = self._parse_fn(self.config.absolute_root, config=self.config)
+        result = self.parse_fn(self.config.absolute_root, config=self.config)
         if result is not None and not isinstance(result, ScmVersion):
             raise TypeError(
                 f"version parse result was {result!r}\n"

--- a/vcs-versioning/src/vcs_versioning/_protocols.py
+++ b/vcs-versioning/src/vcs_versioning/_protocols.py
@@ -32,6 +32,16 @@ class WorkdirProtocol(Protocol):
     @property
     def path(self) -> Path: ...
 
+    @property
+    def project_root(self) -> Path:
+        """The project directory (where pyproject.toml lives).
+
+        For SCM workdirs this may differ from ``path`` (the VCS root).
+        For fallback workdirs this is always equal to ``path``.
+        Guaranteed non-None after construction.
+        """
+        ...
+
     def get_scm_version(self) -> ScmVersion | None:
         """Raw version metadata before overrides / formatting."""
         ...
@@ -48,9 +58,6 @@ class WorkdirProtocol(Protocol):
 @runtime_checkable
 class ScmWorkdirProtocol(WorkdirProtocol, Protocol):
     """Live VCS checkout: adds monorepo / nested-project fields."""
-
-    @property
-    def project_root(self) -> Path: ...
 
     @property
     def project_path(self) -> str:

--- a/vcs-versioning/src/vcs_versioning/_worktree_discovery.py
+++ b/vcs-versioning/src/vcs_versioning/_worktree_discovery.py
@@ -84,7 +84,7 @@ def discover_workdir(config: Configuration) -> AnyWorkdir | None:
         return LegacyParseWorkdir(
             path=Path(config.absolute_root),
             _config=config,
-            _parse_fn=config.parse,
+            parse_fn=config.parse,
         )
 
     factories = _load_discovery_factories()

--- a/vcs-versioning/testing_vcs/test_legacy_parse.py
+++ b/vcs-versioning/testing_vcs/test_legacy_parse.py
@@ -34,8 +34,8 @@ class TestLegacyParseWorkdir:
         return Configuration.from_file(pyproject)
 
     def test_requires_parse_fn(self, tmp_path: Path) -> None:
-        with pytest.raises(TypeError, match="requires a _parse_fn"):
-            LegacyParseWorkdir(path=tmp_path)
+        with pytest.raises(TypeError, match="parse_fn"):
+            LegacyParseWorkdir(path=tmp_path)  # type: ignore[call-arg]
 
     def test_get_scm_version_emits_deprecation(self, tmp_path: Path) -> None:
         config = self._make_config(tmp_path)
@@ -43,7 +43,7 @@ class TestLegacyParseWorkdir:
         def fake_parse(root: _t.PathT, *, config: Configuration) -> ScmVersion | None:
             return ScmVersion(tag=Version("1.0.0"), config=config)
 
-        wd = LegacyParseWorkdir(path=tmp_path, _parse_fn=fake_parse)
+        wd = LegacyParseWorkdir(path=tmp_path, parse_fn=fake_parse)
         wd._config = config
 
         with warnings.catch_warnings(record=True) as w:
@@ -62,7 +62,7 @@ class TestLegacyParseWorkdir:
         def fake_parse(root: _t.PathT, *, config: Configuration) -> ScmVersion | None:
             return None
 
-        wd = LegacyParseWorkdir(path=tmp_path, _parse_fn=fake_parse)
+        wd = LegacyParseWorkdir(path=tmp_path, parse_fn=fake_parse)
         wd._config = config
 
         with warnings.catch_warnings(record=True):
@@ -75,7 +75,7 @@ class TestLegacyParseWorkdir:
         def bad_parse(root: _t.PathT, *, config: Configuration) -> ScmVersion | None:
             return "not-a-version"  # type: ignore[return-value]
 
-        wd = LegacyParseWorkdir(path=tmp_path, _parse_fn=bad_parse)
+        wd = LegacyParseWorkdir(path=tmp_path, parse_fn=bad_parse)
         wd._config = config
 
         with warnings.catch_warnings(record=True):

--- a/vcs-versioning/testing_vcs/test_workdir_discovery.py
+++ b/vcs-versioning/testing_vcs/test_workdir_discovery.py
@@ -86,6 +86,48 @@ class TestDiscoverWorkdirGit:
         assert isinstance(result, ScmWorkdir)
         assert result.path == tmp_path
 
+    @pytest.mark.issue(1440)
+    def test_list_tracked_files_scoped_to_project_root(self, tmp_path: Path) -> None:
+        """In a monorepo, list_tracked_files() must only return files under project_root."""
+        # Resolve to real path to avoid Windows 8.3 short name mismatches
+        tmp_path = tmp_path.resolve()
+        _git_init(tmp_path)
+
+        # Create files in two sibling projects
+        proj_a = tmp_path / "project-a"
+        proj_b = tmp_path / "project-b"
+        proj_a.mkdir()
+        proj_b.mkdir()
+        (proj_a / "a.py").write_text("# a", encoding="utf-8")
+        (proj_b / "b.py").write_text("# b", encoding="utf-8")
+
+        subprocess.run(
+            ["git", "add", "."], cwd=tmp_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "add projects"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # Discover from project-a with root=".." (monorepo pattern)
+        config = Configuration(
+            relative_to=str(proj_a / "pyproject.toml"),
+            root="..",
+        )
+        result = discover_workdir(config)
+        assert result is not None
+        assert isinstance(result, ScmWorkdir)
+        assert result.path == tmp_path
+        assert result.project_root == proj_a
+
+        files = list(result.list_tracked_files())
+        # Should only contain files under project-a, not project-b or repo root
+        assert any("a.py" in f for f in files), f"expected a.py in {files}"
+        assert not any("b.py" in f for f in files), f"unexpected b.py in {files}"
+        assert not any("dummy" in f for f in files), f"unexpected dummy in {files}"
+
 
 class TestDiscoverWorkdirFallback:
     def test_discovers_pkginfo(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- **Fixes #1440**: In monorepos with `root=".."`, `list_tracked_files()` was defaulting to the VCS root instead of the project root, causing `sdist` to include files from the entire repository.
- Refactors `ScmWorkdir.project_root` to use a descriptor that guarantees it always returns a `Path` (defaulting to `self.path` when not explicitly set).
- Adds `project_root` property to `FallbackWorkdir` and promotes it to `WorkdirProtocol` for a uniform interface.
- Passes `config` to `from_potential_worktree` in `_warn_if_tracked` for correct VCS probing.

## Test plan

- [x] Added `test_list_tracked_files_scoped_to_project_root` to verify monorepo file scoping
- [x] Full test suite passes (707 passed, 61 skipped)
- [x] Pre-commit (ruff, mypy, codespell) passes


Made with [Cursor](https://cursor.com)