### PR TITLE
fix: speed up jj version inference in large repos

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -710,9 +710,10 @@ instead of the Git backend.
   (where both `.jj/` and `.git/` exist).
 - **Tags**: Version tags are read via `jj log` with revset expressions.
   Use `jj tag set v1.0.0` to create version tags.
-- **Distance**: The commit distance counts non-empty commits between the latest
-  tag and the working copy. In Jujutsu, the working copy itself is modeled as a
-  commit, so a dirty working copy adds 1 to the distance.
+- **Distance**: The commit distance counts the commits between the latest tag
+  and the head commit, matching `git describe --long`. In Jujutsu, the working
+  copy itself is modeled as a commit; it is the head while it holds changes, so
+  a dirty working copy adds 1 to the distance, and is skipped while empty.
 - **File finder**: Tracked files are listed via `jj file list`.
 
 #### Special considerations

--- a/vcs-versioning/changelog.d/1477.bugfix.md
+++ b/vcs-versioning/changelog.d/1477.bugfix.md
@@ -1,0 +1,11 @@
+Speed up jujutsu version inference in large repositories.
+
+The jj backend filtered whole-ancestry revsets with `empty()`, which makes
+jj diff every commit in the history and took minutes on large repos.  The
+scan for the newest real commit is now bounded to the most recent
+generations, distances are counted without the filter, and the working copy
+is snapshotted only once per run (later queries pass
+`--ignore-working-copy`).
+
+As a side effect distances now match `git describe --long`: merge commits
+count even though jj considers them empty.

--- a/vcs-versioning/src/vcs_versioning/_backends/_jj.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_jj.py
@@ -35,6 +35,16 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+ANCESTOR_SCAN_LIMIT = 20
+"""Generations of ancestors examined when looking for the newest real commit.
+
+Revsets filtered by ``empty()`` force jj to diff every candidate commit
+against its parents, so applying such a filter to the full ancestry costs
+O(history) and takes minutes in large repositories (issue #1477).  Empty
+commits only occur near the head in practice -- ``@`` itself, plus the
+occasional ``jj new`` chain -- so a small window suffices.
+"""
+
 
 def run_jj(
     args: Sequence[str | os.PathLike[str]],
@@ -42,17 +52,20 @@ def run_jj(
     *,
     check: bool = False,
     timeout: int | None = None,
+    ignore_working_copy: bool = False,
 ) -> _CompletedProcess:
-    return _run(
-        ["jj", "--no-pager", "--repository", str(repo), *args],
-        cwd=repo,
-        check=check,
-        timeout=timeout,
-    )
+    cmd: list[str | os.PathLike[str]] = ["jj", "--no-pager", "--repository", str(repo)]
+    if ignore_working_copy:
+        cmd.append("--ignore-working-copy")
+    cmd.extend(args)
+    return _run(cmd, cwd=repo, check=check, timeout=timeout)
 
 
 class JjWorkdir(Workdir):
     """Work directory backed by Jujutsu (jj)."""
+
+    _snapshot_taken: bool = False
+    """Whether a command in this process refreshed the working-copy commit."""
 
     def run_jj(
         self,
@@ -60,9 +73,24 @@ class JjWorkdir(Workdir):
         *,
         check: bool = False,
         timeout: int | None = None,
+        needs_snapshot: bool = False,
     ) -> _CompletedProcess:
+        """Run a jj command in this work directory.
+
+        jj snapshots the working copy on every invocation, which scans the
+        whole tree and writes an operation-log entry.  One snapshot per
+        process is enough, so history queries following it pass
+        ``--ignore-working-copy``.  Commands that must observe uncommitted
+        edits set ``needs_snapshot``.
+        """
+        ignore_working_copy = self._snapshot_taken and not needs_snapshot
+        self._snapshot_taken = True
         return run_jj(
-            args, self.path, check=check, timeout=timeout or self._subprocess_timeout
+            args,
+            self.path,
+            check=check,
+            timeout=timeout or self._subprocess_timeout,
+            ignore_working_copy=ignore_working_copy,
         )
 
     @classmethod
@@ -74,7 +102,7 @@ class JjWorkdir(Workdir):
             return None
 
         timeout = config.env.subprocess_timeout if config is not None else None
-        res = run_jj(["root"], wd, timeout=timeout)
+        res = run_jj(["root"], wd, timeout=timeout, ignore_working_copy=True)
         root = res.parse_success(parse=str)
         if root is None:
             return None
@@ -84,7 +112,7 @@ class JjWorkdir(Workdir):
         return result
 
     def is_dirty(self) -> bool:
-        res = self.run_jj(["diff", "--summary"])
+        res = self.run_jj(["diff", "--summary"], needs_snapshot=True)
         return res.parse_success(parse=bool, default=False)
 
     def get_branch(self) -> str | None:
@@ -133,25 +161,41 @@ class JjWorkdir(Workdir):
             error_msg="failed to get jj head date",
         )
 
+    def _count_revset(self, revset: str) -> int:
+        """Count the commits a revset resolves to."""
+        res = self.run_jj(["log", "--no-graph", "-r", revset, "-T", '"x\\n"'])
+        output = res.parse_success(parse=str)
+        if not output:
+            return 0
+        return output.count("\n") + 1
+
     def node(self) -> str | None:
-        res = self.run_jj(
-            [
-                "log",
-                "--no-graph",
-                "-r",
-                "latest(::@ ~ (empty() ~ tags()))",
-                "-T",
-                "commit_id",
-            ],
-        )
-        result = res.parse_success(parse=str)
-        return result if result else None
+        """Return the newest ancestor of ``@`` that is a real commit.
 
-    def _find_latest_tag(self) -> tuple[str | None, str | None]:
-        """Find the latest tagged ancestor of the working copy.
+        This is jj's equivalent of git's ``HEAD``: the working-copy commit
+        ``@`` is skipped while it holds no changes, as are the empty
+        commits a ``jj new`` chain leaves behind.  Merges and tagged
+        commits are kept even when empty -- git counts them too.
 
-        Returns (tag_name, commit_id) or (None, None) if no tags found.
+        Only ``ANCESTOR_SCAN_LIMIT`` generations are examined; the
+        unbounded query remains as a fallback for histories that are
+        empty all the way down.
         """
+        skip = "empty() ~ tags() ~ merges()"
+        revsets = [
+            f"latest(ancestors(@, {ANCESTOR_SCAN_LIMIT}) ~ ({skip}))",
+            f"latest(::@ ~ ({skip}))",
+        ]
+        for revset in revsets:
+            res = self.run_jj(["log", "--no-graph", "-r", revset, "-T", "commit_id"])
+            result = res.parse_success(parse=str)
+            if result:
+                return result
+            log.debug("no non-empty commit found in %s", revset)
+        return None
+
+    def _find_latest_tag(self) -> str | None:
+        """Find the tag of the latest tagged ancestor of the working copy."""
         res = self.run_jj(
             [
                 "log",
@@ -159,93 +203,58 @@ class JjWorkdir(Workdir):
                 "-r",
                 "latest(heads(::@ & tags()))",
                 "-T",
-                'tags.map(|t| t.name()).join(",") ++ "\\n" ++ commit_id',
+                'tags.map(|t| t.name()).join(",")',
             ],
         )
-        output = res.parse_success(parse=str)
-        if not output:
-            return None, None
-
-        lines = output.strip().split("\n")
-        if len(lines) < 2:
-            return None, None
-
-        tag_names = lines[0].strip()
-        commit_id = lines[1].strip()
+        tag_names = res.parse_success(parse=str)
         if not tag_names:
-            return None, None
+            return None
 
         # Take the first tag if multiple point at the same commit
-        tag = tag_names.split(",")[0].strip()
-        return tag, commit_id
+        return tag_names.split(",")[0].strip() or None
 
-    def _compute_distance(self, tag_name: str) -> int:
-        """Count non-empty commits between a tag and the working copy.
+    def _compute_distance(self, tag_name: str, node: str) -> int:
+        """Count the commits between a tag and ``node``.
 
-        In jj's model the working copy ``@`` is a real commit.  If it
-        contains changes it is counted as one commit of distance, which
-        is the semantically correct representation.
+        Mirrors ``git describe --long``: every commit in the range is
+        counted, the tagged commit itself is not.
         """
-        res = self.run_jj(
-            [
-                "log",
-                "--no-graph",
-                "-r",
-                f'"{tag_name}"::@ ~ empty()',
-                "-T",
-                'commit_id ++ "\\n"',
-            ],
-        )
-        output = res.parse_success(parse=str)
-        if not output:
-            return 0
+        return max(0, self._count_revset(f'"{tag_name}"::{node}') - 1)
 
-        # Each non-empty line is a commit; subtract 1 for the tagged commit itself
-        commits = [line for line in output.strip().split("\n") if line.strip()]
-        return max(0, len(commits) - 1)
+    def _count_ancestors(self, node: str) -> int:
+        """Count the ancestors of ``node``, excluding jj's virtual root."""
+        return self._count_revset(f"::{node} ~ root()")
 
     def count_all_nodes(self) -> int:
-        res = self.run_jj(
-            [
-                "log",
-                "--no-graph",
-                "-r",
-                "::@ ~ empty()",
-                "-T",
-                'commit_id ++ "\\n"',
-            ],
-        )
-        output = res.parse_success(parse=str)
-        if not output:
-            return 0
-        return len([line for line in output.strip().split("\n") if line.strip()])
+        node = self.node()
+        return self._count_ancestors(node) if node is not None else 0
 
     def get_scm_version(self) -> ScmVersion | None:
         config = self.config
 
-        tag_name, _tag_commit = self._find_latest_tag()
+        # first command in the process -- refreshes the working-copy commit
+        # so that the emptiness of ``@`` below reflects uncommitted edits
         dirty = self.is_dirty()
 
+        node = self.node()
+        tag_name = self._find_latest_tag()
+
         if tag_name is not None:
-            distance = self._compute_distance(tag_name)
-            node = self.node()
-            if node:
-                node = "j" + node[:12]
+            distance = 0 if node is None else self._compute_distance(tag_name, node)
             version = meta(
                 tag=tag_name,
                 distance=distance,
                 dirty=dirty,
-                node=node,
+                node=None if node is None else "j" + node[:12],
                 config=config,
             )
         else:
             tag = config.version_cls(config.fallback_version or "0.0")
-            node = self.node()
             if node is None:
                 distance = 0
                 dirty = True
             else:
-                distance = self.count_all_nodes()
+                distance = self._count_ancestors(node)
                 node = "j" + node[:12]
             version = meta(
                 tag=tag, distance=distance, dirty=dirty, node=node, config=config
@@ -270,7 +279,7 @@ class JjWorkdir(Workdir):
         return scm_find_files(base, jj_files, jj_dirs)
 
     def is_file_tracked(self, path: Path) -> bool:
-        res = self.run_jj(["file", "list", str(path)])
+        res = self.run_jj(["file", "list", str(path)], needs_snapshot=True)
         output = res.parse_success(parse=str)
         return bool(output)
 

--- a/vcs-versioning/src/vcs_versioning/_file_finders/_jj.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/_jj.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 def _jj_toplevel(path: str) -> str | None:
     try:
         cwd = os.path.abspath(path or ".")
-        res = _run(["jj", "root", "--no-pager"], cwd=cwd)
+        res = _run(["jj", "root", "--no-pager", "--ignore-working-copy"], cwd=cwd)
         if res.returncode:
             return None
         toplevel = res.stdout.strip()

--- a/vcs-versioning/testing_vcs/test_jj.py
+++ b/vcs-versioning/testing_vcs/test_jj.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -11,7 +12,7 @@ from vcs_versioning import Configuration
 from vcs_versioning._backends import _jj as jj
 from vcs_versioning._backends._discover_vcs import discover
 from vcs_versioning._file_finders._jj import jj_find_files
-from vcs_versioning._run_cmd import CommandNotFoundError
+from vcs_versioning._run_cmd import CommandNotFoundError, CompletedProcess, run
 from vcs_versioning.test_api import DebugMode, WorkDir
 
 
@@ -102,6 +103,65 @@ def test_jj_distance(wd: WorkDir) -> None:
     assert version is not None
     assert version.distance == 2
     assert str(version.tag) == "1.0.0"
+
+
+@pytest.mark.issue(1477)
+def test_jj_distance_counts_merges_like_git(wd: WorkDir) -> None:
+    """Merges are empty in jj terms but git counts them -- so do we."""
+    wd.commit_testfile()
+    wd("jj tag set v1.0.0 -r @-")
+    wd.commit_testfile()
+    main = wd("jj log --no-graph -r @- -T commit_id")
+
+    wd("jj new v1.0.0 -m side")
+    wd.write("side.txt", "side")
+    wd.add_and_commit("side")
+    side = wd("jj log --no-graph -r @- -T commit_id")
+
+    wd(f"jj new {main} {side} -m merge")
+    wd("jj commit -m merged")
+
+    version = jj.parse(wd.cwd, Configuration())
+    assert version is not None
+    assert version.distance == int(wd("git rev-list --count v1.0.0..HEAD"))
+    assert version.node == "j" + wd("git rev-parse HEAD")[:12]
+
+
+@pytest.mark.issue(1477)
+def test_jj_avoids_scanning_the_whole_history(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``empty()`` costs one commit diff per candidate -- keep it bounded.
+
+    An unbounded ``empty()`` filter turns version inference into a
+    minutes-long operation on large repositories.
+    """
+    wd.commit_testfile()
+    wd("jj tag set v1.0.0 -r @-")
+    wd.commit_testfile()
+
+    commands: list[list[str]] = []
+
+    def record(cmd: list[str], cwd: Path, **kwargs: Any) -> CompletedProcess:
+        commands.append([str(part) for part in cmd])
+        return run(cmd, cwd, **kwargs)
+
+    monkeypatch.setattr("vcs_versioning._backends._jj._run", record)
+    assert jj.parse(wd.cwd, Configuration()) is not None
+
+    revsets = [
+        cmd[index + 1]
+        for cmd in commands
+        for index, arg in enumerate(cmd)
+        if arg == "-r"
+    ]
+    assert revsets
+    bound = f"ancestors(@, {jj.ANCESTOR_SCAN_LIMIT})"
+    assert all("empty()" not in revset or bound in revset for revset in revsets)
+
+    # the working copy is snapshotted once, the history queries reuse it
+    snapshotting = [cmd for cmd in commands if "--ignore-working-copy" not in cmd]
+    assert len(snapshotting) == 1
 
 
 def test_jj_branch_detection(wd: WorkDir) -> None:


### PR DESCRIPTION
Closes #1477

`empty()` makes jj diff every candidate commit against its parents, so the
whole-ancestry revsets the backend used cost O(history) — minutes on large
repos. The scan for the newest real commit is now bounded to the last 20
generations, distances are counted without `empty()`, and the working copy is
snapshotted once instead of six times. On a colocated 17.5k commit repo:
3.4s → 0.4s.

Side effect: distances now match `git describe --long`, because merge commits
count even though jj considers them empty (that repo went from
`9.2.0.dev92+j8310c5bc0` to git's `dev117`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)