### PR TITLE
fix: omit SCM egg-info JSON from wheels

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -89,7 +89,7 @@ SCM results always take priority over fallback results.
 | `hg-git` | vcs-versioning | SCM (Git + Mercurial) |
 | `archival` | vcs-versioning | Fallback (`.git_archival.txt`) |
 | `pkginfo` | setuptools-scm | Fallback (`PKG-INFO`) |
-| `egg-info` | setuptools-scm | Fallback (`*.egg-info/scm_version.json`) |
+| `egg-info` | setuptools-scm | Fallback (`*.egg-info/scm_version.json`; written for sdists, omitted from wheels) |
 
 
 ## Version number construction

--- a/setuptools-scm/changelog.d/1473.bugfix.md
+++ b/setuptools-scm/changelog.d/1473.bugfix.md
@@ -1,0 +1,2 @@
+Omit ``scm_version.json`` and ``scm_file_list.json`` from wheel ``.dist-info``
+while still including them in sdists for fallback discovery.

--- a/setuptools-scm/src/setuptools_scm/_integration/bdist_wheel.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/bdist_wheel.py
@@ -1,0 +1,41 @@
+"""bdist_wheel mixin that keeps SCM egg-info JSON out of wheels.
+
+``egg_info`` writes ``scm_version.json`` / ``scm_file_list.json`` for sdist
+fallback discovery. setuptools' ``egg2dist`` copies unknown egg-info files
+into ``.dist-info``, so wheels would otherwise ship them. Wheels already
+have ``METADATA`` and ``RECORD``; strip our files after conversion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+from vcs_versioning._scm_metadata import SCM_FILE_LIST_FILENAME
+from vcs_versioning._scm_metadata import SCM_VERSION_FILENAME
+
+_SCM_DIST_INFO_FILES = (SCM_VERSION_FILENAME, SCM_FILE_LIST_FILENAME)
+
+
+def _unlink_scm_metadata(distinfo_path: Path) -> None:
+    """Remove SCM metadata files from a ``.dist-info`` directory if present.
+
+    Mirrors setuptools ``egg2dist``'s ``adios`` for plain files: ``unlink``
+    when the path exists (including symlinks), never ``rmtree``.
+    """
+    for name in _SCM_DIST_INFO_FILES:
+        path = distinfo_path / name
+        if path.exists() or path.is_symlink():
+            path.unlink()
+
+
+class ScmBdistWheelMixin(_bdist_wheel):
+    """Mixin that strips SCM egg-info JSON from ``.dist-info`` after egg2dist."""
+
+    def egg2dist(self, egginfo_path: str, distinfo_path: str) -> None:
+        super().egg2dist(egginfo_path, distinfo_path)
+        _unlink_scm_metadata(Path(distinfo_path))
+
+
+class bdist_wheel(ScmBdistWheelMixin, _bdist_wheel):
+    """Default bdist_wheel that omits SCM metadata from wheels."""

--- a/setuptools-scm/src/setuptools_scm/_integration/bdist_wheel.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/bdist_wheel.py
@@ -18,15 +18,9 @@ _SCM_DIST_INFO_FILES = (SCM_VERSION_FILENAME, SCM_FILE_LIST_FILENAME)
 
 
 def _unlink_scm_metadata(distinfo_path: Path) -> None:
-    """Remove SCM metadata files from a ``.dist-info`` directory if present.
-
-    Mirrors setuptools ``egg2dist``'s ``adios`` for plain files: ``unlink``
-    when the path exists (including symlinks), never ``rmtree``.
-    """
+    """Remove SCM metadata files from a ``.dist-info`` directory if present."""
     for name in _SCM_DIST_INFO_FILES:
-        path = distinfo_path / name
-        if path.exists() or path.is_symlink():
-            path.unlink()
+        (distinfo_path / name).unlink(missing_ok=True)
 
 
 class ScmBdistWheelMixin(_bdist_wheel):

--- a/setuptools-scm/src/setuptools_scm/_integration/egg_info.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/egg_info.py
@@ -8,6 +8,7 @@ dispatches to ``setuptools.file_finders`` entry points with no context).
 Also writes ``scm_version.json`` and ``scm_file_list.json`` into the
 egg-info directory after ``run()`` creates it, so that sdists carry
 the metadata needed for fallback discovery when no VCS is present.
+Wheels omit these files via the ``bdist_wheel`` egg2dist mixin.
 """
 
 from __future__ import annotations

--- a/setuptools-scm/src/setuptools_scm/_integration/setuptools.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/setuptools.py
@@ -13,6 +13,8 @@ from vcs_versioning._toml import InvalidTomlError
 from vcs_versioning.overrides import GlobalOverrides
 from vcs_versioning.overrides import ensure_context
 
+from .bdist_wheel import ScmBdistWheelMixin
+from .bdist_wheel import bdist_wheel as scm_bdist_wheel
 from .build_py import ScmVersionFileMixin
 from .build_py import build_py as scm_build_py
 from .egg_info import ScmEggInfoMixin
@@ -92,6 +94,37 @@ def _register_egg_info_command(dist: setuptools.Distribution) -> None:
 
     dist.cmdclass["egg_info"] = wrapped
     log.debug("Wrapped project egg_info with setuptools_scm egg-info mixin")
+
+
+def _register_bdist_wheel_command(dist: setuptools.Distribution) -> None:
+    """Register bdist_wheel that strips SCM JSON from wheel ``.dist-info``.
+
+    Sdists keep ``scm_version.json`` / ``scm_file_list.json`` for fallback
+    discovery; wheels already have ``METADATA`` and ``RECORD``.
+    """
+    if not dist.cmdclass:
+        dist.cmdclass = {}
+
+    existing_bdist_wheel = dist.cmdclass.get("bdist_wheel")
+
+    if existing_bdist_wheel is None:
+        dist.cmdclass["bdist_wheel"] = scm_bdist_wheel
+        log.debug("Registered setuptools_scm bdist_wheel command")
+        return
+
+    project_bdist_wheel = cast("type[setuptools.Command]", existing_bdist_wheel)
+
+    if issubclass(project_bdist_wheel, ScmBdistWheelMixin):
+        return
+
+    wrapped = type(
+        "_SetuptoolsScmWrappedBdistWheel",
+        (ScmBdistWheelMixin, project_bdist_wheel),
+        {},
+    )
+
+    dist.cmdclass["bdist_wheel"] = wrapped
+    log.debug("Wrapped project bdist_wheel with setuptools_scm egg2dist mixin")
 
 
 def _log_hookstart(hook: str, dist: setuptools.Distribution) -> None:
@@ -177,6 +210,7 @@ def version_keyword(
 
     _register_build_py_command(dist)
     _register_egg_info_command(dist)
+    _register_bdist_wheel_command(dist)
 
 
 @ensure_context("SETUPTOOLS_SCM", additional_loggers=_setuptools_scm_logger)
@@ -237,3 +271,4 @@ def _infer_version_impl(
 
     _register_build_py_command(dist)
     _register_egg_info_command(dist)
+    _register_bdist_wheel_command(dist)

--- a/setuptools-scm/src/setuptools_scm/_integration/setuptools.py
+++ b/setuptools-scm/src/setuptools_scm/_integration/setuptools.py
@@ -13,8 +13,6 @@ from vcs_versioning._toml import InvalidTomlError
 from vcs_versioning.overrides import GlobalOverrides
 from vcs_versioning.overrides import ensure_context
 
-from .bdist_wheel import ScmBdistWheelMixin
-from .bdist_wheel import bdist_wheel as scm_bdist_wheel
 from .build_py import ScmVersionFileMixin
 from .build_py import build_py as scm_build_py
 from .egg_info import ScmEggInfoMixin
@@ -101,7 +99,20 @@ def _register_bdist_wheel_command(dist: setuptools.Distribution) -> None:
 
     Sdists keep ``scm_version.json`` / ``scm_file_list.json`` for fallback
     discovery; wheels already have ``METADATA`` and ``RECORD``.
+
+    Import is lazy so sdist-only environments without the ``wheel`` package
+    still load ``infer_version`` / ``version_keyword``.
     """
+    try:
+        from .bdist_wheel import ScmBdistWheelMixin
+        from .bdist_wheel import bdist_wheel as scm_bdist_wheel
+    except ImportError:
+        log.debug(
+            "bdist_wheel unavailable; skipping SCM wheel metadata strip",
+            exc_info=True,
+        )
+        return
+
     if not dist.cmdclass:
         dist.cmdclass = {}
 

--- a/setuptools-scm/testing_scm/test_integration.py
+++ b/setuptools-scm/testing_scm/test_integration.py
@@ -1672,6 +1672,82 @@ def test_manifest_in_excludes_scm_tracked_files(
     )
 
 
+@pytest.mark.issue(1473)
+def test_scm_metadata_in_sdist_not_in_wheel(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SCM egg-info JSON is for sdist fallback; wheels must not ship it."""
+    import shutil
+    import zipfile
+
+    from vcs_versioning._scm_metadata import SCM_FILE_LIST_FILENAME
+    from vcs_versioning._scm_metadata import SCM_VERSION_FILENAME
+
+    monkeypatch.chdir(wd.cwd)
+
+    wd.write(
+        "pyproject.toml",
+        textwrap.dedent("""\
+            [build-system]
+            requires = ["setuptools>=61", "setuptools-scm"]
+            build-backend = "setuptools.build_meta"
+
+            [project]
+            name = "test-pkg"
+            dynamic = ["version"]
+
+            [tool.setuptools_scm]
+        """),
+    )
+
+    pkg_dir = wd.cwd / "test_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+
+    wd(wd.add_command)
+    wd.commit()
+    wd("git tag v1.0.0")
+
+    sdist_names = _sdist_names(wd)
+    assert any(SCM_VERSION_FILENAME in n for n in sdist_names), (
+        f"{SCM_VERSION_FILENAME} should be in sdist: {sdist_names}"
+    )
+    assert any(SCM_FILE_LIST_FILENAME in n for n in sdist_names), (
+        f"{SCM_FILE_LIST_FILENAME} should be in sdist: {sdist_names}"
+    )
+
+    dist_dir = wd.cwd / "dist"
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+    for egg_info_dir in wd.cwd.glob("*.egg-info"):
+        shutil.rmtree(egg_info_dir)
+
+    build_result = subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--no-isolation"],
+        cwd=wd.cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build_result.returncode == 0, (
+        f"wheel build failed:\nstdout: {build_result.stdout}\n"
+        f"stderr: {build_result.stderr}"
+    )
+
+    wheels = list(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1, f"Expected 1 wheel, found {len(wheels)}"
+
+    with zipfile.ZipFile(wheels[0], "r") as whl:
+        names = whl.namelist()
+
+    assert not any(SCM_VERSION_FILENAME in n for n in names), (
+        f"{SCM_VERSION_FILENAME} must not be in wheel: {names}"
+    )
+    assert not any(SCM_FILE_LIST_FILENAME in n for n in names), (
+        f"{SCM_FILE_LIST_FILENAME} must not be in wheel: {names}"
+    )
+
+
 class TestIsInsidePackage:
     """Unit tests for _is_inside_package."""
 


### PR DESCRIPTION
## Summary
- Keep writing `scm_version.json` / `scm_file_list.json` into egg-info for sdist fallback discovery
- Wrap `bdist_wheel.egg2dist` to unlink those files from `.dist-info` after conversion (setuptools copies unknown egg-info files into wheels)
- Add regression test covering sdist inclusion and wheel exclusion

Fixes #1473

## Test plan
- [x] `uv run pytest setuptools-scm/testing_scm/test_integration.py::test_scm_metadata_in_sdist_not_in_wheel -n0`
- [ ] CI green
- [ ] Optional: build an sdist and wheel from a sample project and confirm JSON only in the sdist


Made with [Cursor](https://cursor.com)