### PR TITLE
fix: don't re-parse stored tags through tag_regex in MetadataWorkdir

### DIFF
--- a/vcs-versioning/changelog.d/1439.bugfix.md
+++ b/vcs-versioning/changelog.d/1439.bugfix.md
@@ -1,0 +1,1 @@
+Fix MetadataWorkdir crash when using custom `tag_regex` — stored tags are already parsed version strings and no longer re-parsed through the tag regex.

--- a/vcs-versioning/src/vcs_versioning/_fallback_workdir.py
+++ b/vcs-versioning/src/vcs_versioning/_fallback_workdir.py
@@ -81,8 +81,20 @@ class MetadataWorkdir(FallbackWorkdir):
                     data.node_date,
                     self.metadata_dir,
                 )
+        # The tag in scm_version.json is already a parsed version string
+        # (e.g. "1.5.5"), not a raw VCS tag (e.g. "cuda-pathfinder-v1.5.5").
+        # Convert to version_cls so _parse_tag skips tag_regex matching.
+        try:
+            tag = self.config.version_cls(data.tag)
+        except Exception:
+            log.warning(
+                "cannot parse stored tag %r in metadata at %s",
+                data.tag,
+                self.metadata_dir,
+            )
+            return None
         return meta(
-            tag=data.tag,
+            tag=tag,
             distance=data.distance,
             node=data.node,
             dirty=data.dirty,

--- a/vcs-versioning/src/vcs_versioning/_scm_version.py
+++ b/vcs-versioning/src/vcs_versioning/_scm_version.py
@@ -347,20 +347,14 @@ class ScmVersion:
 
 def _parse_tag(
     tag: _Version | str, preformatted: bool, config: _config.Configuration
-) -> _Version:
+) -> _Version | None:
     if preformatted:
-        # For preformatted versions, tag should already be validated as a version object
-        # String validation is handled in meta function before calling this
         if isinstance(tag, str):
-            # This should not happen with enhanced meta, but kept for safety
             return _v.NonNormalizedVersion(tag)
         else:
-            # Already a version object (including test mocks), return as-is
             return tag
     elif not isinstance(tag, config.version_cls):
-        version = tag_to_version(tag, config)
-        assert version is not None
-        return version
+        return tag_to_version(tag, config)
     else:
         return tag
 
@@ -389,18 +383,20 @@ def meta(
     node_date: date | None = None,
     time: datetime | None = None,
 ) -> ScmVersion:
-    parsed_version: _Version
-    # Enhanced string validation for preformatted versions
+    parsed_version: _Version | None
     if preformatted and isinstance(tag, str):
-        # Validate PEP 440 compliance using NonNormalizedVersion
-        # Let validation errors bubble up to the caller
         parsed_version = _v.NonNormalizedVersion(tag)
     else:
-        # Use existing _parse_tag logic for non-preformatted or already validated inputs
         parsed_version = _parse_tag(tag, preformatted, config)
 
+    if parsed_version is None:
+        raise ValueError(
+            f"Can't parse version from tag {tag!r}"
+            f" (tag_regex={config.tag.regex.pattern!r},"
+            f" tag_prefix={config.tag.prefix!r})"
+        )
+
     log.info("version %s -> %s", tag, parsed_version)
-    assert parsed_version is not None, f"Can't parse version {tag}"
 
     kwargs: _ScmVersionKwargs = {
         "distance": distance,

--- a/vcs-versioning/testing_vcs/test_workdir_discovery.py
+++ b/vcs-versioning/testing_vcs/test_workdir_discovery.py
@@ -303,6 +303,27 @@ class TestMetadataWorkdir:
         files = wd.list_tracked_files()
         assert files == ["src/pkg/__init__.py"]
 
+    @pytest.mark.issue(1439)
+    def test_custom_tag_regex_does_not_break_metadata(self, tmp_path: Path) -> None:
+        """Stored tags are already parsed; custom tag_regex must not re-parse them."""
+        data = ScmVersionData(
+            tag="1.5.5",
+            distance=0,
+            node="gabc1234",
+            dirty=False,
+            branch="main",
+            node_date=None,
+        )
+        write_scm_version_data(tmp_path, data)
+
+        config = Configuration(
+            tag_regex=r"^cuda-pathfinder-(?P<version>v\d+\.\d+\.\d+(?:[ab]\d+)?)",
+        )
+        wd = MetadataWorkdir(path=tmp_path, metadata_dir=tmp_path, _config=config)
+        version = wd.get_scm_version()
+        assert version is not None
+        assert str(version.tag) == "1.5.5"
+
     def test_missing_metadata_returns_none(self, tmp_path: Path) -> None:
         config = Configuration()
         wd = MetadataWorkdir(path=tmp_path, metadata_dir=tmp_path, _config=config)


### PR DESCRIPTION
## Summary

Fixes #1439

- **MetadataWorkdir.get_scm_version()** now converts the stored tag string from `scm_version.json` to a `version_cls` instance before passing it to `meta()`. The stored tag is already a parsed version string (e.g. `"1.5.5"`), not a raw VCS tag (e.g. `"cuda-pathfinder-v1.5.5"`), so re-parsing it through `tag_regex` was incorrect and caused an `AssertionError` when using custom `tag_regex` patterns.
- Replaced the bare `assert` in `_parse_tag`/`meta` with a descriptive `ValueError` that includes the tag value, regex pattern, and prefix for easier debugging.

## Test plan

- [x] Added `test_custom_tag_regex_does_not_break_metadata` reproducing the exact scenario from #1439 (custom `tag_regex` with `^cuda-pathfinder-` prefix, stored tag `"1.5.5"`)
- [x] All existing tests pass (`uv run pytest -n12` — 708 passed)
- [x] Pre-commit passes (ruff, mypy, codespell, etc.)

Made with [Cursor](https://cursor.com)