### PR TITLE
doc: fix simple configuration example in README.md

### DIFF
--- a/setuptools-scm/README.md
+++ b/setuptools-scm/README.md
@@ -57,11 +57,12 @@ dynamic = ["version"]
 
     Starting with setuptools-scm 8.1+, if `setuptools_scm` (or `setuptools-scm`) is
     present in your `build-system.requires`, the `[tool.setuptools_scm]` section
-    becomes optional! You can now enable setuptools-scm with just:
+    becomes optional! (In 9.2+, this requires the `simple` extra.) You can now 
+    enable setuptools-scm with just:
 
     ```toml title="pyproject.toml"
     [build-system]
-    requires = ["setuptools>=80", "setuptools-scm>=8"]
+    requires = ["setuptools>=80", "setuptools-scm[simple]>=9.2"]
     build-backend = "setuptools.build_meta"
 
     [project]

--- a/setuptools-scm/README.md
+++ b/setuptools-scm/README.md
@@ -57,7 +57,7 @@ dynamic = ["version"]
 
     Starting with setuptools-scm 8.1+, if `setuptools_scm` (or `setuptools-scm`) is
     present in your `build-system.requires`, the `[tool.setuptools_scm]` section
-    becomes optional! (In 9.2+, this requires the `simple` extra.) You can now 
+    becomes optional! (In 9.2+, this requires the `simple` extra.) You can now
     enable setuptools-scm with just:
 
     ```toml title="pyproject.toml"


### PR DESCRIPTION
`README.md` states that the `[tool.setuptools-scm]` section is optional in 8.1+. However, in 9.2+, this is no longer true. The section must either be present or `setuptools-scm` required with the `simple` extra. This PR updates the example to reflect that. It nows follows the example in the usage docs (with the `simple` extra and a `>=9.2` requirement).

This is the example that shows up on PyPI, so it is the first thing new users are likely to try. Thus, it is important `README.md` stays up to date. I took me a while to figure this out as a new user.