### PR TITLE
Deprecate setuptools.file_finders for unconfigured projects; also emi…

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -380,11 +380,13 @@ These environment variables control setuptools-scm specific behavior.
 
 !!! warning "Setuptools File Finder Integration"
 
-    `setuptools-scm` automatically registers a setuptools file finder that includes all SCM-tracked files in source distributions. This behavior is **always active** when setuptools-scm is installed, regardless of whether you use it for versioning.
+    `setuptools-scm` still registers a setuptools file finder that includes all SCM-tracked files in source distributions. For projects that configure setuptools-scm, file listing uses the validated workdir API instead of this entry point.
+
+    Using the global `setuptools.file_finders` entry point **without** configuring setuptools-scm is deprecated and will be removed in a future major release. Unconfigured projects that still hit the entry point get a `DeprecationWarning`.
 
 **How it works:**
 
-`setuptools-scm` provides a `setuptools.file_finders` entry point that:
+When setuptools-scm is configured, `ScmEggInfoMixin` lists tracked files from the discovered workdir. The legacy `setuptools.file_finders` entry point remains registered for compatibility:
 
 1. Automatically discovers SCM-managed files (Git, Mercurial, Jujutsu)
 2. Includes them in source distributions (`python -m build --sdist`)
@@ -394,7 +396,7 @@ These environment variables control setuptools-scm specific behavior.
 
 ```toml
 [project.entry-points."setuptools.file_finders"]
-setuptools_scm = "setuptools_scm._file_finders:find_files"
+setuptools_scm = "vcs_versioning._file_finders:find_files"
 ```
 
 **Files included by default:**
@@ -434,9 +436,9 @@ python -m build --sdist
 tar -tzf dist/package-*.tar.gz
 ```
 
-!!! note "Cannot be disabled"
+!!! note "Cannot be disabled today"
 
-    The file finder cannot be disabled through configuration - it's automatically active when setuptools-scm is installed. If you need to disable it completely, you must remove setuptools-scm from your build environment (which also means you can't use it for versioning).
+    The file finder cannot be turned off through configuration while the entry point is still registered. To stop using it, either configure setuptools-scm (so builds use the workdir path) or remove setuptools-scm from the build environment. The unconfigured entry-point path will be removed in a future major release.
 
 ## API Reference
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,14 @@ or [configuring Git archive][git-archive-docs].
 
 !!! warning "Automatic File Inclusion Behavior"
 
-    **Important:** Simply installing `setuptools-scm` as a build dependency will automatically enable its file finder, which includes **all SCM-tracked files** in your source distributions. This happens even if you're not using setuptools-scm for versioning.
+    Installing `setuptools-scm` as a build dependency still registers a setuptools file finder that includes **all SCM-tracked files** in source distributions, even if you are not using it for versioning.
+
+    That global `setuptools.file_finders` entry point is **deprecated** when the project being built does not configure setuptools-scm (`[tool.setuptools_scm]`, `setuptools-scm[simple]`, or `use_scm_version`). It will be removed in a future major release.
 
     - ✅ **Expected**: All Git/Mercurial/Jujutsu tracked files will be included in your sdist
     - ⚠️ **Surprise**: This includes development files, configs, tests, docs, etc.
     - 🛠️ **Control**: Use `MANIFEST.in` to exclude unwanted files
+    - ⚠️ **Unconfigured projects**: a `DeprecationWarning` is emitted; configure setuptools-scm to keep file inclusion through the supported workdir path
 
     See the [File Finder Documentation](usage.md#file-finders-hook-makes-most-of-manifestin-unnecessary) for details.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -765,14 +765,15 @@ RUN --mount=source=.git,target=.git,type=bind \
 
 !!! warning "Automatic File Inclusion"
 
-    **`setuptools-scm` automatically provides a setuptools file finder by default.** This means that when you install setuptools-scm, it will automatically include **all SCM-tracked files** in your source distributions (sdist) without requiring a `MANIFEST.in` file.
+    **`setuptools-scm` still provides a setuptools file finder by default.** When it is installed, **all SCM-tracked files** are included in source distributions (sdist) without requiring a `MANIFEST.in` file.
 
-    This automatic behavior can be surprising if you're not expecting it. The file finder is active as soon as setuptools-scm is installed in your build environment.
+    That global [file_finders] entry point is **deprecated** for projects that do not configure setuptools-scm (`[tool.setuptools_scm]` in `pyproject.toml`, `setuptools-scm[simple]`, or `use_scm_version` in `setup.py`). Builds of unconfigured projects emit a `DeprecationWarning`. The entry point will be removed in a future major release.
+
+    Configured projects already bypass the entry point and list files from the discovered workdir.
 
 `setuptools-scm` implements a [file_finders] entry point
 which returns all files tracked by your SCM.
-This eliminates the need for a manually constructed `MANIFEST.in` in most cases where this
-would be required when not using `setuptools-scm`.
+This eliminates the need for a manually constructed `MANIFEST.in` in most cases.
 
 [file_finders]: https://setuptools.pypa.io/en/stable/userguide/extension.html
 

--- a/setuptools-scm/changelog.d/1407.deprecation.md
+++ b/setuptools-scm/changelog.d/1407.deprecation.md
@@ -1,0 +1,1 @@
+Emit a ``DeprecationWarning`` when the ``setuptools.file_finders`` entry point is invoked for a project that does not configure setuptools-scm. The entry point will be removed in a future major release.

--- a/setuptools-scm/testing_scm/test_file_finders.py
+++ b/setuptools-scm/testing_scm/test_file_finders.py
@@ -1,0 +1,91 @@
+"""Tests for the setuptools.file_finders entry point deprecation."""
+
+from __future__ import annotations
+
+import warnings
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from vcs_versioning._file_finders import find_files
+
+_FILE_FINDERS_DEPRECATION = "setuptools.file_finders"
+
+
+def _file_finder_deprecations(
+    caught: list[warnings.WarningMessage],
+) -> list[warnings.WarningMessage]:
+    return [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and _FILE_FINDERS_DEPRECATION in str(w.message)
+    ]
+
+
+@pytest.mark.issue(1407)
+def test_find_files_warns_when_unconfigured(tmp_path: Path) -> None:
+    """A project without setuptools-scm config must warn on the entry point."""
+    (tmp_path / "pyproject.toml").write_text(
+        dedent("""\
+            [build-system]
+            requires = ["setuptools>=61", "setuptools-scm"]
+            build-backend = "setuptools.build_meta"
+
+            [project]
+            name = "unconfigured"
+            version = "1.0.0"
+        """),
+        encoding="utf-8",
+    )
+    with pytest.warns(DeprecationWarning, match=_FILE_FINDERS_DEPRECATION):
+        find_files(str(tmp_path))
+
+
+@pytest.mark.issue(1407)
+def test_find_files_no_warn_when_configured(tmp_path: Path) -> None:
+    """An explicit [tool.setuptools_scm] section silences the deprecation."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.setuptools_scm]\n",
+        encoding="utf-8",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        find_files(str(tmp_path))
+    assert _file_finder_deprecations(caught) == []
+
+
+@pytest.mark.issue(1407)
+def test_find_files_no_warn_when_setup_py_configures(tmp_path: Path) -> None:
+    """setup.py use_scm_version counts as configuration."""
+    (tmp_path / "setup.py").write_text(
+        "from setuptools import setup\nsetup(use_scm_version=True)\n",
+        encoding="utf-8",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        find_files(str(tmp_path))
+    assert _file_finder_deprecations(caught) == []
+
+
+@pytest.mark.issue(1407)
+def test_find_files_no_warn_when_simple_extra(tmp_path: Path) -> None:
+    """setuptools-scm[simple] with a dynamic version counts as configuration."""
+    (tmp_path / "pyproject.toml").write_text(
+        dedent("""\
+            [build-system]
+            requires = ["setuptools>=61", "setuptools-scm[simple]"]
+            build-backend = "setuptools.build_meta"
+
+            [project]
+            name = "simple-pkg"
+            dynamic = ["version"]
+        """),
+        encoding="utf-8",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        find_files(str(tmp_path))
+    assert _file_finder_deprecations(caught) == []

--- a/vcs-versioning/src/vcs_versioning/_file_finders/__init__.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/__init__.py
@@ -140,7 +140,8 @@ def _pyproject_enables_scm(data: PyProjectData) -> bool:
         return True
     if not data.project_present:
         return False
-    if "version" not in data.project.get("dynamic", []):
+    dynamic = data.project.get("dynamic", [])
+    if not isinstance(dynamic, list) or "version" not in dynamic:
         return False
     from .._requirement_cls import Requirement, extract_package_name
 

--- a/vcs-versioning/src/vcs_versioning/_file_finders/__init__.py
+++ b/vcs-versioning/src/vcs_versioning/_file_finders/__init__.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import warnings
 from collections.abc import Callable, Iterable, Mapping
+from pathlib import Path
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -13,6 +15,8 @@ else:
 from .. import _types as _t
 from .._compat import norm_real
 from .._entrypoints import entry_points
+from .._pyproject_reading import PyProjectData, read_pyproject
+from .._toml import InvalidTomlError
 
 log = logging.getLogger("vcs_versioning.file_finder")
 
@@ -125,19 +129,104 @@ def is_toplevel_acceptable(
     return toplevel not in ignore_vcs_roots
 
 
+def _pyproject_enables_scm(data: PyProjectData) -> bool:
+    """Return True if *data* matches setuptools-scm's ``should_infer`` rules.
+
+    Infer when an explicit ``[tool.setuptools_scm]`` / ``[tool.vcs-versioning]``
+    section is present, or when ``setuptools-scm[simple]`` is in
+    ``build-system.requires`` with ``version`` in ``project.dynamic``.
+    """
+    if data.section_present:
+        return True
+    if not data.project_present:
+        return False
+    if "version" not in data.project.get("dynamic", []):
+        return False
+    from .._requirement_cls import Requirement, extract_package_name
+
+    for requirement_string in data.build_requires:
+        try:
+            requirement = Requirement(requirement_string)
+            if (
+                extract_package_name(requirement_string) == "setuptools-scm"
+                and "simple" in requirement.extras
+            ):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _project_configures_scm(path: _t.PathT) -> bool:
+    """Return True if the project at *path* configures setuptools-scm."""
+    root = Path(os.fspath(path) or ".").resolve()
+    if not root.is_dir():
+        root = root.parent
+
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        try:
+            data = read_pyproject(pyproject)
+        except (OSError, InvalidTomlError):
+            pass
+        else:
+            if _pyproject_enables_scm(data):
+                return True
+
+    setup_py = root / "setup.py"
+    if setup_py.is_file():
+        try:
+            return "use_scm_version" in setup_py.read_text(encoding="utf-8")
+        except OSError:
+            return False
+    return False
+
+
+def _warn_if_file_finder_unconfigured(path: _t.PathT) -> None:
+    """Warn when the file-finder entry point runs without setuptools-scm config.
+
+    Library callers (and tests) that pass a bare VCS tree with no project
+    metadata are left alone; setuptools always has ``pyproject.toml`` or
+    ``setup.py`` when it invokes this entry point.
+    """
+    root = Path(os.fspath(path) or ".").resolve()
+    if not root.is_dir():
+        root = root.parent
+    if not (root / "pyproject.toml").is_file() and not (root / "setup.py").is_file():
+        return
+    if _project_configures_scm(path):
+        return
+    warnings.warn(
+        "The setuptools.file_finders entry point is deprecated and will be "
+        "removed in a future major release. Configure setuptools-scm via "
+        "[tool.setuptools_scm] in pyproject.toml or use_scm_version in "
+        "setup.py; file inclusion will then use the workdir API instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 def find_files(path: _t.PathT = "") -> list[str]:
-    """Discover files using registered file finder entry points."""
+    """Discover files using registered file finder entry points.
+
+    Invoking this via the ``setuptools.file_finders`` entry point without
+    configuring setuptools-scm is deprecated and will be removed in a
+    future major release.
+    """
     eps = [
         *entry_points(group="setuptools_scm.files_command"),
         *entry_points(group="setuptools_scm.files_command_fallback"),
     ]
+    result: list[str] = []
     for ep in eps:
         command: Callable[[_t.PathT], list[str]] = ep.load()
         res: list[str] = command(path)
         if res:
-            return res
+            result = res
+            break
 
-    return []
+    _warn_if_file_finder_unconfigured(path)
+    return result
 
 
 def collect_files_and_dirs(


### PR DESCRIPTION
## Summary

* The first part of #1407: emit a `DeprecationWarning` when the global `setuptools.file_finders` entry point runs for a project that isn't configured to use setuptools-scm (`[tool.setuptools_scm]`, `setuptools-scm[simple]`, or `use_scm_version`)
* No change for configured projects; they already use the workdir API : (`ScmEggInfoMixin`) and won't warn.
* File discovery still works the same... the entry point stays registered for now and can be removed in a future major release

## Test plan

* [x] `setuptools-scm/testing_scm/test_file_finders.py`: warns when setuptools-scm is only a build dependency; no warning with `[tool.setuptools_scm]`, `use_scm_version`, or `setuptools-scm[simple]`
* [x] `uv run pytest -n12`
* [x] `pre-commit run --all-files`
* [ ] Confirm a real sdist for an unconfigured project with setuptools-scm installed still builds, includes tracked files, and emits the deprecation warning
