### PR TITLE
fix: make describe command warnings coherent

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -84,7 +84,7 @@ strict = true      # require tags to contain at least one dot
 
     | Value   | Behavior |
     |---------|----------|
-    | unset (`None`) | Current permissive matching (`*[0-9]*`) with a `FutureWarning` advising you to set this explicitly. |
+    | unset (`None`) | Current permissive matching (`*[0-9]*`) with a `FutureWarning` advising you to set this explicitly, unless `scm.git.describe_command` supplies the describe command. |
     | `true` | **Strict** – tags must contain at least one dot (e.g. `*[0-9]*.*[0-9]*`).  Event-like tags such as `2026-event` are rejected. |
     | `false` | **Permissive** – matches any tag containing a digit (`*[0-9]*`), no warning. |
 
@@ -182,8 +182,10 @@ strict = true      # require tags to contain at least one dot
     !!! warning "Overrides tag.prefix / tag.strict"
 
         When `scm.git.describe_command` is explicitly set, `tag.prefix` and
-        `tag.strict` have no effect on the describe match pattern (a warning
-        is emitted).  The explicit command takes full precedence.
+        `tag.strict` have no effect on the describe match pattern. A non-empty
+        `tag.prefix` or `tag.strict = true` emits a warning; the explicit
+        permissive value `tag.strict = false` does not. `tag.prefix` is still
+        stripped from the tag returned by the custom command before parsing.
 
 `scm.git.pre_parse`
 :   A string specifying which git pre-parse function to use before parsing version information.

--- a/vcs-versioning/changelog.d/1429.bugfix.md
+++ b/vcs-versioning/changelog.d/1429.bugfix.md
@@ -1,0 +1,1 @@
+Avoid conflicting tag matching warnings when a custom Git describe command is configured.

--- a/vcs-versioning/src/vcs_versioning/_config.py
+++ b/vcs-versioning/src/vcs_versioning/_config.py
@@ -49,6 +49,30 @@ def _is_called_from_dataclasses() -> bool:
         del frame
 
 
+def _warning_stacklevel() -> int:
+    """Point configuration warnings at the first external caller."""
+    import inspect
+
+    frame = inspect.currentframe()
+    try:
+        current_frame = frame
+        stacklevel = 0
+        while current_frame is not None:
+            current_frame = current_frame.f_back
+            if current_frame is None:
+                break
+            stacklevel += 1
+            filename = current_frame.f_code.co_filename
+            if (
+                filename != "<string>"
+                and Path(filename).resolve() != Path(__file__).resolve()
+            ):
+                return stacklevel
+        return 2
+    finally:
+        del frame
+
+
 class _GitDescribeCommandDescriptor:
     """Data descriptor for deprecated git_describe_command field."""
 
@@ -343,21 +367,6 @@ class Configuration:
                     self.tag, regex=_check_tag_regex(tag_regex)
                 )
 
-        # TODO(#1429): re-introduce these warnings with non-conflicting logic
-        if self.tag.strict is None:
-            log.debug(
-                "tag.strict is not set — defaults to False (permissive tag matching)"
-            )
-
-        if (
-            self.tag.prefix or self.tag.strict is not None
-        ) and self.scm.git.describe_command is not None:
-            log.debug(
-                "Both tag.prefix/tag.strict and scm.git.describe_command are set. "
-                "The explicit describe_command takes precedence; tag.prefix and "
-                "tag.strict will have no effect on the git describe match pattern."
-            )
-
         self._resolved_paths = resolve_paths(
             relative_to=self.relative_to,
             root=self.root,
@@ -396,6 +405,29 @@ class Configuration:
                         "'scm.git.describe_command'. Please use only 'scm.git.describe_command'."
                     )
                 self.scm.git.describe_command = git_describe_command
+
+        describe_command_is_set = self.scm.git.describe_command is not None
+
+        if self.tag.strict is None and not describe_command_is_set:
+            warnings.warn(
+                "tag.strict is not set. Currently defaults to False (permissive "
+                "tag matching). In a future major version the default will change "
+                "to True (require tags to contain a dot). "
+                "Set tag.strict = true or tag.strict = false explicitly in your "
+                "[tool.setuptools_scm] / [tool.vcs-versioning] config to silence "
+                "this warning.",
+                FutureWarning,
+                stacklevel=_warning_stacklevel(),
+            )
+
+        if describe_command_is_set and (self.tag.prefix or self.tag.strict is True):
+            warnings.warn(
+                "Both tag.prefix/tag.strict and scm.git.describe_command are set. "
+                "The explicit describe_command takes precedence; tag.prefix and "
+                "tag.strict will have no effect on the git describe match pattern.",
+                UserWarning,
+                stacklevel=_warning_stacklevel(),
+            )
 
     @property
     def absolute_root(self) -> str:

--- a/vcs-versioning/testing_vcs/test_tag_config.py
+++ b/vcs-versioning/testing_vcs/test_tag_config.py
@@ -59,12 +59,12 @@ class TestDescribeMatchGlob:
         assert tc.describe_match_glob() == "*[0-9]*"
 
 
+@pytest.mark.issue(1429)
 class TestTagStrictWarning:
-    def test_none_strict_no_warning(self) -> None:
-        """tag.strict=None no longer warns (suppressed per #1422, see #1429)."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
+    def test_none_strict_emits_future_warning(self) -> None:
+        with pytest.warns(FutureWarning, match="tag.strict is not set") as recorded:
             Configuration(tag=TagConfiguration(strict=None))
+        assert recorded[0].filename == __file__
 
     def test_true_strict_no_warning(self) -> None:
         with warnings.catch_warnings():
@@ -81,13 +81,13 @@ class TestTagPrefixStripping:
     """Test that tag.prefix is stripped before tag_regex matching."""
 
     def test_prefix_stripped_from_tag(self) -> None:
-        config = Configuration(tag=TagConfiguration(prefix="hatchling-v"))
+        config = Configuration(tag=TagConfiguration(prefix="hatchling-v", strict=False))
         version = tag_to_version("hatchling-v1.0.0", config)
         assert version is not None
         assert str(version) == "1.0.0"
 
     def test_no_prefix_no_stripping(self) -> None:
-        config = Configuration(tag=TagConfiguration(prefix=""))
+        config = Configuration(tag=TagConfiguration(prefix="", strict=False))
         version = tag_to_version("v1.0.0", config)
         assert version is not None
         assert str(version) == "1.0.0"
@@ -99,13 +99,13 @@ class TestTagPrefixStripping:
         may still parse -- but the prefix is NOT stripped, meaning
         git describe --match would have already filtered it out in practice.
         """
-        config = Configuration(tag=TagConfiguration(prefix="other-"))
+        config = Configuration(tag=TagConfiguration(prefix="other-", strict=False))
         version = tag_to_version("hatchling-v1.0.0", config)
         # Default tag_regex matches and extracts "v1.0.0" from dashed prefix
         assert version is not None
 
     def test_prefix_v_strips_v(self) -> None:
-        config = Configuration(tag=TagConfiguration(prefix="v"))
+        config = Configuration(tag=TagConfiguration(prefix="v", strict=False))
         version = tag_to_version("v1.2.3", config)
         assert version is not None
         assert str(version) == "1.2.3"
@@ -115,13 +115,13 @@ class TestTagToVersionSuffixPreservation:
     """Test that tag_to_version preserves +local suffixes when possible."""
 
     def test_tag_with_build_metadata_preserved(self) -> None:
-        config = Configuration()
+        config = Configuration(tag=TagConfiguration(strict=False))
         version = tag_to_version("1.2.3+build.123", config)
         assert version is not None
         assert str(version) == "1.2.3+build.123"
 
     def test_tag_with_invalid_suffix_stripped(self) -> None:
-        config = Configuration()
+        config = Configuration(tag=TagConfiguration(strict=False))
         # "+invalid!!" is captured as suffix by the default regex but
         # Version("1.2.3+invalid!!") raises, so the suffix gets stripped
         with pytest.warns(UserWarning, match="will be stripped of its suffix"):
@@ -138,7 +138,7 @@ class TestTagToVersionSuffixPreservation:
         ],
     )
     def test_various_build_metadata_tags(self, tag: str, expected: str) -> None:
-        config = Configuration()
+        config = Configuration(tag=TagConfiguration(strict=False))
         version = tag_to_version(tag, config)
         assert version is not None
         assert str(version) == expected
@@ -149,7 +149,10 @@ class TestTagToVersionSuffixPreservation:
         def rejecting_version_cls(version_str: str) -> Version:
             raise ValueError(f"rejected: {version_str}")
 
-        config = Configuration(version_cls=rejecting_version_cls)  # type: ignore[arg-type]
+        config = Configuration(
+            version_cls=rejecting_version_cls,  # type: ignore[arg-type]
+            tag=TagConfiguration(strict=False),
+        )
         with pytest.warns(UserWarning, match="could not be parsed"):
             result = tag_to_version("1.2.3", config)
         assert result is None
@@ -170,26 +173,77 @@ class TestConfigFromData:
         assert config.tag.strict is True
 
     def test_no_tag_in_from_data(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
+        with pytest.warns(FutureWarning, match="tag.strict") as recorded:
             config = Configuration.from_data(
                 relative_to=".",
                 data={"dist_name": "test"},
             )
         assert config.tag.prefix == ""
         assert config.tag.strict is None
+        future_warning = next(
+            item for item in recorded if item.category is FutureWarning
+        )
+        assert future_warning.filename == __file__
 
 
+@pytest.mark.issue(1429)
 class TestDescribeCommandConflictWarning:
-    def test_no_warning_when_prefix_and_describe_command_both_set(self) -> None:
-        """Suppressed per #1422, see #1429 for follow-up."""
+    @staticmethod
+    def make_config(*, prefix: str = "", strict: bool | None = None) -> Configuration:
         from vcs_versioning._config import GitConfiguration, ScmConfiguration
 
+        return Configuration(
+            tag=TagConfiguration(prefix=prefix, strict=strict),
+            scm=ScmConfiguration(
+                git=GitConfiguration(describe_command=["git", "describe", "--tags"])
+            ),
+        )
+
+    def test_no_warning_with_default_tag_config(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            warnings.simplefilter("error", UserWarning)
+            self.make_config()
+
+    def test_no_warning_with_explicit_permissive_strict(self) -> None:
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
+            self.make_config(strict=False)
+
+    def test_warns_with_strict_enabled(self) -> None:
+        with pytest.warns(UserWarning, match="scm.git.describe_command"):
+            self.make_config(strict=True)
+
+    def test_warns_with_prefix(self) -> None:
+        with pytest.warns(UserWarning, match="scm.git.describe_command"):
+            self.make_config(prefix="v")
+
+    def test_prefix_is_still_stripped_from_returned_tag(self) -> None:
+        with pytest.warns(UserWarning, match="scm.git.describe_command"):
+            config = self.make_config(prefix="v")
+
+        version = tag_to_version("v1.2.3", config)
+        assert version is not None
+        assert str(version) == "1.2.3"
+
+    @pytest.mark.parametrize(
+        ("strict", "expected_categories"),
+        [
+            (None, (DeprecationWarning,)),
+            (False, (DeprecationWarning,)),
+            (True, (DeprecationWarning, UserWarning)),
+        ],
+    )
+    def test_deprecated_describe_command_warning_interaction(
+        self,
+        strict: bool | None,
+        expected_categories: tuple[type[Warning], ...],
+    ) -> None:
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
             Configuration(
-                tag=TagConfiguration(prefix="v", strict=True),
-                scm=ScmConfiguration(
-                    git=GitConfiguration(describe_command=["git", "describe", "--tags"])
-                ),
+                tag=TagConfiguration(strict=strict),
+                git_describe_command=["git", "describe", "--tags"],
             )
+
+        assert tuple(item.category for item in recorded) == expected_categories


### PR DESCRIPTION
Fixes #1429.

## Summary

- suppress the `tag.strict` future warning when a custom Git describe command supplies the matching behavior
- emit the conflict warning only for `tag.strict = true` or a non-empty `tag.prefix`
- evaluate deprecated `git_describe_command` values after normalization so both configuration forms behave consistently
- point configuration warnings at the external caller and document that `tag.prefix` still strips returned tags

## Validation

- hosted validation: 24 checks passed, covering Ubuntu and Windows on Python 3.8-3.13, PyPy 3.11, MSYS2, package builds, API stability, documentation, pre-commit, and changelog validation; 7 release-only jobs were conditionally skipped
- `vcs-versioning/testing_vcs/test_tag_config.py`: 33 passed
- core `vcs-versioning/testing_vcs`: 535 passed, 66 skipped, 1 xfailed, 2 failed
- the two failures require the POSIX `rm` and `ls` commands and reproduce unchanged on `aef602d8`
- Ruff 0.16.1 check and format check passed
- Mypy 2.3.0 strict check passed for the changed Python files
- codespell and `git diff --check` passed
