### PR TITLE
fix: add missing pytest-timeout to vcs-versioning test dependencies

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2545,6 +2545,7 @@ test = [
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
@@ -2559,6 +2560,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "pytest" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
 

--- a/vcs-versioning/changelog.d/1461.bugfix.md
+++ b/vcs-versioning/changelog.d/1461.bugfix.md
@@ -1,0 +1,1 @@
+Add missing pytest-timeout to vcs-versioning test dependencies.

--- a/vcs-versioning/pyproject.toml
+++ b/vcs-versioning/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
 [dependency-groups]
 test = [
   "pytest",
+  "pytest-timeout",
   "pytest-xdist",
 ]
 


### PR DESCRIPTION
Fixes #1461

## Summary

- Adds `pytest-timeout` to the `vcs-versioning` test dependency group
- Adds a changelog fragment for the fix

## Problem

The vcs-versioning pytest config has `timeout = 300` but `pytest-timeout` was not listed in its `[dependency-groups] test` dependencies. This means sdist builds that only install vcs-versioning's own test deps would fail because the `timeout` config option is unrecognized without the plugin.

## Test plan

- [x] `uv lock` succeeds
- [x] Pre-commit hooks pass
- [ ] CI passes

Made with [Cursor](https://cursor.com)