### PR TITLE
Keep the PEP 440 epoch in the semver version schemes

### DIFF
--- a/vcs-versioning/changelog.d/1513.bugfix.md
+++ b/vcs-versioning/changelog.d/1513.bugfix.md
@@ -1,0 +1,1 @@
+The `semver-pep440` and `semver-pep440-release-branch` version schemes now keep the PEP 440 epoch of the tag they are derived from, instead of emitting a version that sorts below it.

--- a/vcs-versioning/src/vcs_versioning/_version_schemes/_standard.py
+++ b/vcs-versioning/src/vcs_versioning/_version_schemes/_standard.py
@@ -40,11 +40,14 @@ def guess_next_dev_version(version: ScmVersion) -> str:
 def guess_next_simple_semver(
     version: ScmVersion, retain: int, increment: bool = True
 ) -> str:
+    # ``Version.release`` excludes the epoch, so it has to be put back or the
+    # guessed version sorts below the tag it was derived from.
+    epoch = f"{version.tag.epoch}!" if version.tag.epoch else ""
     if increment and getattr(version.tag, "dev", None) == 0:
         parts = list(version.tag.release)
         while len(parts) < SEMVER_LEN:
             parts.append(0)
-        return ".".join(str(i) for i in parts)
+        return epoch + ".".join(str(i) for i in parts)
     parts = list(version.tag.release[:retain])
     while len(parts) < retain:
         parts.append(0)
@@ -52,7 +55,7 @@ def guess_next_simple_semver(
         parts[-1] += 1
     while len(parts) < SEMVER_LEN:
         parts.append(0)
-    return ".".join(str(i) for i in parts)
+    return epoch + ".".join(str(i) for i in parts)
 
 
 def simplified_semver_version(version: ScmVersion) -> str:

--- a/vcs-versioning/testing_vcs/test_version.py
+++ b/vcs-versioning/testing_vcs/test_version.py
@@ -75,6 +75,16 @@ c_non_normalize = Configuration(version_cls=NonNormalizedVersion)
             "3.0.0.dev1",
             id="dev0_anchor_single_commit",
         ),
+        pytest.param(
+            meta("1!2.0.0", distance=2, branch="default", config=c),
+            "1!2.0.1.dev2",
+            id="epoch_default_branch",
+        ),
+        pytest.param(
+            meta("1!2.0.0", distance=2, branch="feature/fun", config=c),
+            "1!2.1.0.dev2",
+            id="epoch_feature_branch",
+        ),
     ],
 )
 def test_next_semver(version: ScmVersion, expected_next: str) -> None:
@@ -127,6 +137,11 @@ def test_next_semver(version: ScmVersion, expected_next: str) -> None:
             meta("2.0.dev0", distance=5, branch="release-2.0", config=c),
             "2.0.dev5",
             id="dev0_anchor_release_branch",
+        ),
+        pytest.param(
+            meta("1!2.0.0", distance=2, branch="master", config=c),
+            "1!2.1.0.dev2",
+            id="epoch_development_branch",
         ),
     ],
 )


### PR DESCRIPTION
`guess_next_simple_semver` rebuilds the next version from `version.tag.release`. `Version.release` is the release tuple only — it does not carry the epoch — so both schemas that route through it drop it. `guess-next-dev`, `no-guess-dev` and `post-release` do not, because they bump the tag as a string.

Measured on `96956be`, tag `1!2.0.0`, `distance=3`:

```
semver-pep440                  2.0.1.dev3          <- epoch lost
semver-pep440-release-branch   2.1.0.dev3          <- epoch lost
guess-next-dev                 1!2.0.1.dev3
no-guess-dev                   1!2.0.0.post1.dev3
post-release                   1!2.0.0.post3

Version("2.0.1.dev3") < Version("1!2.0.0")  ->  True
Version("2.1.0.dev3") < Version("1!2.0.0")  ->  True
```

The generated development version sorts *below* the tag it was derived from. Per PEP 440, "if included in a version number, the epoch appears before all other components" and epoch-bearing versions sort strictly above lower-epoch ones — the whole point of bumping an epoch is that the new series outranks the old, so this inverts it for the two semver schemes.

Fix prefixes `{epoch}!` when the tag has a non-zero epoch, and nothing otherwise (epoch 0 is implicit and must not appear in the canonical form).

Ran the full `vcs-versioning` suite against an unmodified `origin/main` checkout in its own virtualenv as a baseline, and against this branch, with `_standard.__file__` printed on both to be sure which tree was imported:

```
origin/main   2 failed, 597 passed, 65 skipped, 1 xfailed
this branch   2 failed, 600 passed, 65 skipped, 1 xfailed
```

The 2 failures are identical and pre-existing here (`test_git_getdate_signed_commit`, `test_egg_info_metadata_wins_over_pkginfo`); the +3 are the new parameters. Reverting only `_standard.py` to `origin/main` fails exactly those 3. Emitting the epoch unconditionally — the naive version — fails 16, because `0!1.0.1.dev2` is not the canonical spelling the existing parameters assert. `ruff check`, `ruff format --check` and `mypy` are clean on both touched files.

Not changed, and I would rather ask than guess: `release_branch_semver_version` compares `str(version.tag).split(".")[:2]` against the branch name, which for `1!2.0.0` yields `['1!2', '0']`, so a `release-2.0` branch no longer matches its own tag. That needs a decision about how an epoch should be spelled in a branch name, so I left it alone. I also did not run the `setuptools-scm` half of the monorepo.

AI assistance: this change was drafted with Claude Opus 5 (`claude-opus-5`). Every number above came from running the suites locally against this branch and against the unmodified baseline.
