### PR TITLE
fix: make tag.strict and describe_command diagnostics actionable

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -84,15 +84,22 @@ strict = true      # require tags to contain at least one dot
 
     | Value   | Behavior |
     |---------|----------|
-    | unset (`None`) | Current permissive matching (`*[0-9]*`) with a `FutureWarning` advising you to set this explicitly. |
+    | unset (`None`) | Current permissive matching (`*[0-9]*`). |
     | `true` | **Strict** – tags must contain at least one dot (e.g. `*[0-9]*.*[0-9]*`).  Event-like tags such as `2026-event` are rejected. |
-    | `false` | **Permissive** – matches any tag containing a digit (`*[0-9]*`), no warning. |
+    | `false` | **Permissive** – matches any tag containing a digit (`*[0-9]*`). |
 
     !!! note "Migration"
 
         In a future major release the default will change from permissive to strict.
         Set `tag.strict = false` now if you rely on the permissive matching, or
         `tag.strict = true` to adopt the stricter behavior early.
+
+        While `tag.strict` is unset, a warning is logged **only** if the future
+        default would actually pick a different tag for your repository, naming
+        both the current and the future version.  Projects the change cannot
+        affect are never nagged.  Silence it with `SETUPTOOLS_SCM_DEBUG=ERROR`
+        if you cannot act on it, for example when building someone else's
+        project from a checkout.
 
     `tag.prefix` and `tag.strict` compose naturally:
 
@@ -179,11 +186,17 @@ strict = true      # require tags to contain at least one dot
 
     Defaults to the value set by [vcs_versioning._backends._git.DEFAULT_DESCRIBE][]
 
-    !!! warning "Overrides tag.prefix / tag.strict"
+    !!! warning "Overrides tag.strict"
 
-        When `scm.git.describe_command` is explicitly set, `tag.prefix` and
-        `tag.strict` have no effect on the describe match pattern (a warning
-        is emitted).  The explicit command takes full precedence.
+        When `scm.git.describe_command` is explicitly set, it supplies its own
+        `--match` pattern, so `tag.strict` has no effect on tag matching.  A
+        warning is emitted only if the two would actually select different
+        tags for your repository.
+
+        `tag.prefix` is *not* overridden: it still strips the prefix from the
+        selected tag before version parsing, so combining it with an explicit
+        `describe_command` is a supported way to bring your own match pattern
+        while keeping prefix stripping.
 
 `scm.git.pre_parse`
 :   A string specifying which git pre-parse function to use before parsing version information.

--- a/vcs-versioning/changelog.d/1429.bugfix.md
+++ b/vcs-versioning/changelog.d/1429.bugfix.md
@@ -1,0 +1,7 @@
+Make the `tag.strict` and `scm.git.describe_command` diagnostics actionable and non-conflicting.
+
+The `tag.strict` future-default notice is now reported by the git backend rather than at configuration time, and only when the future default would actually select a different tag for the repository -- the message names both the current and the future version string. Projects the change cannot affect are silent, and setting an explicit `describe_command` no longer triggers it at all, so the two warnings can no longer contradict each other.
+
+The `describe_command` notice is likewise limited to the case where it and an explicit `tag.strict` really disagree, and no longer claims that `tag.prefix` has no effect -- prefix stripping applies regardless of how the tag was selected.
+
+Both are logged at warning level instead of raised as warnings, so `SETUPTOOLS_SCM_DEBUG=ERROR` silences them.

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import fnmatch
 import logging
 import os
 import re
@@ -23,10 +24,11 @@ from .._run_cmd import CompletedProcess as _CompletedProcess
 from .._run_cmd import require_command as _require_command
 from .._run_cmd import run as _run
 from .._scm_version import ScmVersion, meta, tag_to_version
+from .._version_schemes import format_version
 from ._scm_workdir import Workdir, get_latest_file_mtime
 
 if TYPE_CHECKING:
-    from .._protocols import DescribeCapable
+    from .._protocols import DescribeCapable, GitQueryable
     from . import _hg_git as hg_git
 log = logging.getLogger(__name__)
 
@@ -232,7 +234,10 @@ class GitWorkdir(Workdir):
     def default_describe(self) -> _CompletedProcess:
         match_glob = self.config.tag.describe_match_glob()
         cmd = make_describe_command(match_glob)
-        return self.run_git(cmd[1:])
+        res = self.run_git(cmd[1:])
+        if self.config.tag.strict is None:
+            _warn_if_strict_would_differ(self, self.config, res)
+        return res
 
     def get_scm_version(self) -> ScmVersion | None:
         """Obtain version metadata from this git work directory."""
@@ -262,6 +267,130 @@ class GitWorkdir(Workdir):
             ["ls-files", "--error-unmatch", str(path)],
         )
         return res.returncode == 0
+
+
+_diagnostics_reported: set[str] = set()
+
+
+def _report_once(key: str, message: str, *args: object) -> None:
+    """Log a config diagnostic at most once per process.
+
+    Unlike ``warnings.warn`` the logging module does not deduplicate, and a
+    build constructs the configuration more than once (metadata hook plus
+    build hook), so the guard is explicit.
+    """
+    if key in _diagnostics_reported:
+        return
+    _diagnostics_reported.add(key)
+    log.warning(message, *args)
+
+
+def _describe_tag(output: str) -> str | None:
+    """Extract just the tag name from a ``git describe --long`` output."""
+    if not output.strip():
+        return None
+    return _git_parse_describe(output.strip())[0]
+
+
+def _strict_match_glob(prefix: str) -> str:
+    """The ``--match`` glob ``tag.strict = true`` would produce."""
+    return f"{prefix}*[0-9]*.*[0-9]*"
+
+
+def _config_location(config: Configuration) -> str:
+    return str(config.relative_to or "your pyproject.toml")
+
+
+def _describe_outcome(output: str, config: Configuration) -> str:
+    """Render what *output* would yield, for use in a diagnostic message.
+
+    Shows the resulting version string rather than just the tag, since the
+    version is what the user actually cares about.  Falls back to prose when
+    no tag matched or the tag does not parse as a version.
+    """
+    if not output.strip():
+        return "no matching tag, falling back to the fallback version"
+
+    tag, distance, node, dirty = _git_parse_describe(output.strip())
+    try:
+        # meta() warns before raising on an unparsable tag; this is a
+        # hypothetical, so neither the warning nor the error should escape
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            scm_version = meta(
+                tag=tag, distance=distance, dirty=dirty, node=node, config=config
+            )
+            version = format_version(scm_version)
+    except (ValueError, TypeError):
+        return f"no usable version -- tag {tag!r} does not parse as a version"
+    return f"{version} (from tag {tag!r})"
+
+
+def _warn_if_strict_would_differ(
+    wd: GitQueryable, config: Configuration, permissive: _CompletedProcess
+) -> None:
+    """Report the ``tag.strict`` future default only when it changes the answer.
+
+    ``tag.strict`` is unset, so the permissive glob was used.  Stay silent
+    unless the strict glob would pick a different tag, so that projects the
+    future default cannot affect are never nagged.
+    """
+    permissive_tag = _describe_tag(permissive.stdout)
+    strict_glob = _strict_match_glob(config.tag.prefix)
+
+    if permissive_tag is None:
+        # nothing matched the wider glob, so nothing matches the narrower one
+        return
+    if fnmatch.fnmatchcase(permissive_tag, strict_glob):
+        # the strict glob matches a subset of the permissive one, so a
+        # permissive answer that is itself strict-matching is also the
+        # closest strict-matching tag -- no subprocess needed
+        return
+
+    strict = wd.run_git(make_describe_command(strict_glob)[1:])
+    _report_once(
+        f"strict-divergence:{wd.path}:{permissive_tag}:{_describe_tag(strict.stdout)}",
+        "tag.strict is not set, and the future default changes this"
+        " repository's version:\n"
+        "  now (tag.strict = false):           %s\n"
+        "  future default (tag.strict = true): %s\n"
+        "Set tag.strict explicitly in the [tool.setuptools_scm] table of %s.",
+        _describe_outcome(permissive.stdout, config),
+        _describe_outcome(strict.stdout, config),
+        _config_location(config),
+    )
+
+
+def _warn_if_describe_command_overrides_strict(
+    wd: GitQueryable, config: Configuration, describe_res: _CompletedProcess
+) -> None:
+    """Report that ``describe_command`` beat an explicit ``tag.strict``.
+
+    Only fires when the two actually disagree about which tag to use --
+    setting both is harmless as long as they pick the same tag.  ``tag.prefix``
+    is deliberately not mentioned: it still strips the prefix before version
+    parsing, so combining it with ``describe_command`` is legitimate.
+    """
+    strict_glob = _strict_match_glob(config.tag.prefix)
+    strict = wd.run_git(make_describe_command(strict_glob)[1:])
+    strict_tag = _describe_tag(strict.stdout)
+    describe_tag = _describe_tag(describe_res.stdout)
+    if strict_tag == describe_tag:
+        return
+
+    _report_once(
+        f"describe-overrides-strict:{wd.path}:{describe_tag}:{strict_tag}",
+        "scm.git.describe_command takes precedence over tag.strict, and they"
+        " disagree for this repository:\n"
+        "  describe_command gives:      %s\n"
+        "  tag.strict = %s would give: %s\n"
+        "Drop tag.strict, or drop describe_command and let tag.prefix/tag.strict"
+        " build the match pattern, in %s.",
+        _describe_outcome(describe_res.stdout, config),
+        str(config.tag.strict).lower(),
+        _describe_outcome(strict.stdout, config),
+        _config_location(config),
+    )
 
 
 def warn_on_shallow(wd: GitWorkdir) -> None:
@@ -410,6 +539,8 @@ def version_from_describe(
             describe_res = wd.run_git(cmd_args[1:])
         else:
             describe_res = _run(cmd_args, wd.path, timeout=wd._subprocess_timeout)
+        if config.tag.strict is not None:
+            _warn_if_describe_command_overrides_strict(wd, config, describe_res)
     else:
         describe_res = wd.default_describe()
 

--- a/vcs-versioning/src/vcs_versioning/_config.py
+++ b/vcs-versioning/src/vcs_versioning/_config.py
@@ -343,20 +343,9 @@ class Configuration:
                     self.tag, regex=_check_tag_regex(tag_regex)
                 )
 
-        # TODO(#1429): re-introduce these warnings with non-conflicting logic
-        if self.tag.strict is None:
-            log.debug(
-                "tag.strict is not set — defaults to False (permissive tag matching)"
-            )
-
-        if (
-            self.tag.prefix or self.tag.strict is not None
-        ) and self.scm.git.describe_command is not None:
-            log.debug(
-                "Both tag.prefix/tag.strict and scm.git.describe_command are set. "
-                "The explicit describe_command takes precedence; tag.prefix and "
-                "tag.strict will have no effect on the git describe match pattern."
-            )
+        # tag.strict and describe_command diagnostics deliberately do not live
+        # here: they are only actionable once the SCM has been consulted, so the
+        # git backend reports them when they actually change the version (#1429)
 
         self._resolved_paths = resolve_paths(
             relative_to=self.relative_to,

--- a/vcs-versioning/src/vcs_versioning/_protocols.py
+++ b/vcs-versioning/src/vcs_versioning/_protocols.py
@@ -70,7 +70,20 @@ class ScmWorkdirProtocol(WorkdirProtocol, Protocol):
 # ---------------------------------------------------------------------------
 
 
-class DescribeCapable(Protocol):
+class GitQueryable(Protocol):
+    """Bare git access: enough to run an extra query against a checkout.
+
+    Used by the configuration diagnostics, which re-run ``git describe`` with
+    a different ``--match`` to find out whether a setting changes the version.
+    """
+
+    @property
+    def path(self) -> Path: ...
+
+    def run_git(self, args: Sequence[str]) -> CompletedProcess: ...
+
+
+class DescribeCapable(GitQueryable, Protocol):
     """What version_from_describe() needs to produce a describe result.
 
     Implemented by GitWorkdir (native git describe) and GitWorkdirHgClient
@@ -78,14 +91,9 @@ class DescribeCapable(Protocol):
     """
 
     @property
-    def path(self) -> Path: ...
-
-    @property
     def _subprocess_timeout(self) -> int | None: ...
 
     def default_describe(self) -> CompletedProcess: ...
-
-    def run_git(self, args: Sequence[str]) -> CompletedProcess: ...
 
 
 class WorkdirState(Protocol):

--- a/vcs-versioning/testing_vcs/test_tag_config.py
+++ b/vcs-versioning/testing_vcs/test_tag_config.py
@@ -61,7 +61,11 @@ class TestDescribeMatchGlob:
 
 class TestTagStrictWarning:
     def test_none_strict_no_warning(self) -> None:
-        """tag.strict=None no longer warns (suppressed per #1422, see #1429)."""
+        """Configuration construction never warns about tag.strict.
+
+        The future-default notice moved to the git backend, which reports it
+        only when it changes the version -- see test_tag_strict_diagnostics.
+        """
         with warnings.catch_warnings():
             warnings.simplefilter("error", FutureWarning)
             Configuration(tag=TagConfiguration(strict=None))
@@ -182,7 +186,12 @@ class TestConfigFromData:
 
 class TestDescribeCommandConflictWarning:
     def test_no_warning_when_prefix_and_describe_command_both_set(self) -> None:
-        """Suppressed per #1422, see #1429 for follow-up."""
+        """tag.prefix keeps working with describe_command, so it never warns.
+
+        The prefix is stripped before version parsing regardless of how the
+        tag was selected; only tag.strict is overridden, and the git backend
+        reports that only when the two actually disagree.
+        """
         from vcs_versioning._config import GitConfiguration, ScmConfiguration
 
         with warnings.catch_warnings():

--- a/vcs-versioning/testing_vcs/test_tag_strict_diagnostics.py
+++ b/vcs-versioning/testing_vcs/test_tag_strict_diagnostics.py
@@ -1,0 +1,301 @@
+"""Tests for the actionable ``tag.strict`` / ``describe_command`` diagnostics.
+
+The diagnostics only fire when the setting in question actually changes the
+version for the repository at hand -- see #1429.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+import pytest
+from vcs_versioning import Configuration
+from vcs_versioning._backends import _git
+from vcs_versioning._config import TagConfiguration
+from vcs_versioning._run_cmd import CompletedProcess
+from vcs_versioning._test_utils import WorkDir
+
+
+@pytest.fixture(autouse=True)
+def _reset_reported() -> Iterator[None]:
+    """The once-per-process guard would otherwise leak between tests."""
+    _git._diagnostics_reported.clear()
+    yield
+    _git._diagnostics_reported.clear()
+
+
+@pytest.fixture
+def wd(wd: WorkDir, monkeypatch: pytest.MonkeyPatch) -> WorkDir:
+    wd.setup_git(monkeypatch)
+    return wd
+
+
+def reported(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Messages of warning-or-worse records; debug logging is noise here."""
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def describe_output(tag: str, distance: int = 1, node: str = "abcdef1") -> str:
+    return f"{tag}-{distance}-g{node}"
+
+
+class FakeWorkdir:
+    """Minimal stand-in providing the parts the diagnostics use."""
+
+    def __init__(self, config: Configuration, results: dict[str, str]) -> None:
+        self.config = config
+        self.path = Path("/fake/repo")
+        self.results = results
+        self.calls: list[str] = []
+
+    def run_git(self, args: Sequence[str]) -> CompletedProcess:
+        args = list(args)
+        match = args[args.index("--match") + 1]
+        self.calls.append(match)
+        stdout = self.results.get(match, "")
+        return CompletedProcess(
+            args=args, returncode=0 if stdout else 128, stdout=stdout, stderr=""
+        )
+
+
+def make_config(**tag_kw: object) -> Configuration:
+    return Configuration(tag=TagConfiguration(**tag_kw))  # type: ignore[arg-type]
+
+
+class TestStrictMatchGlob:
+    """The strict glob must match a subset of the permissive one."""
+
+    @pytest.mark.parametrize("prefix", ["", "v", "hatchling-v"])
+    def test_glob_shape(self, prefix: str) -> None:
+        assert _git._strict_match_glob(prefix) == f"{prefix}*[0-9]*.*[0-9]*"
+
+    @pytest.mark.parametrize(
+        ("tag", "matches"),
+        [
+            ("v1.2.3", True),
+            ("1.0", True),
+            ("1.2.3rc1", True),
+            ("2024", False),
+            ("event-2024", False),
+            # a dot is not sufficient -- the glob needs a digit before it,
+            # which is why "does the tag contain a dot" is not a valid shortcut
+            ("rel.2024", False),
+            ("nightly", False),
+        ],
+    )
+    def test_strict_glob_membership(self, tag: str, matches: bool) -> None:
+        assert fnmatch.fnmatchcase(tag, _git._strict_match_glob("")) is matches
+
+
+class TestDescribeTag:
+    @pytest.mark.parametrize(
+        ("output", "expected"),
+        [
+            ("v1.2.3-0-gabcdef1", "v1.2.3"),
+            ("v1.2.3-4-gabcdef1-dirty", "v1.2.3"),
+            # tags may contain dashes themselves
+            ("event-2024-1-gabcdef1", "event-2024"),
+            # a node ending in hex letters must not be truncated
+            ("v1.2.3-0-gabcddd-dirty", "v1.2.3"),
+            ("", None),
+            ("   ", None),
+        ],
+    )
+    def test_describe_tag(self, output: str, expected: str | None) -> None:
+        assert _git._describe_tag(output) == expected
+
+
+class TestDescribeOutcome:
+    def test_renders_version_and_tag(self) -> None:
+        outcome = _git._describe_outcome(
+            describe_output("v1.2.3"), make_config(strict=None)
+        )
+        assert outcome == "1.2.4.dev1+gabcdef1 (from tag 'v1.2.3')"
+
+    def test_no_match_reports_fallback(self) -> None:
+        outcome = _git._describe_outcome("", make_config(strict=None))
+        assert "no matching tag" in outcome
+
+    def test_unparsable_tag_does_not_raise(self) -> None:
+        """A hypothetical must never raise, nor leak meta()'s own warning."""
+        outcome = _git._describe_outcome(
+            describe_output("nightly"), make_config(strict=None)
+        )
+        assert (
+            outcome == "no usable version -- tag 'nightly' does not parse as a version"
+        )
+
+    def test_prefix_is_stripped(self) -> None:
+        outcome = _git._describe_outcome(
+            describe_output("hatchling-v1.2.3"), make_config(prefix="hatchling-v")
+        )
+        assert outcome.startswith("1.2.4.dev1+gabcdef1 (from tag 'hatchling-v1.2.3')")
+
+
+class TestStrictDivergence:
+    """`tag.strict` unset: warn only when the future default changes the version."""
+
+    def test_silent_when_permissive_answer_is_already_strict(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        config = make_config(strict=None)
+        wd = FakeWorkdir(config, {"*[0-9]*": describe_output("v1.2.3")})
+        with caplog.at_level(logging.WARNING):
+            _git._warn_if_strict_would_differ(
+                wd, config, wd.run_git(["--match", "*[0-9]*"])
+            )
+        assert reported(caplog) == []
+        # the shortcut must avoid the second describe entirely
+        assert wd.calls == ["*[0-9]*"]
+
+    def test_silent_when_nothing_matched(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        config = make_config(strict=None)
+        wd = FakeWorkdir(config, {})
+        with caplog.at_level(logging.WARNING):
+            _git._warn_if_strict_would_differ(
+                wd, config, wd.run_git(["--match", "*[0-9]*"])
+            )
+        assert reported(caplog) == []
+        assert wd.calls == ["*[0-9]*"]
+
+    def test_warns_when_strict_picks_another_tag(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        config = make_config(strict=None)
+        wd = FakeWorkdir(
+            config,
+            {
+                "*[0-9]*": describe_output("event-2024"),
+                "*[0-9]*.*[0-9]*": describe_output("v1.2.3", distance=2),
+            },
+        )
+        with caplog.at_level(logging.WARNING):
+            _git._warn_if_strict_would_differ(
+                wd, config, wd.run_git(["--match", "*[0-9]*"])
+            )
+
+        (message,) = reported(caplog)
+        assert "tag.strict is not set" in message
+        # both concrete versions have to be in the message
+        assert "2025.dev1+gabcdef1 (from tag 'event-2024')" in message
+        assert "1.2.4.dev2+gabcdef1 (from tag 'v1.2.3')" in message
+
+    def test_warns_when_strict_matches_nothing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        config = make_config(strict=None)
+        wd = FakeWorkdir(config, {"*[0-9]*": describe_output("2024")})
+        with caplog.at_level(logging.WARNING):
+            _git._warn_if_strict_would_differ(
+                wd, config, wd.run_git(["--match", "*[0-9]*"])
+            )
+
+        (message,) = reported(caplog)
+        assert "no matching tag" in message
+
+    def test_prefix_is_applied_to_the_strict_glob(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        config = make_config(prefix="pkg-", strict=None)
+        wd = FakeWorkdir(config, {"pkg-*[0-9]*": describe_output("pkg-2024")})
+        with caplog.at_level(logging.WARNING):
+            _git._warn_if_strict_would_differ(
+                wd, config, wd.run_git(["--match", "pkg-*[0-9]*"])
+            )
+        assert wd.calls == ["pkg-*[0-9]*", "pkg-*[0-9]*.*[0-9]*"]
+
+    def test_reported_only_once_per_process(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A build constructs the configuration more than once."""
+        config = make_config(strict=None)
+        results = {
+            "*[0-9]*": describe_output("event-2024"),
+            "*[0-9]*.*[0-9]*": describe_output("v1.2.3"),
+        }
+        with caplog.at_level(logging.WARNING):
+            for _ in range(3):
+                wd = FakeWorkdir(config, results)
+                _git._warn_if_strict_would_differ(
+                    wd, config, wd.run_git(["--match", "*[0-9]*"])
+                )
+        assert len(reported(caplog)) == 1
+
+
+class TestDescribeCommandOverridesStrict:
+    """`describe_command` wins over `tag.strict` -- say so only when it matters."""
+
+    def test_silent_when_they_agree(self, caplog: pytest.LogCaptureFixture) -> None:
+        config = make_config(strict=True)
+        wd = FakeWorkdir(config, {"*[0-9]*.*[0-9]*": describe_output("v1.2.3")})
+        with caplog.at_level(logging.WARNING):
+            _git._warn_if_describe_command_overrides_strict(
+                wd, config, CompletedProcess([], 0, describe_output("v1.2.3"), "")
+            )
+        assert reported(caplog) == []
+
+    def test_warns_when_they_disagree(self, caplog: pytest.LogCaptureFixture) -> None:
+        config = make_config(strict=True)
+        wd = FakeWorkdir(config, {"*[0-9]*.*[0-9]*": describe_output("v1.2.3")})
+        with caplog.at_level(logging.WARNING):
+            _git._warn_if_describe_command_overrides_strict(
+                wd, config, CompletedProcess([], 0, describe_output("nightly"), "")
+            )
+
+        (message,) = reported(caplog)
+        assert "describe_command takes precedence over tag.strict" in message
+        assert "1.2.4.dev1+gabcdef1 (from tag 'v1.2.3')" in message
+        # tag.prefix still strips prefixes, so it must never be blamed here
+        assert "tag.prefix" not in message.split("Drop tag.strict")[0]
+
+
+class TestIntegration:
+    """End to end against real git repositories."""
+
+    def test_event_tag_shadowing_version_tag_warns(
+        self, wd: WorkDir, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        wd.commit_testfile()
+        wd("git tag v1.2.3")
+        wd.commit_testfile()
+        wd("git tag event-2024")
+
+        with caplog.at_level(logging.WARNING):
+            wd.get_version()
+
+        messages = reported(caplog)
+        assert any("tag.strict is not set" in m for m in messages), messages
+
+    def test_plain_version_tags_stay_silent(
+        self, wd: WorkDir, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        wd.commit_testfile()
+        wd("git tag v1.2.3")
+        wd.commit_testfile()
+
+        with caplog.at_level(logging.WARNING):
+            wd.get_version()
+
+        messages = reported(caplog)
+        assert not any("tag.strict" in m for m in messages), messages
+
+    def test_describe_command_suppresses_the_strict_nag(
+        self, wd: WorkDir, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The #1422 configuration must not produce conflicting advice."""
+        wd.commit_testfile()
+        wd("git tag v1.2.3")
+        wd.commit_testfile()
+        wd("git tag event-2024")
+
+        describe = "git describe --dirty --tags --long --match v[0-9]*"
+        with caplog.at_level(logging.WARNING):
+            wd.get_version(scm={"git": {"describe_command": describe}})
+
+        messages = reported(caplog)
+        assert not any("tag.strict is not set" in m for m in messages), messages


### PR DESCRIPTION
Fixes #1429.

## The problem

The `tag.strict` `FutureWarning` and the "both are set" `UserWarning` contradicted each other: not setting `tag.strict` triggered the first, and setting it to silence that triggered the second. Both were temporarily downgraded to debug logging in the fix for #1422; this re-introduces them with logic that cannot conflict.

## Approach

Both diagnostics move out of `Configuration.__post_init__` and into the git backend, and now fire **only when the setting actually changes the version** for the repository at hand.

The placement does most of the work. `default_describe()` is only reached when there is no explicit `describe_command`, so the strict notice cannot fire in the situation that triggers the second warning — the two can no longer contradict each other regardless of what a user configures. That is issue point 1, solved structurally rather than by a condition.

The message names the concrete versions rather than the setting:

```
tag.strict is not set, and the future default changes this repository's version:
  now (tag.strict = false):           2024 (from tag 'event-2024')
  future default (tag.strict = true): 1.2.4.dev1+g6911871 (from tag 'v1.2.3')
Set tag.strict explicitly in the [tool.setuptools_scm] table of /…/pyproject.toml.
```

Behavior across the cases, verified end to end against real repositories:

| config | result |
|---|---|
| plain `v1.2.3` history | silent, **no extra subprocess** |
| `event-2024` shadowing `v1.2.3` | warns, naming both versions |
| only a non-dotted `2024` tag | warns, "no matching tag, falling back to the fallback version" |
| `describe_command` set (the #1422 report) | silent |
| `tag.prefix` + `describe_command` | silent |
| `tag.strict` + `describe_command`, agreeing | silent |
| `tag.strict` + `describe_command`, disagreeing | warns |

## `tag.prefix` is not overridden by `describe_command`

The suppressed warning claimed `tag.prefix` "will have no effect" alongside `describe_command`. That is wrong. `tag.prefix` has two jobs and only one is describe-related — it is also consumed in `_scm_version.py` to strip the prefix before version parsing, independent of how the tag was selected. So this is a legitimate, working combination:

```toml
[tool.setuptools_scm]
tag.prefix = "hatchling-v"
[tool.setuptools_scm.scm.git]
describe_command = "git describe --dirty --tags --long --match hatchling-v*"
```

Bring your own match pattern, keep prefix stripping. The narrowed warning never mentions `tag.prefix`, and `docs/config.md` documents the combination instead of warning about it. That resolves issue point 3.

## Cost

The extra `git describe` is skipped when the permissive result already matches the strict glob. This is exact, not a heuristic: the strict glob matches a subset of the permissive one, so a permissive answer that itself matches strict is necessarily also the closest strict-matching tag. Most repositories therefore run **no** extra subprocess, and the check disappears entirely once `tag.strict` is set — which is the point.

Note that "does the tag contain a dot" would *not* be a valid shortcut: `rel.2024` contains a dot but does not match `*[0-9]*.*[0-9]*`, which requires a digit *before* the dot. There is a parametrized test pinning that case.

## Warnings vs. logging

These are logged at `WARNING` level rather than raised as warnings. Measured reach, per path:

| path | `log.warning` | `warnings.warn` |
|---|---|---|
| `python -m vcs_versioning` | visible | visible |
| raw API, logging unconfigured | visible (`logging.lastResort`) | visible |
| `python -m build` | visible | visible |
| `pip install .` (default verbosity) | invisible | invisible |

Logging reaches the author everywhere warnings did — `pip` swallows both alike — while not exploding downstream `-W error` runs, and `SETUPTOOLS_SCM_DEBUG=ERROR` silences it (`_parse_debug` already accepts level names, so no new env var). Unlike `warnings`, logging does not deduplicate, and a build constructs the configuration twice (metadata hook plus build hook), so `_report_once` guards it.

## Notable

- `DescribeCapable` gains a `GitQueryable` base protocol so the diagnostics take the minimum they need instead of a concrete `GitWorkdir`, which is what makes the comparison unit-testable against a fake. Happy to drop this if you would rather keep the protocol surface as it was.
- Mercurial honours `tag.strict` too but has no equivalent diagnostic; tracked in #1495.
- The changelog fragment is under `vcs-versioning/` since all the code is there, though the issue is filed against setuptools-scm.

## Verification

- 754 passed, 64 skipped (31 new tests: unit coverage of the glob membership, describe-output parsing, outcome rendering, the subprocess-skipping shortcut and the once-per-process guard, plus integration tests over real repositories)
- `pre-commit run --all-files` clean
- `mkdocs build --clean --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
