### PR TITLE
fix: move PKG-INFO discovery tests to setuptools-scm

### DIFF
--- a/setuptools-scm/changelog.d/1446.misc.md
+++ b/setuptools-scm/changelog.d/1446.misc.md
@@ -1,0 +1,1 @@
+Move PKG-INFO discovery tests from vcs-versioning to setuptools-scm where the entry points are registered.

--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -103,9 +103,6 @@ setuptools_scm = "setuptools_scm._integration.setuptools:infer_version"
 pkginfo = "setuptools_scm._integration._discover:discover_pkginfo"
 egg-info = "setuptools_scm._integration._discover:discover_egg_info_metadata"
 
-# VCS-related entry points are now provided by vcs-versioning package
-# Only file-finder entry points remain in setuptools_scm
-
 [tool.setuptools.packages.find]
 where = ["src"]
 namespaces = false

--- a/setuptools-scm/testing_scm/test_workdir_discovery_pkginfo.py
+++ b/setuptools-scm/testing_scm/test_workdir_discovery_pkginfo.py
@@ -1,0 +1,53 @@
+"""Tests for PKG-INFO discovery (depends on setuptools-scm entry points)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vcs_versioning._config import Configuration
+from vcs_versioning._fallback_workdir import PkgInfoWorkdir
+from vcs_versioning._worktree_discovery import discover_workdir
+
+
+def test_discovers_pkginfo(tmp_path: Path) -> None:
+    (tmp_path / "PKG-INFO").write_text(
+        "Metadata-Version: 2.1\nName: pkg\nVersion: 3.0.0\n",
+        encoding="utf-8",
+    )
+    config = Configuration(relative_to=str(tmp_path / "pyproject.toml"))
+    result = discover_workdir(config)
+    assert result is not None
+    assert isinstance(result, PkgInfoWorkdir)
+
+
+@pytest.mark.issue(1431)
+def test_unprocessed_archival_falls_through_to_pkginfo(tmp_path: Path) -> None:
+    """Unprocessed .git_archival.txt must not shadow a valid PKG-INFO.
+
+    PyPI sdists contain both files: a .git_archival.txt with raw
+    ``$Format:...`` placeholders (never substituted because the sdist
+    was built by setuptools, not ``git archive``) and a PKG-INFO with
+    the correct version.  Before the fix, the archival fallback was
+    stashed as the sole candidate and its ``get_scm_version()`` returned
+    None, causing a LookupError.
+    """
+    (tmp_path / ".git_archival.txt").write_text(
+        "node: $Format:%H$\n"
+        "node-date: $Format:%cI$\n"
+        "describe-name: $Format:%(describe:tags=true)$\n"
+        "ref-names: $Format:%D$\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "PKG-INFO").write_text(
+        "Metadata-Version: 2.1\nName: my-pkg\nVersion: 1.2.3\n",
+        encoding="utf-8",
+    )
+    config = Configuration(relative_to=str(tmp_path / "pyproject.toml"))
+    result = discover_workdir(config)
+    assert result is not None
+    assert isinstance(result, PkgInfoWorkdir)
+    version = result.get_scm_version()
+    assert version is not None
+    assert str(version.tag) == "1.2.3"

--- a/vcs-versioning/changelog.d/1446.misc.md
+++ b/vcs-versioning/changelog.d/1446.misc.md
@@ -1,0 +1,1 @@
+Move PKG-INFO discovery tests to setuptools-scm where the entry points are registered.

--- a/vcs-versioning/testing_vcs/test_workdir_discovery.py
+++ b/vcs-versioning/testing_vcs/test_workdir_discovery.py
@@ -11,7 +11,6 @@ from vcs_versioning._config import Configuration
 from vcs_versioning._fallback_workdir import (
     ArchivedWorkdir,
     MetadataWorkdir,
-    PkgInfoWorkdir,
     StaticWorkdir,
 )
 from vcs_versioning._scm_metadata import (
@@ -130,16 +129,6 @@ class TestDiscoverWorkdirGit:
 
 
 class TestDiscoverWorkdirFallback:
-    def test_discovers_pkginfo(self, tmp_path: Path) -> None:
-        (tmp_path / "PKG-INFO").write_text(
-            "Metadata-Version: 2.1\nName: pkg\nVersion: 3.0.0\n",
-            encoding="utf-8",
-        )
-        config = Configuration(relative_to=str(tmp_path / "pyproject.toml"))
-        result = discover_workdir(config)
-        assert result is not None
-        assert isinstance(result, PkgInfoWorkdir)
-
     def test_discovers_git_archival(self, tmp_path: Path) -> None:
         (tmp_path / ".git_archival.txt").write_text(
             "node: abc1234\nref-names: HEAD\n",
@@ -217,40 +206,6 @@ class TestProjectPathVerificationInDiscovery:
         )
         with pytest.raises(ValueError, match="project_path mismatch"):
             discover_workdir(config)
-
-
-class TestFallbackPriority:
-    @pytest.mark.issue(1431)
-    def test_unprocessed_archival_falls_through_to_pkginfo(
-        self, tmp_path: Path
-    ) -> None:
-        """Unprocessed .git_archival.txt must not shadow a valid PKG-INFO.
-
-        PyPI sdists contain both files: a .git_archival.txt with raw
-        ``$Format:...`` placeholders (never substituted because the sdist
-        was built by setuptools, not ``git archive``) and a PKG-INFO with
-        the correct version.  Before the fix, the archival fallback was
-        stashed as the sole candidate and its ``get_scm_version()`` returned
-        None, causing a LookupError.
-        """
-        (tmp_path / ".git_archival.txt").write_text(
-            "node: $Format:%H$\n"
-            "node-date: $Format:%cI$\n"
-            "describe-name: $Format:%(describe:tags=true)$\n"
-            "ref-names: $Format:%D$\n",
-            encoding="utf-8",
-        )
-        (tmp_path / "PKG-INFO").write_text(
-            "Metadata-Version: 2.1\nName: my-pkg\nVersion: 1.2.3\n",
-            encoding="utf-8",
-        )
-        config = Configuration(relative_to=str(tmp_path / "pyproject.toml"))
-        result = discover_workdir(config)
-        assert result is not None
-        assert isinstance(result, PkgInfoWorkdir)
-        version = result.get_scm_version()
-        assert version is not None
-        assert str(version.tag) == "1.2.3"
 
 
 class TestFallbackWorkdirDiscoveryFactories:


### PR DESCRIPTION
## Summary

- Moves two PKG-INFO discovery tests from `vcs-versioning/testing_vcs/` to `setuptools-scm/testing_scm/` since they depend on the `pkginfo` entry point registered by setuptools-scm
- Fixes vcs-versioning tests failing when run without setuptools-scm installed

Closes #1446

## Test plan

- [x] `uv run pytest vcs-versioning/testing_vcs/test_workdir_discovery.py` passes (no pkginfo dependency)
- [x] `uv run pytest setuptools-scm/testing_scm/test_workdir_discovery_pkginfo.py` passes
- [x] Pre-commit passes

Made with [Cursor](https://cursor.com)