### PR TITLE
fix: honor export-ignore for git submodules in file discovery (#1469)

### DIFF
--- a/vcs-versioning/changelog.d/1469.bugfix.md
+++ b/vcs-versioning/changelog.d/1469.bugfix.md
@@ -1,0 +1,1 @@
+Stop recursing into git submodules during file discovery so that submodules marked ``export-ignore`` are excluded from sdists, restoring the pre-9.2 ``git archive`` behavior

--- a/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
@@ -64,16 +64,18 @@ def _git_ls_files_and_dirs(
     toplevel: str, *, timeout: int | None = None
 ) -> tuple[set[str], set[str]]:
     # Use git ls-files with -z for NUL-separated output (safe parsing).
-    # --recurse-submodules lists files inside submodules with prefixed paths.
     # The exclude pathspec filters out files marked with the export-ignore
-    # gitattribute, matching the old git-archive behavior.
+    # gitattribute, matching the git-archive behavior.
     # "." is needed as positive pathspec for the exclude to apply against.
+    # Submodules are intentionally *not* recursed into: git archive never
+    # descended into submodules, and --recurse-submodules would bypass the
+    # parent's export-ignore attribute on the submodule path, wrongly pulling
+    # export-ignore'd submodules into the sdist (see #1469).
     # Uses run_git (--git-dir) to pin to the correct repository.
     res = run_git(
         [
             "ls-files",
             "-z",
-            "--recurse-submodules",
             "--",
             ".",
             ":(exclude,attr:export-ignore)",

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -384,12 +384,8 @@ def test_git_export_ignore_with_staged_files(
     assert opj(".", "ignore.txt") not in found
 
 
-@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/662")
-def test_git_submodule_files_listed(
-    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # Create a separate repo to use as submodule
-    sub_src = wd.cwd.parent / "sub_src"
+def _make_submodule_source(sub_src: Path) -> None:
+    """Create a standalone git repo to be used as a submodule source."""
     sub_src.mkdir()
     subprocess.check_call(["git", "init", str(sub_src)])
     subprocess.check_call(
@@ -397,12 +393,18 @@ def test_git_submodule_files_listed(
     )
     subprocess.check_call(["git", "-C", str(sub_src), "config", "user.name", "test"])
     (sub_src / "sub_file.txt").write_text("sub content", encoding="utf-8")
-    (sub_src / ".gitattributes").write_text(
-        "/sub_ignored.txt export-ignore\n", encoding="utf-8"
-    )
-    (sub_src / "sub_ignored.txt").write_text("ignored", encoding="utf-8")
     subprocess.check_call(["git", "-C", str(sub_src), "add", "."])
     subprocess.check_call(["git", "-C", str(sub_src), "commit", "-m", "init sub"])
+
+
+def test_git_submodule_files_not_recursed(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # File discovery mirrors ``git archive``, which never descends into
+    # submodules.  The submodule contents therefore must not appear in the
+    # listing (only the parent's own tracked files are reported).
+    sub_src = wd.cwd.parent / "sub_src"
+    _make_submodule_source(sub_src)
 
     # Add as submodule (allow file:// protocol for local clone)
     wd.write("parent_file.txt", "parent content")
@@ -427,11 +429,50 @@ def test_git_submodule_files_listed(
     # Parent files present
     assert opj(".", "parent_file.txt") in found
     assert opj(".", ".gitmodules") in found
-    # Submodule files listed with correct prefixed paths
-    assert opj(".", "mysub", "sub_file.txt") in found
-    assert opj(".", "mysub", ".gitattributes") in found
-    # export-ignore honored inside submodule
-    assert opj(".", "mysub", "sub_ignored.txt") not in found
+    # Submodule contents are not recursed into (matching git archive)
+    assert opj(".", "mysub", "sub_file.txt") not in found
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1469")
+def test_git_export_ignore_submodule_excluded(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A submodule placed under a directory marked ``export-ignore`` must be
+    # excluded from file discovery, exactly as ``git archive`` excludes it.
+    # Regression test for #1469: ``--recurse-submodules`` bypassed the
+    # parent's export-ignore attribute and wrongly pulled the submodule's
+    # files into the sdist.
+    sub_src = wd.cwd.parent / "sub_src"
+    _make_submodule_source(sub_src)
+
+    wd.write("parent_file.txt", "parent content")
+    # Mark the whole vendor/ directory as export-ignore.
+    wd.write(".gitattributes", "/vendor/ export-ignore\n")
+    wd("git add parent_file.txt .gitattributes")
+    wd.commit()
+    wd(
+        [
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(sub_src),
+            "vendor/mysub",
+        ]
+    )
+    wd.commit()
+
+    monkeypatch.chdir(wd.cwd)
+    found = set(vcs_versioning._file_finders.find_files("."))
+
+    # Parent files still present
+    assert opj(".", "parent_file.txt") in found
+    # Nothing under the export-ignore'd vendor/ directory may be listed,
+    # including files that live inside the submodule.
+    assert opj(".", "vendor", "mysub", "sub_file.txt") not in found
+    vendor_prefix = opj(".", "vendor") + os.sep
+    assert not [f for f in found if f.startswith(vendor_prefix)], sorted(found)
 
 
 @pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/728")


### PR DESCRIPTION
Fixes #1469

## Root cause

`git ls-files` file discovery (introduced in #1405) is invoked with `--recurse-submodules`:

```python
run_git(
    ["ls-files", "-z", "--recurse-submodules", "--", ".", ":(exclude,attr:export-ignore)"],
    ...
)
```

`git archive` — the reference behavior this discovery method is meant to approximate — never descended into submodules. `--recurse-submodules` is a divergence: it lists files from each submodule's *own* index, and the `:(exclude,attr:export-ignore)` pathspec is evaluated against the submodule's own attributes, not against the parent's `export-ignore` marking on the gitlink path. As a result, a submodule placed under an `export-ignore`'d directory (e.g. a shared `vendor/`) is not excluded, and its entire contents get pulled into the sdist — which is what blew the reporter's sdist up to ~45x its intended size.

## Reproduction

```bash
# submodule source (contains sub_file.txt)
git init sub_src && (cd sub_src && git add . && git commit -m init)

# parent repo, submodule under an export-ignore'd vendor/ dir
git init parent && cd parent
printf '/vendor/ export-ignore\n' > .gitattributes
git add . && git commit -m init
git -c protocol.file.allow=always submodule add ../sub_src vendor/mysub
git commit -m 'add submodule under export-ignore vendor'
python -c "import vcs_versioning._file_finders as f, pprint; pprint.pprint(sorted(f.find_files('.')))"
```

**Before (wrong):** the export-ignore'd submodule leaks in —

```
['./.gitattributes', './.gitmodules', './parent_file.txt', './vendor/mysub/sub_file.txt']
```

`git archive HEAD | tar -t` on the same repo, by contrast, contains only `.gitattributes`, `.gitmodules`, `parent_file.txt`.

**After (correct):**

```
['./.gitattributes', './.gitmodules', './parent_file.txt']
```

## Fix

Drop `--recurse-submodules` from the `git ls-files` call in `vcs-versioning/src/vcs_versioning/_file_finders/_git.py`. This restores archive-equivalent behavior: submodules are listed as gitlinks and their contents are not descended into, so `export-ignore` on the submodule path is honored again. The change is a one-flag removal in a single discovery call; the `-z` NUL parsing and the `export-ignore` exclude pathspec that #1405 introduced are preserved, so the #662 fixes (staged-file visibility, safe parsing) are unaffected.

## Tests

- Added `test_git_export_ignore_submodule_excluded` (marked `@pytest.mark.issue(.../1469)`): a submodule under an `export-ignore`'d `vendor/` directory must not contribute any files to the listing. It fails on the unmodified code (`./vendor/mysub/sub_file.txt` present) and passes after the fix.
- Updated the former `test_git_submodule_files_listed` to `test_git_submodule_files_not_recursed`, asserting the restored archive-equivalent behavior (submodule contents are not recursed into). Both share a small `_make_submodule_source` helper.
- `uv run pytest vcs-versioning/testing_vcs/test_git.py` passes (the only failure, `test_git_getdate_signed_commit`, is a pre-existing GPG-signing environment issue that also fails on unmodified `main`). setuptools-scm regression/pyproject tests and the vcs file-finder/compat modules pass. `ruff check`, `ruff format`, `mypy --strict`, and `codespell` are clean.
- Added changelog fragment `vcs-versioning/changelog.d/1469.bugfix.md`.

Disclosure: prepared with AI assistance; reviewed and verified locally.
