### PR TITLE
fix: skip gitlinks whose working tree is absent in file finding

### DIFF
--- a/vcs-versioning/changelog.d/1500.bugfix.md
+++ b/vcs-versioning/changelog.d/1500.bugfix.md
@@ -1,0 +1,1 @@
+Fix a `FileNotFoundError` crash in the git file finder when a submodule is tracked in the index but its working tree directory does not exist - such gitlinks are now skipped like not checked out submodules.

--- a/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/_git.py
@@ -84,6 +84,10 @@ def _ls_files_entries(
     ``None`` signals that git refused to list files (no repository yet,
     or a submodule that is not checked out).
     """
+    if not repo.is_dir():
+        # a submodule tracked in the index whose working tree is absent -
+        # running git in it would fail before git could report anything
+        return None
     res = run_git(
         ["ls-files", "-z", "-s", "--", ".", ":(exclude,attr:export-ignore)"],
         repo,

--- a/vcs-versioning/testing_vcs/test_git.py
+++ b/vcs-versioning/testing_vcs/test_git.py
@@ -508,6 +508,26 @@ def test_git_uninitialized_submodule_skipped(
     assert not [name for name in found if "mysub" in name]
 
 
+@pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/1500")
+def test_git_submodule_without_working_tree_skipped(
+    wd: WorkDir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A gitlink whose directory does not exist at all is skipped, not fatal."""
+    wd.write("parent_file.txt", "parent content")
+    wd("git add parent_file.txt")
+    wd(
+        "git update-index --add --cacheinfo"
+        " 160000,77ef5b8fe4bab2b73f7b234267f0dfb75e96eeee,missing_submodule"
+    )
+    wd.commit()
+
+    monkeypatch.chdir(wd.cwd)
+    found = set(vcs_versioning._file_finders.find_files("."))
+
+    assert opj(".", "parent_file.txt") in found
+    assert not [name for name in found if "missing_submodule" in name]
+
+
 @pytest.mark.issue("https://github.com/pypa/setuptools-scm/issues/728")
 def test_git_branch_names_correct(wd: WorkDir) -> None:
     wd.commit_testfile()


### PR DESCRIPTION
Fixes #1500 — regression in vcs-versioning 2.3.0.

`_list_tracked_paths` recurses into each gitlink by running git with the submodule path as `cwd`. When the gitlink is tracked in the index but the directory does not exist in the working tree, `subprocess` raises `FileNotFoundError` before git can report anything, failing metadata generation. Common in Docker builds that COPY a partial source tree and bind-mount `.git`.

`_ls_files_entries` now returns `None` for a nonexistent directory, so the caller skips it like a not checked out submodule. Test covers a gitlink added via `git update-index --cacheinfo` with no working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)