### PR TITLE
fix: resolve relative paths in _warn_if_tracked (#1451)

### DIFF
--- a/vcs-versioning/changelog.d/1451.bugfix.md
+++ b/vcs-versioning/changelog.d/1451.bugfix.md
@@ -1,0 +1,3 @@
+Fix crash in `_warn_if_tracked` when the version file target is a relative path
+by resolving it against the project root before comparison.
+Also warn (instead of crashing) when the target resolves outside the project root.

--- a/vcs-versioning/src/vcs_versioning/_get_version_impl.py
+++ b/vcs-versioning/src/vcs_versioning/_get_version_impl.py
@@ -105,7 +105,9 @@ def _warn_if_tracked(target: Path, root: Path, config: Configuration) -> bool:
         target = root / target
     resolved_target = target.resolve()
     resolved_root = root.resolve()
-    if not resolved_target.is_relative_to(resolved_root):
+    try:
+        resolved_target.relative_to(resolved_root)
+    except ValueError:
         # todo: emit as GitHub Actions warning via ::warning:: syntax
         warnings.warn(
             f"version file target {target} resolves outside of the project root {root}",

--- a/vcs-versioning/src/vcs_versioning/_get_version_impl.py
+++ b/vcs-versioning/src/vcs_versioning/_get_version_impl.py
@@ -90,14 +90,28 @@ def _resolve_version(config: Configuration) -> ScmVersion | None:
     return None
 
 
-def _warn_if_tracked(target: Path, root: Path, config: Configuration) -> None:
+def _warn_if_tracked(target: Path, root: Path, config: Configuration) -> bool:
     """Warn when *target* is tracked in version control (#468).
 
     Writing a version file that is tracked makes ``git describe --dirty``
     report a dirty tree on tag checkouts, causing wrong version numbers.
+
+    Returns False if target resolves outside root (caller should skip the write).
     """
     from ._backends._git import GitWorkdir
     from ._backends._hg import HgWorkdir
+
+    if not target.is_absolute():
+        target = root / target
+    resolved_target = target.resolve()
+    resolved_root = root.resolve()
+    if not resolved_target.is_relative_to(resolved_root):
+        # todo: emit as GitHub Actions warning via ::warning:: syntax
+        warnings.warn(
+            f"version file target {target} resolves outside of the project root {root}",
+            stacklevel=2,
+        )
+        return False
 
     for workdir_cls in (GitWorkdir, HgWorkdir):
         try:
@@ -113,7 +127,8 @@ def _warn_if_tracked(target: Path, root: Path, config: Configuration) -> None:
                 " See https://github.com/pypa/setuptools-scm/issues/468",
                 stacklevel=3,
             )
-            return
+            return True
+    return True
 
 
 def write_version_files(
@@ -125,7 +140,8 @@ def write_version_files(
 
         write_to = Path(config.write_to)
         target = root / write_to if not write_to.is_absolute() else write_to
-        _warn_if_tracked(target, root, config)
+        if not _warn_if_tracked(target, root, config):
+            return
 
         dump_version(
             root=config.root,
@@ -142,7 +158,8 @@ def write_version_files(
         # todo: use a better name than fallback root
         assert config.relative_to is not None
         target = Path(config.relative_to).parent.joinpath(version_file)
-        _warn_if_tracked(target, root, config)
+        if not _warn_if_tracked(target, root, config):
+            return
 
         write_version_to_path(
             target,

--- a/vcs-versioning/testing_vcs/test_regressions.py
+++ b/vcs-versioning/testing_vcs/test_regressions.py
@@ -82,11 +82,7 @@ def test_write_to_absolute_path_passes_when_subdir_of_root(tmp_path: Path) -> No
     write_version_files(replace(c, write_to="VERSION.py"), "1.0", v)
     subdir = tmp_path / "subdir"
     subdir.mkdir()
-    with pytest.raises(
-        # todo: python version specific error list
-        ValueError,
-        match=r".*VERSION.py' .* .*subdir.*",
-    ):
+    with pytest.warns(UserWarning, match=r"resolves outside of"):
         write_version_files(replace(c, root=subdir), "1.0", v)
 
 
@@ -136,6 +132,40 @@ def test_no_warn_when_version_file_not_tracked(tmp_path: Path, scm: str) -> None
         w for w in caught if "tracked by version control" in str(w.message)
     ]
     assert tracked_warnings == []
+
+
+@pytest.mark.issue(1451)
+def test_warn_if_tracked_relative_target_no_crash(tmp_path: Path) -> None:
+    """_warn_if_tracked must not crash when target is relative and root is absolute."""
+    from vcs_versioning._get_version_impl import _warn_if_tracked
+
+    wd = WorkDir(tmp_path).setup_git()
+    version_file = tmp_path / "pkg" / "__version__.py"
+    version_file.parent.mkdir()
+    version_file.write_text("__version__ = '0.0.0'\n")
+    wd.add_and_commit("add tracked version file")
+
+    c = Configuration(root=tmp_path)
+    relative_target = Path("pkg/__version__.py")
+
+    with pytest.warns(UserWarning, match="tracked by version control"):
+        _warn_if_tracked(relative_target, tmp_path, c)
+
+
+@pytest.mark.issue(1451)
+def test_warn_if_tracked_warns_when_target_escapes_root(tmp_path: Path) -> None:
+    """_warn_if_tracked must warn when target resolves outside root."""
+    from vcs_versioning._get_version_impl import _warn_if_tracked
+
+    project = tmp_path / "project"
+    project.mkdir()
+    WorkDir(project).setup_git()
+
+    c = Configuration(root=project)
+    escaping_target = Path("../../etc/passwd")
+
+    with pytest.warns(UserWarning, match="resolves outside of"):
+        _warn_if_tracked(escaping_target, project, c)
 
 
 @pytest.mark.issue(1423)


### PR DESCRIPTION
## Summary

- Fix crash in `_warn_if_tracked` when the version file target is a relative `Path` and `root` is absolute (`Path.relative_to` raises `ValueError`)
- Resolve relative targets against `root` before any comparison
- Warn and skip the write (instead of crashing) when the resolved target is outside the project root

Fixes #1451

## Test plan

- [x] New test: relative target path resolves correctly and tracked-file warning fires
- [x] New test: target escaping root emits a warning (no crash)
- [x] Existing tests updated and passing (526 passed)
- [x] Pre-commit (ruff, mypy, codespell) all pass

Made with [Cursor](https://cursor.com)