### PR TITLE
fix: parse git describe suffix precisely (#1481)

### DIFF
--- a/vcs-versioning/changelog.d/1481.bugfix.md
+++ b/vcs-versioning/changelog.d/1481.bugfix.md
@@ -1,0 +1,1 @@
+Fix `ValueError` when parsing `.git_archival.txt` of a tagged commit whose tag contains more than one dash (e.g. `llvmorg-23.1.0-rc2`) - the `git describe` suffix is now matched precisely instead of splitting on the last two dashes.

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -33,6 +33,11 @@ log = logging.getLogger(__name__)
 REF_TAG_RE = re.compile(r"(?<=\btag: )([^,]+)\b")
 DESCRIBE_UNSUPPORTED = "%(describe"
 
+# ``git describe`` appends ``-<distance>-g<abbreviated node>`` to the tag name.
+# Tags may contain dashes themselves, so the suffix has to be matched precisely
+# instead of just splitting on the last two dashes.
+DESCRIBE_SUFFIX_RE = re.compile(r"^(?P<tag>.+)-(?P<distance>\d+)-g(?P<node>[0-9a-f]+)$")
+
 
 # If testing command in shell make sure to quote the match argument like
 # '*[0-9]*' as it will expand before being sent to git if there are any matching
@@ -473,15 +478,15 @@ def _git_parse_describe(
     else:
         dirty = False
 
-    split = describe_output.rsplit("-", 2)
-    if len(split) < 3:  # probably a tagged commit
-        tag = describe_output
-        number = 0
-        node = None
-    else:
-        tag, number_, node = split
-        number = int(number_)
-    return tag, number, node, dirty
+    match = DESCRIBE_SUFFIX_RE.match(describe_output)
+    if match is None:  # probably a tagged commit
+        return describe_output, 0, None, dirty
+    return (
+        match.group("tag"),
+        int(match.group("distance")),
+        "g" + match.group("node"),
+        dirty,
+    )
 
 
 def archival_to_version(

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -50,10 +50,15 @@ def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch, debug_mode: DebugMode) -> W
     [
         ("3.3.1-rc26-0-g9df187b", "3.3.1-rc26", 0, "g9df187b", False),
         ("17.33.0-rc-17-g38c3047c0", "17.33.0-rc", 17, "g38c3047c0", False),
+        ("v1.15.1rc1-37-g9bd1298-dirty", "v1.15.1rc1", 37, "g9bd1298", True),
+        # bare tags containing dashes must not be mistaken for describe output
+        ("llvmorg-23.1.0-rc2", "llvmorg-23.1.0-rc2", 0, None, False),
+        ("llvmorg-23.1.0-rc2-dirty", "llvmorg-23.1.0-rc2", 0, None, True),
+        ("release-1.2.2", "release-1.2.2", 0, None, False),
     ],
 )
 def test_parse_describe_output(
-    given: str, tag: str, number: int, node: str, dirty: bool
+    given: str, tag: str, number: int, node: str | None, dirty: bool
 ) -> None:
     parsed = _git._git_parse_describe(given)
     assert parsed == (tag, number, node, dirty)
@@ -648,6 +653,18 @@ def test_git_archival_to_version(expected: str, from_data: dict[str, str]) -> No
     version = archival_to_version(from_data, config=config)
     assert version is not None
     assert format_version(version) == expected
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1481")
+def test_git_archival_bare_tag_with_dashes() -> None:
+    config = Configuration(tag_regex=r"^llvmorg-(?P<version>.+)$")
+    version = archival_to_version(
+        {"describe-name": "llvmorg-23.1.0-rc2"}, config=config
+    )
+    assert version is not None
+    assert str(version.tag) == "23.1.0rc2"
+    assert version.distance == 0
+    assert version.node is None
 
 
 @pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/727")


### PR DESCRIPTION
Closes #1481

Bare tags with more than one dash (e.g. `llvmorg-23.1.0-rc2` in `.git_archival.txt`) were mistaken for `git describe` output because the parser split on the last two dashes. Match the `-<distance>-g<node>` suffix with a regex instead.

xref https://github.com/llvm/llvm-project/issues/212578

🤖 Generated with [Claude Code](https://claude.com/claude-code)