### PR TITLE
fix: add rich>=13 lower bound to prevent dependabot downgrade

### DIFF
--- a/setuptools-scm/pyproject.toml
+++ b/setuptools-scm/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 
 
 [project.optional-dependencies]
-rich = ["rich"]
+rich = ["rich>=13"]
 simple = []
 toml = []
 
@@ -70,7 +70,7 @@ test = [
   "pytest",
   "pytest-timeout",  # Timeout protection for CI/CD
   "pytest-xdist",
-  "rich",
+  "rich>=13",
   "ruff",
   "mypy; implementation_name != 'pypy'",
   'typing-extensions; python_version < "3.11"',

--- a/uv.lock
+++ b/uv.lock
@@ -2275,7 +2275,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "packaging", specifier = ">=20" },
-    { name = "rich", marker = "extra == 'rich'" },
+    { name = "rich", marker = "extra == 'rich'", specifier = ">=13" },
     { name = "setuptools" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1" },
@@ -2295,7 +2295,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
-    { name = "rich" },
+    { name = "rich", specifier = ">=13" },
     { name = "ruff" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -2318,7 +2318,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
-    { name = "rich" },
+    { name = "rich", specifier = ">=13" },
     { name = "ruff" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]


### PR DESCRIPTION
## Summary

- Adds `rich>=13` lower bound to both the optional dependency and test dependency group in `setuptools-scm/pyproject.toml`
- Prevents dependabot from "upgrading" `rich` from `14.3.4` to `0.1.0` for the Python <3.9 resolution fork

## Problem

Because `requires-python = ">=3.8"`, uv resolves two versions of `rich` in the lockfile: `15.0.0` for Python >=3.9, and `14.3.4` for Python <3.9 (since rich 15 dropped py3.8 support).

Dependabot's uv integration incorrectly treats `rich 0.1.0` (from 2019, with no `requires-python` metadata) as a valid upgrade from `14.3.4`, because it's technically compatible with Python 3.8 and dependabot's version comparison is confused by the `0.x` → `14.x` ordering.

Adding a `>=13` lower bound ensures uv will never resolve anything below `rich 13`, regardless of what dependabot proposes.

## Test plan

- [x] `uv lock` succeeds with the new constraint
- [x] Pre-commit hooks pass
- [ ] CI passes on GitHub

Made with [Cursor](https://cursor.com)