### PR TITLE
fix: honour export-ignore for directories and submodules in git file discovery

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -782,6 +782,25 @@ would be required when not using `setuptools-scm`.
 2. **SCM Integration**: The file finder queries your SCM (Git/Mercurial) for all tracked files
 3. **Inclusion**: All tracked files are automatically included in the sdist
 
+For Git the listing is based on the index (so freshly `git add`-ed files are
+included) and it follows `export-ignore` just like `git archive` does.
+
+#### Git submodules
+
+The Git file finder descends into submodules and lists their tracked files
+under the submodule path. Inside a submodule the submodule's own
+`.gitattributes` apply.
+
+A submodule is skipped when `export-ignore` excludes it in the parent
+repository - either directly or through one of its parent directories:
+
+```{.bash title=".gitattributes"}
+# no vendored submodule ends up in the sdist
+vendor/ export-ignore
+```
+
+Submodules that are not checked out are skipped as well.
+
 #### Controlling file inclusion
 
 **To exclude unwanted files:**

--- a/vcs-versioning/changelog.d/1469.bugfix.md
+++ b/vcs-versioning/changelog.d/1469.bugfix.md
@@ -1,0 +1,5 @@
+Honour `export-ignore` on directories and submodules again in the git file finder.
+
+The switch from `git archive` to `git ls-files --recurse-submodules` lost two parts of the archive semantics: `--recurse-submodules` listed every submodule regardless of `export-ignore`, and the `:(exclude,attr:export-ignore)` pathspec only matches files, so an `export-ignore` on a directory no longer excluded the files below it. Projects that kept vendored submodules in an `export-ignore`d directory suddenly shipped them in their sdists.
+
+The finder now lists a repository without recursion, checks `export-ignore` for directories via `git check-attr` (which is what `git archive` effectively does when it skips a tree), and only then descends into the submodules that survived. Submodule contents are still listed - with their own `.gitattributes` applied - so `export-ignore` in the parent repository now controls exactly which submodules get packaged. Submodules that are not checked out are skipped instead of failing the listing.

--- a/vcs-versioning/src/vcs_versioning/_backends/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_backends/_git.py
@@ -82,12 +82,14 @@ def run_git(
     *,
     check: bool = False,
     timeout: int | None = None,
+    input: str | None = None,
 ) -> _CompletedProcess:
     return _run(
         ["git", "--git-dir", repo / ".git", *args],
         cwd=repo,
         check=check,
         timeout=timeout,
+        input=input,
     )
 
 

--- a/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 from .. import _types as _t
@@ -13,6 +14,9 @@ from .._run_cmd import run as _run
 from . import collect_files_and_dirs, is_toplevel_acceptable, scm_find_files
 
 log = logging.getLogger(__name__)
+
+GITLINK_MODE = "160000"
+"""index mode ``git ls-files -s`` reports for submodule entries"""
 
 
 def _git_toplevel(path: str) -> str | None:
@@ -60,33 +64,115 @@ def _git_toplevel(path: str) -> str | None:
         return None
 
 
-def _git_ls_files_and_dirs(
-    toplevel: str, *, timeout: int | None = None
-) -> tuple[set[str], set[str]]:
-    # Use git ls-files with -z for NUL-separated output (safe parsing).
-    # --recurse-submodules lists files inside submodules with prefixed paths.
-    # The exclude pathspec filters out files marked with the export-ignore
-    # gitattribute, matching the old git-archive behavior.
-    # "." is needed as positive pathspec for the exclude to apply against.
-    # Uses run_git (--git-dir) to pin to the correct repository.
+def _ancestors(name: str) -> Iterator[str]:
+    """Yield the directories a slash separated path is nested in."""
+    index = name.find("/")
+    while index != -1:
+        yield name[:index]
+        index = name.find("/", index + 1)
+
+
+def _ls_files_entries(
+    repo: Path, *, timeout: int | None = None
+) -> list[tuple[str, str]] | None:
+    """List tracked ``(mode, path)`` entries of *repo*.
+
+    Uses NUL-separated output for safe parsing and ``-s`` to tell submodule
+    entries (gitlinks) from ordinary files.  The exclude pathspec drops files
+    carrying the ``export-ignore`` gitattribute - it matches per file, so
+    directories and submodules are dealt with by the caller.
+    ``None`` signals that git refused to list files (no repository yet,
+    or a submodule that is not checked out).
+    """
     res = run_git(
-        [
-            "ls-files",
-            "-z",
-            "--recurse-submodules",
-            "--",
-            ".",
-            ":(exclude,attr:export-ignore)",
-        ],
-        Path(toplevel),
+        ["ls-files", "-z", "-s", "--", ".", ":(exclude,attr:export-ignore)"],
+        repo,
         timeout=timeout,
     )
     if res.returncode:
+        return None
+    entries = []
+    for record in res.stdout.rstrip("\0").split("\0"):
+        if not record:
+            continue
+        # <mode> SP <object> SP <stage> TAB <path>
+        info, _, name = record.partition("\t")
+        entries.append((info.split(" ", 1)[0], name))
+    return entries
+
+
+def _export_ignored_dirs(
+    repo: Path, dirs: set[str], *, timeout: int | None = None
+) -> set[str]:
+    """Return the subset of *dirs* carrying the ``export-ignore`` attribute.
+
+    ``git archive`` skips whole trees, but an ``export-ignore`` on a directory
+    is not inherited by the paths below it, so the pathspec used for files
+    cannot see it.  Directories are therefore queried explicitly, with the
+    trailing slash git needs to match ``dir/`` style attribute patterns.
+    """
+    if not dirs:
+        return set()
+    res = run_git(
+        ["check-attr", "-z", "--stdin", "export-ignore"],
+        repo,
+        timeout=timeout,
+        input="\0".join(f"{name}/" for name in sorted(dirs)),
+    )
+    if res.returncode:
+        log.warning("checking export-ignore attributes failed: %s", res.stderr)
+        return set()
+    # NUL separated <path> <attribute> <value> triples
+    fields = res.stdout.split("\0")
+    return {
+        path.rstrip("/")
+        for path, value in zip(fields[::3], fields[2::3])
+        if value == "set"
+    }
+
+
+def _list_tracked_paths(repo: Path, *, timeout: int | None = None) -> list[str] | None:
+    """Slash separated paths tracked in *repo*, submodules included.
+
+    ``export-ignore`` is honored for files, directories and submodules,
+    so a submodule below an ignored directory is skipped entirely instead
+    of dragging its whole history into the distribution.
+    """
+    entries = _ls_files_entries(repo, timeout=timeout)
+    if entries is None:
+        return None
+    candidates = {parent for _, name in entries for parent in _ancestors(name)}
+    candidates.update(name for mode, name in entries if mode == GITLINK_MODE)
+    ignored = _export_ignored_dirs(repo, candidates, timeout=timeout)
+
+    paths: list[str] = []
+    for mode, name in entries:
+        if ignored and (
+            name in ignored or any(parent in ignored for parent in _ancestors(name))
+        ):
+            log.debug("export-ignore excludes %s", name)
+            continue
+        if mode != GITLINK_MODE:
+            paths.append(name)
+            continue
+        submodule = _list_tracked_paths(repo / name, timeout=timeout)
+        if submodule is None:
+            log.info("submodule %s is not checked out - not listing its files", name)
+            continue
+        paths.extend(f"{name}/{sub_name}" for sub_name in submodule)
+    return paths
+
+
+def _git_ls_files_and_dirs(
+    toplevel: str, *, timeout: int | None = None
+) -> tuple[set[str], set[str]]:
+    # Uses run_git (--git-dir) to pin to the correct repository.
+    paths = _list_tracked_paths(Path(toplevel), timeout=timeout)
+    if paths is None:
         log.error("listing git files failed - pretending there aren't any")
         return set(), set()
 
-    toplevel = norm_real(toplevel)
-    return collect_files_and_dirs(res.stdout.rstrip("\0").split("\0"), toplevel)
+    return collect_files_and_dirs(paths, norm_real(toplevel))
 
 
 def git_find_files(path: _t.PathT = "") -> list[str]:

--- a/vcs-versioning/src/vcs_versioning/_run_cmd.py
+++ b/vcs-versioning/src/vcs_versioning/_run_cmd.py
@@ -146,6 +146,7 @@ def run(
     trace: bool = True,
     timeout: int | None = None,
     check: bool = False,
+    input: str | None = None,
 ) -> CompletedProcess:
     if isinstance(cmd, str):
         cmd = shlex.split(cmd)
@@ -159,6 +160,7 @@ def run(
         cmd,
         check=False,  # handled below via CompletedProcess.check_returncode
         capture_output=True,
+        input=input,
         cwd=os.fspath(cwd),
         env=dict(
             avoid_pip_isolation(no_git_env(os.environ)),

--- a/vcs-versioning/src/vcs_versioning/_test_utils.py
+++ b/vcs-versioning/src/vcs_versioning/_test_utils.py
@@ -49,6 +49,7 @@ class WorkDir:
 
     def write(self, name: str, content: str | bytes) -> Path:
         path = self.cwd / name
+        path.parent.mkdir(parents=True, exist_ok=True)
         if isinstance(content, bytes):
             path.write_bytes(content)
         else:

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -389,30 +389,26 @@ def test_git_export_ignore_with_staged_files(
     assert opj(".", "ignore.txt") not in found
 
 
-@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/662")
-def test_git_submodule_files_listed(
-    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # Create a separate repo to use as submodule
-    sub_src = wd.cwd.parent / "sub_src"
-    sub_src.mkdir()
-    subprocess.check_call(["git", "init", str(sub_src)])
+def make_submodule_source(path: Path) -> Path:
+    """Create a standalone repo usable as submodule of the ``wd`` fixture."""
+    path.mkdir()
+    subprocess.check_call(["git", "init", str(path)])
     subprocess.check_call(
-        ["git", "-C", str(sub_src), "config", "user.email", "test@example.com"]
+        ["git", "-C", str(path), "config", "user.email", "test@example.com"]
     )
-    subprocess.check_call(["git", "-C", str(sub_src), "config", "user.name", "test"])
-    (sub_src / "sub_file.txt").write_text("sub content", encoding="utf-8")
-    (sub_src / ".gitattributes").write_text(
+    subprocess.check_call(["git", "-C", str(path), "config", "user.name", "test"])
+    (path / "sub_file.txt").write_text("sub content", encoding="utf-8")
+    (path / ".gitattributes").write_text(
         "/sub_ignored.txt export-ignore\n", encoding="utf-8"
     )
-    (sub_src / "sub_ignored.txt").write_text("ignored", encoding="utf-8")
-    subprocess.check_call(["git", "-C", str(sub_src), "add", "."])
-    subprocess.check_call(["git", "-C", str(sub_src), "commit", "-m", "init sub"])
+    (path / "sub_ignored.txt").write_text("ignored", encoding="utf-8")
+    subprocess.check_call(["git", "-C", str(path), "add", "."])
+    subprocess.check_call(["git", "-C", str(path), "commit", "-m", "init sub"])
+    return path
 
-    # Add as submodule (allow file:// protocol for local clone)
-    wd.write("parent_file.txt", "parent content")
-    wd("git add parent_file.txt")
-    wd.commit()
+
+def add_submodule(wd: WorkDir, source: Path, target: str) -> None:
+    """Add *source* as submodule at *target* (allow file:// protocol)."""
     wd(
         [
             "git",
@@ -420,10 +416,22 @@ def test_git_submodule_files_listed(
             "protocol.file.allow=always",
             "submodule",
             "add",
-            str(sub_src),
-            "mysub",
+            str(source),
+            target,
         ]
     )
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/662")
+def test_git_submodule_files_listed(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sub_src = make_submodule_source(wd.cwd.parent / "sub_src")
+
+    wd.write("parent_file.txt", "parent content")
+    wd("git add parent_file.txt")
+    wd.commit()
+    add_submodule(wd, sub_src, "mysub")
     wd.commit()
 
     monkeypatch.chdir(wd.cwd)
@@ -437,6 +445,67 @@ def test_git_submodule_files_listed(
     assert opj(".", "mysub", ".gitattributes") in found
     # export-ignore honored inside submodule
     assert opj(".", "mysub", "sub_ignored.txt") not in found
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1469")
+@pytest.mark.parametrize("pattern", ["vendor/", "vendor/*", "/vendor/**"])
+def test_git_submodule_below_export_ignored_dir_skipped(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch, pattern: str
+) -> None:
+    """A submodule excluded via export-ignore must not be listed."""
+    sub_src = make_submodule_source(wd.cwd.parent / "sub_src")
+
+    wd.write("parent_file.txt", "parent content")
+    wd.write(".gitattributes", f"{pattern} export-ignore\n")
+    wd("git add parent_file.txt .gitattributes")
+    wd.commit()
+    add_submodule(wd, sub_src, "vendor/mysub")
+    wd.commit()
+
+    monkeypatch.chdir(wd.cwd)
+    found = set(vcs_versioning._file_finders.find_files("."))
+
+    assert opj(".", "parent_file.txt") in found
+    assert not [name for name in found if "mysub" in name]
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1469")
+def test_git_export_ignore_on_directory_excludes_content(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """export-ignore on a directory drops its whole subtree, as archive does."""
+    wd.write("keep.txt", "keep")
+    wd.write(".gitattributes", "vendor/ export-ignore\n")
+    wd.write("vendor/nested/drop.txt", "drop")
+    wd("git add -A")
+    wd.commit()
+
+    monkeypatch.chdir(wd.cwd)
+    found = set(vcs_versioning._file_finders.find_files("."))
+
+    assert opj(".", "keep.txt") in found
+    assert opj(".", "vendor", "nested", "drop.txt") not in found
+
+
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1469")
+def test_git_uninitialized_submodule_skipped(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A submodule that is not checked out is skipped without failing."""
+    sub_src = make_submodule_source(wd.cwd.parent / "sub_src")
+
+    wd.write("parent_file.txt", "parent content")
+    wd("git add parent_file.txt")
+    wd.commit()
+    add_submodule(wd, sub_src, "mysub")
+    wd.commit()
+    wd("git submodule deinit -f mysub")
+
+    monkeypatch.chdir(wd.cwd)
+    found = set(vcs_versioning._file_finders.find_files("."))
+
+    assert opj(".", "parent_file.txt") in found
+    assert not [name for name in found if "mysub" in name]
 
 
 @pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/728")


### PR DESCRIPTION
Fixes #1469

## Problem

The switch from `git archive` to `git ls-files --recurse-submodules` (#662) lost two parts of the archive semantics:

1. `--recurse-submodules` lists every submodule unconditionally — the parent's `:(exclude,attr:export-ignore)` pathspec is not applied to the recursed entries at all (verified with git 2.55).
2. The pathspec matches *files* only. A `vendor/ export-ignore` rule sets no attribute on `vendor/plain/x.txt` or on the gitlink `vendor/sub`, so a directory level `export-ignore` stopped excluding its subtree — a regression beyond submodules.

The reporter's sdist grew by a factor of 45 because their vendored submodules live below an `export-ignore`d `vendor/` directory.

## Fix

- list each repository with `ls-files -z -s` and no recursion; `-s` exposes the `160000` gitlink mode, so submodules are identifiable
- resolve `export-ignore` for directories and gitlinks via `git check-attr -z --stdin` with a trailing slash — the only way to see `dir/` style attribute patterns, and effectively what `git archive` does when it skips a tree
- drop everything below an ignored directory, then descend only into the surviving submodules
- submodule contents keep being listed, with the submodule's own `.gitattributes` applied, so `export-ignore` in the parent repository now controls exactly which submodules get packaged (the approach suggested in the issue — no new option needed)
- submodules that are not checked out are skipped with an info log instead of failing the listing

Supporting changes: `run()`/`run_git()` gained an `input=` passthrough for the `--stdin` query, and `WorkDir.write` creates parent directories.

## Verification

On a repo with `vendor/ export-ignore` and a submodule at `vendor/sub`, the finder output now matches `git archive HEAD` exactly.

New tests cover the ignored submodule (parametrized over `vendor/`, `vendor/*`, `/vendor/**`), directory level `export-ignore`, and a deinit'd submodule; the existing submodule inclusion test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)