### PR TITLE
Improve reproducibility of scm_file_list.json

### DIFF
--- a/vcs-versioning/changelog.d/1488.bugfix.md
+++ b/vcs-versioning/changelog.d/1488.bugfix.md
@@ -1,0 +1,1 @@
+Improve reproducibility of scm_file_list.json

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -255,7 +255,7 @@ class GitWorkdir(Workdir):
         git_files, git_dirs = _git_ls_files_and_dirs(
             str(self.path), timeout=self._subprocess_timeout
         )
-        return scm_find_files(base, git_files, git_dirs)
+        return sorted(scm_find_files(base, git_files, git_dirs))
 
     def is_file_tracked(self, path: Path) -> bool:
         res = self.run_git(


### PR DESCRIPTION
As part of Freedesktop SDKs work on reproducibility we do regular testing of the elements we package. In a recent round of testing we noticed that several python elements using the setuptools backend were failing reproducibility checks due to differently ordered scm_file_list.json files.

This fix just simply sorts the output of `scm_find_files` in the GitWorkdir class so that the list is reproducibly in the same order each time.

Links to the issues on Freedesktop SDK and the PR testing the patch:
- [Issue 2007](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/work_items/2007#note_3532562291)
- [MR 33655](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/merge_requests/33655/diffs)